### PR TITLE
feat: Find-or-create Agent pattern with copy-on-write and  cleanup orphan agent in update/delete a session

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -24,6 +24,7 @@ use crate::models::{
     UpdateSpeedwagonRequest,
 };
 use crate::repository::RepositoryError;
+use crate::services::agent::{self as agent_service};
 use crate::services::session::{self as session_service, SessionError, SseEvent};
 use crate::services::speedwagon::{self as speedwagon_service, SpeedwagonError};
 use crate::state::AppState;
@@ -197,12 +198,15 @@ async fn create_agent(
     Json(payload): Json<CreateAgentRequest>,
 ) -> Result<(StatusCode, Json<AgentResponse>), (StatusCode, Json<AppError>)> {
     let CreateAgentRequest { spec } = payload;
-    let agent = state
-        .repository
-        .create_agent(spec)
+    let (agent, created) = agent_service::find_or_create_agent(&state, spec)
         .await
         .map_err(repo_err)?;
-    Ok((StatusCode::CREATED, Json(to_agent_response(&agent))))
+    let status = if created {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+    Ok((status, Json(to_agent_response(&agent))))
 }
 
 async fn list_agents(
@@ -1537,5 +1541,252 @@ mod tests {
         let list_resp = get_req(&app, "/sources").await;
         let list_body = response_json(list_resp).await;
         assert_eq!(list_body.as_array().expect("list should be array").len(), 1);
+    }
+
+    // ===================== find-or-create Agent Tests =====================
+
+    #[tokio::test]
+    async fn find_or_create_same_spec_returns_same_id() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let spec = json!({ "spec": { "lm": "gpt-4.1", "instruction": null, "tools": [] } });
+
+        let resp1 = post_json(&app, "/agents", spec.clone()).await;
+        assert_eq!(resp1.status(), StatusCode::CREATED);
+        let body1 = response_json(resp1).await;
+
+        let resp2 = post_json(&app, "/agents", spec.clone()).await;
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let body2 = response_json(resp2).await;
+
+        assert_eq!(
+            body1["id"], body2["id"],
+            "same spec must return same agent id"
+        );
+
+        // Verify only one row in DB
+        let list = response_json(get_req(&app, "/agents").await).await;
+        assert_eq!(list.as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn find_or_create_tools_order_independent() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let resp1 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "gpt-4.1", "tools": ["b", "a"] } }),
+        )
+        .await;
+        assert_eq!(resp1.status(), StatusCode::CREATED);
+        let id1 = response_json(resp1).await["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let resp2 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "gpt-4.1", "tools": ["a", "b"] } }),
+        )
+        .await;
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let id2 = response_json(resp2).await["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert_eq!(id1, id2, "tools order must not affect agent identity");
+    }
+
+    #[tokio::test]
+    async fn find_or_create_empty_instruction_variants_match() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let resp1 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "gpt-4.1", "instruction": null, "tools": [] } }),
+        )
+        .await;
+        assert_eq!(resp1.status(), StatusCode::CREATED);
+        let id1 = response_json(resp1).await["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Some("") should normalize to None
+        let resp2 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "gpt-4.1", "instruction": "", "tools": [] } }),
+        )
+        .await;
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let id2 = response_json(resp2).await["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert_eq!(
+            id1, id2,
+            "null and empty instruction must produce same agent"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_or_create_different_lm_creates_new_agent() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let resp1 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "gpt-4.1", "tools": [] } }),
+        )
+        .await;
+        assert_eq!(resp1.status(), StatusCode::CREATED);
+        let id1 = response_json(resp1).await["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let resp2 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "claude-opus-4-5", "tools": [] } }),
+        )
+        .await;
+        assert_eq!(resp2.status(), StatusCode::CREATED);
+        let id2 = response_json(resp2).await["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert_ne!(id1, id2, "different lm must create a new agent");
+    }
+
+    // ===================== Session agent_id relink Tests =====================
+
+    #[tokio::test]
+    async fn update_session_agent_id_relinks_session() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let agent_id1 = create_agent(&app).await;
+        // Create a second agent with a different spec
+        let resp2 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "claude-opus-4-5", "tools": [] } }),
+        )
+        .await;
+        let agent_id2 =
+            Uuid::parse_str(response_json(resp2).await["id"].as_str().expect("agent id")).unwrap();
+        assert_ne!(agent_id1, agent_id2);
+
+        let profile_id =
+            create_provider_profile(&app, "openai-default", "chat_completion", true).await;
+
+        let session_body = response_json(
+            post_json(
+                &app,
+                "/sessions",
+                json!({ "agent_id": agent_id1, "provider_profile_id": profile_id }),
+            )
+            .await,
+        )
+        .await;
+        let session_id = Uuid::parse_str(session_body["id"].as_str().expect("session id")).unwrap();
+        assert_eq!(
+            session_body["agent_id"].as_str().unwrap(),
+            agent_id1.to_string()
+        );
+
+        // Relink to agent2
+        let update_resp = put_json(
+            &app,
+            &format!("/sessions/{session_id}"),
+            json!({ "agent_id": agent_id2 }),
+        )
+        .await;
+        assert_eq!(update_resp.status(), StatusCode::OK);
+        let updated = response_json(update_resp).await;
+        assert_eq!(updated["agent_id"].as_str().unwrap(), agent_id2.to_string());
+    }
+
+    // ===================== Cascade Delete Tests =====================
+
+    #[tokio::test]
+    async fn delete_session_cascade_deletes_orphaned_agent() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        // Create agent + profile + session
+        let agent_id = create_agent(&app).await;
+        let profile_id =
+            create_provider_profile(&app, "openai-default", "chat_completion", true).await;
+
+        let session_body = response_json(
+            post_json(
+                &app,
+                "/sessions",
+                json!({ "agent_id": agent_id, "provider_profile_id": profile_id }),
+            )
+            .await,
+        )
+        .await;
+        let session_id = Uuid::parse_str(session_body["id"].as_str().expect("session id")).unwrap();
+
+        // Delete the only session → agent should be deleted too
+        let del_resp = delete_req(&app, &format!("/sessions/{session_id}")).await;
+        assert_eq!(del_resp.status(), StatusCode::NO_CONTENT);
+
+        let agent_resp = get_req(&app, &format!("/agents/{agent_id}")).await;
+        assert_eq!(agent_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_session_keeps_agent_when_other_sessions_exist() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let agent_id = create_agent(&app).await;
+        let profile_id =
+            create_provider_profile(&app, "openai-default", "chat_completion", true).await;
+
+        // Create two sessions for the same agent
+        let session1_body = response_json(
+            post_json(
+                &app,
+                "/sessions",
+                json!({ "agent_id": agent_id, "provider_profile_id": profile_id }),
+            )
+            .await,
+        )
+        .await;
+        let session1_id =
+            Uuid::parse_str(session1_body["id"].as_str().expect("session id")).unwrap();
+
+        let _session2_body = response_json(
+            post_json(
+                &app,
+                "/sessions",
+                json!({ "agent_id": agent_id, "provider_profile_id": profile_id }),
+            )
+            .await,
+        )
+        .await;
+
+        // Delete session1 only → agent must still exist
+        let del_resp = delete_req(&app, &format!("/sessions/{session1_id}")).await;
+        assert_eq!(del_resp.status(), StatusCode::NO_CONTENT);
+
+        let agent_resp = get_req(&app, &format!("/agents/{agent_id}")).await;
+        assert_eq!(agent_resp.status(), StatusCode::OK);
     }
 }

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -420,7 +420,7 @@ async fn update_session(
 ) -> Result<Json<SessionResponse>, (StatusCode, Json<AppError>)> {
     let session = session_service::update_session(&state, id, payload)
         .await
-        .map_err(|e| AppError::internal(e.to_string()))?;
+        .map_err(session_err)?;
     Ok(Json(SessionResponse::from(&session)))
 }
 
@@ -430,7 +430,7 @@ async fn delete_session(
 ) -> Result<StatusCode, (StatusCode, Json<AppError>)> {
     session_service::delete_session(&state, id)
         .await
-        .map_err(|e| AppError::internal(e.to_string()))?;
+        .map_err(session_err)?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1465,7 +1465,7 @@ mod tests {
     // ===================== find-or-create Agent Tests =====================
 
     #[tokio::test]
-    async fn find_or_create_same_spec_returns_same_id() {
+    async fn find_or_create_same_spec_is_idempotent() {
         let temp_dir = TempDir::new().expect("temp dir should be created");
         let app = test_app(&temp_dir).await;
 
@@ -1475,16 +1475,34 @@ mod tests {
         assert_eq!(resp1.status(), StatusCode::CREATED);
         let body1 = response_json(resp1).await;
 
+        // Sleep past now_string()'s millisecond resolution so that any accidental
+        // UPDATE on reuse would produce a visibly different updated_at. Without
+        // this gap, a buggy `SET updated_at = excluded.updated_at` could
+        // coincidentally write the same millisecond and hide the regression.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
         let resp2 = post_json(&app, "/agents", spec.clone()).await;
         assert_eq!(resp2.status(), StatusCode::OK);
         let body2 = response_json(resp2).await;
 
+        // Identity: same spec → same agent id
         assert_eq!(
             body1["id"], body2["id"],
             "same spec must return same agent id"
         );
 
-        // Verify only one row in DB
+        // Immutability: reuse must not touch the row. Agents are immutable
+        // snapshots under copy-on-write, so created_at/updated_at are stable.
+        assert_eq!(
+            body1["updated_at"], body2["updated_at"],
+            "reuse must not bump updated_at — agents are immutable under CoW",
+        );
+        assert_eq!(
+            body1["created_at"], body2["created_at"],
+            "created_at must be stable across reuse",
+        );
+
+        // Uniqueness: exactly one row in DB
         let list = response_json(get_req(&app, "/agents").await).await;
         assert_eq!(list.as_array().unwrap().len(), 1);
     }

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -20,8 +20,7 @@ use crate::models::{
     CreateProviderProfileRequest, CreateSessionRequest, CreateSpeedwagonRequest, ErrorResponse,
     ListSessionsQuery, ProviderProfile, ProviderProfileResponse, SessionDetailResponse,
     SessionResponse, SourceResponse, SourceType, SpeedwagonIndexStatus, SpeedwagonResponse,
-    UpdateAgentRequest, UpdateProviderProfileRequest, UpdateSessionRequest,
-    UpdateSpeedwagonRequest,
+    UpdateProviderProfileRequest, UpdateSessionRequest, UpdateSpeedwagonRequest,
 };
 use crate::repository::RepositoryError;
 use crate::services::agent::{self as agent_service};
@@ -151,7 +150,7 @@ pub fn router(state: AppState_) -> ApiRouter {
         .api_route("/agents", get(list_agents).post(create_agent))
         .api_route(
             "/agents/{id}",
-            get(get_agent).put(update_agent).delete(delete_agent),
+            get(get_agent).delete(delete_agent),
         )
         .api_route(
             "/provider-profiles",
@@ -222,26 +221,6 @@ async fn get_agent(
 ) -> Result<Json<AgentResponse>, (StatusCode, Json<AppError>)> {
     match state.repository.get_agent(id).await.map_err(repo_err)? {
         Some(agent) => Ok(Json(to_agent_response(&agent))),
-        None => Err(AppError::not_found("agent not found")),
-    }
-}
-
-async fn update_agent(
-    State(state): State<AppState_>,
-    Path(id): Path<Uuid>,
-    Json(payload): Json<UpdateAgentRequest>,
-) -> Result<Json<AgentResponse>, (StatusCode, Json<AppError>)> {
-    let UpdateAgentRequest { spec } = payload;
-    match state
-        .repository
-        .update_agent(id, spec)
-        .await
-        .map_err(repo_err)?
-    {
-        Some(agent) => {
-            state.invalidate_runtimes_by_agent_id(id);
-            Ok(Json(to_agent_response(&agent)))
-        }
         None => Err(AppError::not_found("agent not found")),
     }
 }
@@ -1328,69 +1307,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_agent_resets_session_runtime_cache() {
-        let (mock_url, request_counts) = start_mock_chat_completion_server().await;
-        let temp_dir = TempDir::new().expect("temp dir should be created");
-        let app = test_app(&temp_dir).await;
-
-        let agent_id = create_agent(&app).await;
-        let profile_id = create_provider_profile_with_url(
-            &app,
-            "openai-default",
-            "chat_completion",
-            &mock_url,
-            true,
-        )
-        .await;
-
-        let session_body = response_json(
-            post_json(
-                &app,
-                "/sessions",
-                json!({
-                    "agent_id": agent_id,
-                    "provider_profile_id": profile_id
-                }),
-            )
-            .await,
-        )
-        .await;
-        let session_id = session_body["id"]
-            .as_str()
-            .expect("session id must exist")
-            .to_string();
-
-        let (status, _) = stream_user_message(&app, &session_id, "before-update").await;
-        assert_eq!(status, StatusCode::OK);
-
-        let update_resp = put_json(
-            &app,
-            &format!("/agents/{agent_id}"),
-            json!({
-                "spec": {
-                    "lm": "gpt-4.1-mini",
-                    "instruction": null,
-                    "tools": []
-                }
-            }),
-        )
-        .await;
-        assert_eq!(update_resp.status(), StatusCode::OK);
-
-        let (status, _) = stream_user_message(&app, &session_id, "after-update").await;
-        assert_eq!(status, StatusCode::OK);
-
-        let counts = request_counts
-            .lock()
-            .expect("request counts lock should be available")
-            .clone();
-        // After agent update, runtime cache is invalidated and recreated with DB history restore.
-        // turn-1: system(1) + restored-user(1) + streaming-user(1) = 3
-        // turn-2 (after reset): system(1) + restored-history(2) + restored-user(1) + streaming-user(1) = 5
-        assert_eq!(counts, vec![3, 5]);
-    }
-
-    #[tokio::test]
     async fn update_provider_profile_resets_session_runtime_cache() {
         let (mock_url, request_counts) = start_mock_chat_completion_server().await;
         let temp_dir = TempDir::new().expect("temp dir should be created");
@@ -1788,5 +1704,119 @@ mod tests {
 
         let agent_resp = get_req(&app, &format!("/agents/{agent_id}")).await;
         assert_eq!(agent_resp.status(), StatusCode::OK);
+    }
+
+    // ===================== Update-Session Orphan Cleanup (CoW Symmetry) =====================
+
+    /// When `PUT /sessions/{id}` swaps agent_id on the session's *only* session,
+    /// the previous agent becomes an orphan and must be deleted — symmetric with
+    /// `delete_session_cascade_deletes_orphaned_agent`.
+    #[tokio::test]
+    async fn update_session_agent_swap_cascade_deletes_orphaned_previous_agent() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let agent_id1 = create_agent(&app).await;
+        let resp2 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "claude-opus-4-5", "tools": [] } }),
+        )
+        .await;
+        let agent_id2 =
+            Uuid::parse_str(response_json(resp2).await["id"].as_str().expect("agent id")).unwrap();
+        assert_ne!(agent_id1, agent_id2);
+
+        let profile_id =
+            create_provider_profile(&app, "openai-default", "chat_completion", true).await;
+
+        let session_body = response_json(
+            post_json(
+                &app,
+                "/sessions",
+                json!({ "agent_id": agent_id1, "provider_profile_id": profile_id }),
+            )
+            .await,
+        )
+        .await;
+        let session_id = Uuid::parse_str(session_body["id"].as_str().expect("session id")).unwrap();
+
+        // Swap to agent2 — this is the only session pointing at agent1, so agent1 is orphaned.
+        let update_resp = put_json(
+            &app,
+            &format!("/sessions/{session_id}"),
+            json!({ "agent_id": agent_id2 }),
+        )
+        .await;
+        assert_eq!(update_resp.status(), StatusCode::OK);
+
+        // agent1 was orphaned by the swap → must be deleted.
+        let agent1_resp = get_req(&app, &format!("/agents/{agent_id1}")).await;
+        assert_eq!(
+            agent1_resp.status(),
+            StatusCode::NOT_FOUND,
+            "previous agent should have been cleaned up after pointer swap"
+        );
+
+        // agent2 still has a session → must remain.
+        let agent2_resp = get_req(&app, &format!("/agents/{agent_id2}")).await;
+        assert_eq!(agent2_resp.status(), StatusCode::OK);
+    }
+
+    /// When another session still references the previous agent, the swap must
+    /// NOT delete that agent.
+    #[tokio::test]
+    async fn update_session_agent_swap_keeps_previous_agent_when_other_sessions_exist() {
+        let temp_dir = TempDir::new().expect("temp dir should be created");
+        let app = test_app(&temp_dir).await;
+
+        let agent_id1 = create_agent(&app).await;
+        let resp2 = post_json(
+            &app,
+            "/agents",
+            json!({ "spec": { "lm": "claude-opus-4-5", "tools": [] } }),
+        )
+        .await;
+        let agent_id2 =
+            Uuid::parse_str(response_json(resp2).await["id"].as_str().expect("agent id")).unwrap();
+
+        let profile_id =
+            create_provider_profile(&app, "openai-default", "chat_completion", true).await;
+
+        // Two sessions both pointing at agent1.
+        let session1_body = response_json(
+            post_json(
+                &app,
+                "/sessions",
+                json!({ "agent_id": agent_id1, "provider_profile_id": profile_id }),
+            )
+            .await,
+        )
+        .await;
+        let session1_id =
+            Uuid::parse_str(session1_body["id"].as_str().expect("session id")).unwrap();
+
+        let _session2_body = response_json(
+            post_json(
+                &app,
+                "/sessions",
+                json!({ "agent_id": agent_id1, "provider_profile_id": profile_id }),
+            )
+            .await,
+        )
+        .await;
+
+        // Swap session1 to agent2. agent1 is still referenced by session2.
+        let update_resp = put_json(
+            &app,
+            &format!("/sessions/{session1_id}"),
+            json!({ "agent_id": agent_id2 }),
+        )
+        .await;
+        assert_eq!(update_resp.status(), StatusCode::OK);
+
+        // agent1 must still exist — session2 depends on it.
+        let agent1_resp = get_req(&app, &format!("/agents/{agent_id1}")).await;
+        assert_eq!(agent1_resp.status(), StatusCode::OK);
     }
 }

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -151,10 +151,7 @@ pub fn router(state: AppState_) -> ApiRouter {
         // No PUT on agents: specs are the agent's identity. "Changing" an agent
         // means POST /agents (find-or-create returns either a matching row or a
         // new one) followed by PUT /sessions/{id} to relink — the CoW flow.
-        .api_route(
-            "/agents/{id}",
-            get(get_agent).delete(delete_agent),
-        )
+        .api_route("/agents/{id}", get(get_agent).delete(delete_agent))
         .api_route(
             "/provider-profiles",
             get(list_provider_profiles).post(create_provider_profile),
@@ -1607,15 +1604,27 @@ mod tests {
         assert_ne!(id1, id2, "different lm must create a new agent");
     }
 
-    // ===================== Session agent_id relink Tests =====================
-
+    /// Agent-swap contract covers two invariants at once:
+    ///   (a) DB pointer: `sessions.agent_id` updates to the new agent (response reflects it).
+    ///   (b) Runtime: the per-session runtime cache is invalidated and rebuilt with the new
+    ///       agent's spec, and prior turns are replayed from DB into the fresh runtime.
+    ///
+    /// (b) was previously covered by `update_agent_resets_session_runtime_cache` (deleted when
+    /// agents became immutable under copy-on-write). Under CoW, the same invariant now lives on
+    /// the agent-swap path — swapping `agent_id` is the only way to "change" an agent. Keeping
+    /// (a) and (b) in one test mirrors the "swap == invalidate + restore" contract stated in the
+    /// PR body, and ensures a future refactor that updates the DB row but forgets
+    /// `invalidate_session_runtime(id)` fails loudly instead of silently serving stale specs.
+    ///
+    /// Mirrors the request-count shape used by `update_provider_profile_resets_session_runtime_cache`.
     #[tokio::test]
-    async fn update_session_agent_id_relinks_session() {
+    async fn update_session_agent_id_resets_runtime_and_restores_history() {
+        let (mock_url, request_counts) = start_mock_chat_completion_server().await;
         let temp_dir = TempDir::new().expect("temp dir should be created");
         let app = test_app(&temp_dir).await;
 
+        // Two distinct agent specs → two agent rows under CoW.
         let agent_id1 = create_agent(&app).await;
-        // Create a second agent with a different spec
         let resp2 = post_json(
             &app,
             "/agents",
@@ -1626,8 +1635,16 @@ mod tests {
             Uuid::parse_str(response_json(resp2).await["id"].as_str().expect("agent id")).unwrap();
         assert_ne!(agent_id1, agent_id2);
 
-        let profile_id =
-            create_provider_profile(&app, "openai-default", "chat_completion", true).await;
+        // Single mock provider profile shared across both agents — the swap exercises the
+        // agent-side invalidation path in isolation (provider stays identical).
+        let profile_id = create_provider_profile_with_url(
+            &app,
+            "openai-default",
+            "chat_completion",
+            &mock_url,
+            true,
+        )
+        .await;
 
         let session_body = response_json(
             post_json(
@@ -1641,10 +1658,16 @@ mod tests {
         let session_id = Uuid::parse_str(session_body["id"].as_str().expect("session id")).unwrap();
         assert_eq!(
             session_body["agent_id"].as_str().unwrap(),
-            agent_id1.to_string()
+            agent_id1.to_string(),
+            "session must initially point at agent1"
         );
 
-        // Relink to agent2
+        // turn-1: establish baseline under agent1. Populates DB history that the post-swap
+        // runtime must replay.
+        let (status1, _) = stream_user_message(&app, &session_id.to_string(), "turn-1").await;
+        assert_eq!(status1, StatusCode::OK);
+
+        // (a) DB pointer: relink to agent2
         let update_resp = put_json(
             &app,
             &format!("/sessions/{session_id}"),
@@ -1653,10 +1676,32 @@ mod tests {
         .await;
         assert_eq!(update_resp.status(), StatusCode::OK);
         let updated = response_json(update_resp).await;
-        assert_eq!(updated["agent_id"].as_str().unwrap(), agent_id2.to_string());
-    }
+        assert_eq!(
+            updated["agent_id"].as_str().unwrap(),
+            agent_id2.to_string(),
+            "response must reflect the relink to agent2",
+        );
 
-    // ===================== Cascade Delete Tests =====================
+        // turn-2: drives the cached runtime. If `invalidate_session_runtime` was skipped,
+        // the cached agent1 runtime would serve this turn without replaying DB history,
+        // producing `[3, 3]` instead of `[3, 5]`.
+        let (status2, _) = stream_user_message(&app, &session_id.to_string(), "turn-2").await;
+        assert_eq!(status2, StatusCode::OK);
+
+        // (b) Runtime reset + history restore — observable via LLM call shape:
+        //   turn-1:              system(1) + restored-user(1) + streaming-user(1)            = 3
+        //   turn-2 (post-swap):  system(1) + restored-history(user+assistant=2)
+        //                        + restored-user(1) + streaming-user(1)                       = 5
+        let counts = request_counts
+            .lock()
+            .expect("request counts lock should be available")
+            .clone();
+        assert_eq!(
+            counts,
+            vec![3, 5],
+            "agent-swap must invalidate the session runtime and replay DB history on the next turn",
+        );
+    }
 
     #[tokio::test]
     async fn delete_session_cascade_deletes_orphaned_agent() {

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -148,6 +148,9 @@ pub fn router(state: AppState_) -> ApiRouter {
     ApiRouter::new()
         .api_route("/health", get(health))
         .api_route("/agents", get(list_agents).post(create_agent))
+        // No PUT on agents: specs are the agent's identity. "Changing" an agent
+        // means POST /agents (find-or-create returns either a matching row or a
+        // new one) followed by PUT /sessions/{id} to relink — the CoW flow.
         .api_route(
             "/agents/{id}",
             get(get_agent).delete(delete_agent),

--- a/backend/src/models/agent.rs
+++ b/backend/src/models/agent.rs
@@ -31,9 +31,3 @@ pub struct AgentResponse {
 pub struct CreateAgentRequest {
     pub spec: AgentSpec,
 }
-
-#[derive(Debug, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct UpdateAgentRequest {
-    pub spec: AgentSpec,
-}

--- a/backend/src/models/session.rs
+++ b/backend/src/models/session.rs
@@ -170,6 +170,7 @@ pub struct CreateSessionRequest {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct UpdateSessionRequest {
     pub title: Option<String>,
+    pub agent_id: Option<Uuid>,
     pub provider_profile_id: Option<Uuid>,
     pub speedwagon_ids: Option<Vec<Uuid>>,
     pub source_ids: Option<Vec<Uuid>>,

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -27,10 +27,15 @@ const DEFAULT_DATABASE_URL: &str = "sqlite://./data/app.db";
 /// - `instruction`: trim whitespace; empty string → None (unifies Some(""), Some("  "), None)
 /// - `lm`: preserved as-is (controlled by frontend constants)
 ///
-/// NOTE: This depends on serde_json preserving struct field order
-/// (guaranteed for #[derive(Serialize)]).
-/// If ailoy's AgentSpec adds new fields (especially floating-point),
-/// this function MUST be reviewed.
+/// NOTE: This output is the sole basis of Agent identity (enforced by
+/// `UNIQUE(spec_json)` in SQLite). Determinism depends on serde_json preserving
+/// struct field order (guaranteed for `#[derive(Serialize)]`).
+///
+/// **STANDING REVIEW TRIGGER**: Review this function on every ailoy version bump.
+/// If `ailoy::AgentSpec` adds, removes, or reorders fields — especially
+/// floating-point, HashMap-like, or otherwise non-deterministic types — the
+/// UNIQUE constraint can silently permit duplicates. Tracked in
+/// `.omc/plans/open-questions.md`.
 pub fn normalize_spec(spec: &AgentSpec) -> RepositoryResult<String> {
     let mut normalized = spec.clone();
     normalized.tools.sort();
@@ -61,14 +66,9 @@ pub type RepositoryResult<T> = Result<T, RepositoryError>;
 
 #[async_trait]
 pub trait Repository: Send + Sync {
-    async fn create_agent(&self, spec: AgentSpec) -> RepositoryResult<Agent>;
+    async fn create_agent(&self, spec: AgentSpec) -> RepositoryResult<(Agent, bool)>;
     async fn list_agents(&self) -> RepositoryResult<Vec<Agent>>;
     async fn get_agent(&self, id: Uuid) -> RepositoryResult<Option<Agent>>;
-    async fn find_agent_by_spec(
-        &self,
-        normalized_spec_json: &str,
-    ) -> RepositoryResult<Option<Agent>>;
-    async fn update_agent(&self, id: Uuid, spec: AgentSpec) -> RepositoryResult<Option<Agent>>;
     async fn delete_agent(&self, id: Uuid) -> RepositoryResult<bool>;
     async fn has_sessions_for_agent(&self, agent_id: Uuid) -> RepositoryResult<bool>;
 
@@ -121,6 +121,16 @@ pub trait Repository: Send + Sync {
         role: MessageRole,
         content: String,
     ) -> RepositoryResult<Option<SessionMessage>>;
+    /// Atomically update a session's fields.
+    ///
+    /// Returns `Option<(Session, Option<Uuid>)>`:
+    /// - Outer `None` → session not found
+    /// - Inner `Option<Uuid>` → previous `agent_id` when the caller actually
+    ///   changed `agent_id` to a new value; `None` otherwise (no agent swap
+    ///   happened, or the new id matched the existing one).
+    ///
+    /// The previous id lets the service layer clean up orphaned agents
+    /// symmetrically with `delete_session` (CoW pointer-swap cleanup).
     async fn update_session_atomic(
         &self,
         id: Uuid,
@@ -129,7 +139,7 @@ pub trait Repository: Send + Sync {
         provider_profile_id: Option<Uuid>,
         speedwagon_ids: Option<Vec<Uuid>>,
         source_ids: Option<Vec<Uuid>>,
-    ) -> RepositoryResult<Option<Session>>;
+    ) -> RepositoryResult<Option<(Session, Option<Uuid>)>>;
 
     // --- Source ---
     async fn create_source(

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -20,6 +20,28 @@ pub use sqlite::SqliteRepository;
 
 const DEFAULT_DATABASE_URL: &str = "sqlite://./data/app.db";
 
+/// Normalize an AgentSpec for deterministic JSON comparison.
+///
+/// Rules applied:
+/// - `tools`: alphabetical sort + dedup (order-independent matching)
+/// - `instruction`: trim whitespace; empty string → None (unifies Some(""), Some("  "), None)
+/// - `lm`: preserved as-is (controlled by frontend constants)
+///
+/// NOTE: This depends on serde_json preserving struct field order
+/// (guaranteed for #[derive(Serialize)]).
+/// If ailoy's AgentSpec adds new fields (especially floating-point),
+/// this function MUST be reviewed.
+pub fn normalize_spec(spec: &AgentSpec) -> RepositoryResult<String> {
+    let mut normalized = spec.clone();
+    normalized.tools.sort();
+    normalized.tools.dedup();
+    normalized.instruction = normalized
+        .instruction
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    serde_json::to_string(&normalized).map_err(RepositoryError::from)
+}
+
 #[derive(Debug, Error)]
 pub enum RepositoryError {
     #[error("database error: {0}")]
@@ -42,6 +64,10 @@ pub trait Repository: Send + Sync {
     async fn create_agent(&self, spec: AgentSpec) -> RepositoryResult<Agent>;
     async fn list_agents(&self) -> RepositoryResult<Vec<Agent>>;
     async fn get_agent(&self, id: Uuid) -> RepositoryResult<Option<Agent>>;
+    async fn find_agent_by_spec(
+        &self,
+        normalized_spec_json: &str,
+    ) -> RepositoryResult<Option<Agent>>;
     async fn update_agent(&self, id: Uuid, spec: AgentSpec) -> RepositoryResult<Option<Agent>>;
     async fn delete_agent(&self, id: Uuid) -> RepositoryResult<bool>;
     async fn has_sessions_for_agent(&self, agent_id: Uuid) -> RepositoryResult<bool>;
@@ -99,6 +125,7 @@ pub trait Repository: Send + Sync {
         &self,
         id: Uuid,
         title: Option<String>,
+        agent_id: Option<Uuid>,
         provider_profile_id: Option<Uuid>,
         speedwagon_ids: Option<Vec<Uuid>>,
         source_ids: Option<Vec<Uuid>>,

--- a/backend/src/repository/postgres.rs
+++ b/backend/src/repository/postgres.rs
@@ -31,6 +31,13 @@ impl Repository for PostgresRepository {
         todo!("postgres implementation")
     }
 
+    async fn find_agent_by_spec(
+        &self,
+        _normalized_spec_json: &str,
+    ) -> RepositoryResult<Option<Agent>> {
+        todo!("postgres implementation")
+    }
+
     async fn update_agent(&self, _id: Uuid, _spec: AgentSpec) -> RepositoryResult<Option<Agent>> {
         todo!("postgres implementation")
     }
@@ -130,6 +137,7 @@ impl Repository for PostgresRepository {
         &self,
         _id: Uuid,
         _title: Option<String>,
+        _agent_id: Option<Uuid>,
         _provider_profile_id: Option<Uuid>,
         _speedwagon_ids: Option<Vec<Uuid>>,
         _source_ids: Option<Vec<Uuid>>,

--- a/backend/src/repository/postgres.rs
+++ b/backend/src/repository/postgres.rs
@@ -19,7 +19,7 @@ impl PostgresRepository {
 
 #[async_trait]
 impl Repository for PostgresRepository {
-    async fn create_agent(&self, _spec: AgentSpec) -> RepositoryResult<Agent> {
+    async fn create_agent(&self, _spec: AgentSpec) -> RepositoryResult<(Agent, bool)> {
         todo!("postgres implementation")
     }
 
@@ -28,17 +28,6 @@ impl Repository for PostgresRepository {
     }
 
     async fn get_agent(&self, _id: Uuid) -> RepositoryResult<Option<Agent>> {
-        todo!("postgres implementation")
-    }
-
-    async fn find_agent_by_spec(
-        &self,
-        _normalized_spec_json: &str,
-    ) -> RepositoryResult<Option<Agent>> {
-        todo!("postgres implementation")
-    }
-
-    async fn update_agent(&self, _id: Uuid, _spec: AgentSpec) -> RepositoryResult<Option<Agent>> {
         todo!("postgres implementation")
     }
 
@@ -141,7 +130,7 @@ impl Repository for PostgresRepository {
         _provider_profile_id: Option<Uuid>,
         _speedwagon_ids: Option<Vec<Uuid>>,
         _source_ids: Option<Vec<Uuid>>,
-    ) -> RepositoryResult<Option<Session>> {
+    ) -> RepositoryResult<Option<(Session, Option<Uuid>)>> {
         todo!("postgres implementation")
     }
 

--- a/backend/src/repository/sqlite.rs
+++ b/backend/src/repository/sqlite.rs
@@ -578,13 +578,14 @@ impl Repository for SqliteRepository {
 
         // Upsert: if another row with identical spec_json already exists, return it.
         // DO UPDATE (not DO NOTHING) is required for RETURNING to emit the conflict row.
-        // The updated_at bump on conflict is a benign side effect; agents are immutable
-        // under the copy-on-write model so updated_at has no semantic meaning.
+        // Self-assignment (`agents.updated_at = agents.updated_at`) takes the conflict
+        // branch without mutating the row — agents are immutable under copy-on-write,
+        // so reuse must not touch created_at/updated_at.
         let row = sqlx::query(
             r#"
             INSERT INTO agents (id, spec_json, created_at, updated_at)
             VALUES (?, ?, ?, ?)
-            ON CONFLICT(spec_json) DO UPDATE SET updated_at = excluded.updated_at
+            ON CONFLICT(spec_json) DO UPDATE SET updated_at = agents.updated_at
             RETURNING id, spec_json, created_at, updated_at;
             "#,
         )

--- a/backend/src/repository/sqlite.rs
+++ b/backend/src/repository/sqlite.rs
@@ -13,7 +13,7 @@ use crate::models::{
     Agent, MessageRole, ProviderProfile, Session, SessionMessage, SessionToolCall, Source,
     SourceType, Speedwagon, SpeedwagonIndexStatus,
 };
-use crate::repository::{Repository, RepositoryError, RepositoryResult};
+use crate::repository::{Repository, RepositoryError, RepositoryResult, normalize_spec};
 
 pub struct SqliteRepository {
     pool: SqlitePool,
@@ -563,6 +563,7 @@ impl Repository for SqliteRepository {
     async fn create_agent(&self, spec: AgentSpec) -> RepositoryResult<Agent> {
         let now = Self::now_string();
         let id = Uuid::new_v4();
+        let spec_json = normalize_spec(&spec)?;
 
         sqlx::query(
             r#"
@@ -571,18 +572,39 @@ impl Repository for SqliteRepository {
             "#,
         )
         .bind(id.to_string())
-        .bind(serde_json::to_string(&spec)?)
+        .bind(&spec_json)
         .bind(&now)
         .bind(&now)
         .execute(&self.pool)
         .await?;
 
+        // Deserialize the normalized form so the returned Agent is consistent
+        let normalized_spec: AgentSpec = serde_json::from_str(&spec_json)?;
         Ok(Agent {
             id,
-            spec,
+            spec: normalized_spec,
             created_at: Self::parse_timestamp(now.clone(), "agents.created_at")?,
             updated_at: Self::parse_timestamp(now, "agents.updated_at")?,
         })
+    }
+
+    async fn find_agent_by_spec(
+        &self,
+        normalized_spec_json: &str,
+    ) -> RepositoryResult<Option<Agent>> {
+        let row = sqlx::query(
+            r#"
+            SELECT id, spec_json, created_at, updated_at
+            FROM agents
+            WHERE spec_json = ?
+            LIMIT 1;
+            "#,
+        )
+        .bind(normalized_spec_json)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.as_ref().map(Self::row_to_agent).transpose()
     }
 
     async fn list_agents(&self) -> RepositoryResult<Vec<Agent>> {
@@ -991,6 +1013,7 @@ impl Repository for SqliteRepository {
         &self,
         id: Uuid,
         title: Option<String>,
+        agent_id: Option<Uuid>,
         provider_profile_id: Option<Uuid>,
         speedwagon_ids: Option<Vec<Uuid>>,
         source_ids: Option<Vec<Uuid>>,
@@ -1015,6 +1038,27 @@ impl Repository for SqliteRepository {
         if let Some(title) = title {
             sqlx::query("UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?")
                 .bind(&title)
+                .bind(&now)
+                .bind(&id_str)
+                .execute(tx.as_mut())
+                .await?;
+        }
+
+        if let Some(new_agent_id) = agent_id {
+            // Verify agent exists before updating
+            let agent_exists: bool =
+                sqlx::query_scalar("SELECT COUNT(*) > 0 FROM agents WHERE id = ?")
+                    .bind(new_agent_id.to_string())
+                    .fetch_one(tx.as_mut())
+                    .await?;
+            if !agent_exists {
+                tx.rollback().await?;
+                return Err(RepositoryError::InvalidData(format!(
+                    "agent not found: {new_agent_id}"
+                )));
+            }
+            sqlx::query("UPDATE sessions SET agent_id = ?, updated_at = ? WHERE id = ?")
+                .bind(new_agent_id.to_string())
                 .bind(&now)
                 .bind(&id_str)
                 .execute(tx.as_mut())

--- a/backend/src/repository/sqlite.rs
+++ b/backend/src/repository/sqlite.rs
@@ -646,7 +646,7 @@ impl Repository for SqliteRepository {
             WHERE id = ?;
             "#,
         )
-        .bind(serde_json::to_string(&spec)?)
+        .bind(normalize_spec(&spec)?)
         .bind(now)
         .bind(id.to_string())
         .execute(&self.pool)

--- a/backend/src/repository/sqlite.rs
+++ b/backend/src/repository/sqlite.rs
@@ -51,11 +51,21 @@ impl SqliteRepository {
             r#"
             CREATE TABLE IF NOT EXISTS agents (
                 id TEXT PRIMARY KEY,
-                spec_json TEXT NOT NULL,
+                spec_json TEXT NOT NULL UNIQUE,
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL
             );
             "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        // Belt-and-suspenders: CREATE TABLE IF NOT EXISTS silently ignores the inline
+        // UNIQUE on existing DBs. Add an explicit unique index so pre-existing tables
+        // also get the constraint. Fails with SQLITE_CONSTRAINT if duplicate spec_json
+        // rows already exist — in that case delete backend/data/app.db (dev stage).
+        sqlx::query(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_agents_spec_json ON agents(spec_json);",
         )
         .execute(&self.pool)
         .await?;
@@ -560,51 +570,34 @@ impl SqliteRepository {
 
 #[async_trait]
 impl Repository for SqliteRepository {
-    async fn create_agent(&self, spec: AgentSpec) -> RepositoryResult<Agent> {
+    async fn create_agent(&self, spec: AgentSpec) -> RepositoryResult<(Agent, bool)> {
         let now = Self::now_string();
         let id = Uuid::new_v4();
+        let id_str = id.to_string();
         let spec_json = normalize_spec(&spec)?;
 
-        sqlx::query(
+        // Upsert: if another row with identical spec_json already exists, return it.
+        // DO UPDATE (not DO NOTHING) is required for RETURNING to emit the conflict row.
+        // The updated_at bump on conflict is a benign side effect; agents are immutable
+        // under the copy-on-write model so updated_at has no semantic meaning.
+        let row = sqlx::query(
             r#"
             INSERT INTO agents (id, spec_json, created_at, updated_at)
-            VALUES (?, ?, ?, ?);
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(spec_json) DO UPDATE SET updated_at = excluded.updated_at
+            RETURNING id, spec_json, created_at, updated_at;
             "#,
         )
-        .bind(id.to_string())
+        .bind(&id_str)
         .bind(&spec_json)
         .bind(&now)
         .bind(&now)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
 
-        // Deserialize the normalized form so the returned Agent is consistent
-        let normalized_spec: AgentSpec = serde_json::from_str(&spec_json)?;
-        Ok(Agent {
-            id,
-            spec: normalized_spec,
-            created_at: Self::parse_timestamp(now.clone(), "agents.created_at")?,
-            updated_at: Self::parse_timestamp(now, "agents.updated_at")?,
-        })
-    }
-
-    async fn find_agent_by_spec(
-        &self,
-        normalized_spec_json: &str,
-    ) -> RepositoryResult<Option<Agent>> {
-        let row = sqlx::query(
-            r#"
-            SELECT id, spec_json, created_at, updated_at
-            FROM agents
-            WHERE spec_json = ?
-            LIMIT 1;
-            "#,
-        )
-        .bind(normalized_spec_json)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        row.as_ref().map(Self::row_to_agent).transpose()
+        let created = row.get::<String, _>("id") == id_str;
+        let agent = Self::row_to_agent(&row)?;
+        Ok((agent, created))
     }
 
     async fn list_agents(&self) -> RepositoryResult<Vec<Agent>> {
@@ -634,29 +627,6 @@ impl Repository for SqliteRepository {
         .await?;
 
         row.as_ref().map(Self::row_to_agent).transpose()
-    }
-
-    async fn update_agent(&self, id: Uuid, spec: AgentSpec) -> RepositoryResult<Option<Agent>> {
-        let now = Self::now_string();
-
-        let result = sqlx::query(
-            r#"
-            UPDATE agents
-            SET spec_json = ?, updated_at = ?
-            WHERE id = ?;
-            "#,
-        )
-        .bind(normalize_spec(&spec)?)
-        .bind(now)
-        .bind(id.to_string())
-        .execute(&self.pool)
-        .await?;
-
-        if result.rows_affected() == 0 {
-            return Ok(None);
-        }
-
-        self.get_agent(id).await
     }
 
     async fn delete_agent(&self, id: Uuid) -> RepositoryResult<bool> {
@@ -1017,7 +987,7 @@ impl Repository for SqliteRepository {
         provider_profile_id: Option<Uuid>,
         speedwagon_ids: Option<Vec<Uuid>>,
         source_ids: Option<Vec<Uuid>>,
-    ) -> RepositoryResult<Option<Session>> {
+    ) -> RepositoryResult<Option<(Session, Option<Uuid>)>> {
         let id_str = id.to_string();
 
         let mut tx = self.pool.begin().await?;
@@ -1044,6 +1014,13 @@ impl Repository for SqliteRepository {
                 .await?;
         }
 
+        // Track the previous agent_id only when the caller requested an agent change
+        // and the new id actually differs from the current one. This lets the service
+        // layer clean up an orphaned agent symmetrically with delete_session (CoW
+        // pointer-swap cleanup). Skipping the SELECT on pure title/provider/speedwagon
+        // updates avoids a wasted query on the common path.
+        let mut previous_agent_id: Option<Uuid> = None;
+
         if let Some(new_agent_id) = agent_id {
             // Verify agent exists before updating
             let agent_exists: bool =
@@ -1057,12 +1034,28 @@ impl Repository for SqliteRepository {
                     "agent not found: {new_agent_id}"
                 )));
             }
-            sqlx::query("UPDATE sessions SET agent_id = ?, updated_at = ? WHERE id = ?")
-                .bind(new_agent_id.to_string())
-                .bind(&now)
-                .bind(&id_str)
-                .execute(tx.as_mut())
-                .await?;
+
+            // Read the current agent_id so we can report an orphan candidate to the
+            // caller. Gated on `agent_id.is_some()` so the query only fires when an
+            // agent swap was actually requested.
+            let current_agent_str: String =
+                sqlx::query_scalar("SELECT agent_id FROM sessions WHERE id = ?")
+                    .bind(&id_str)
+                    .fetch_one(tx.as_mut())
+                    .await?;
+            let current_agent_id = Uuid::parse_str(&current_agent_str).map_err(|e| {
+                RepositoryError::InvalidData(format!("invalid agent_id in sessions row: {e}"))
+            })?;
+
+            if current_agent_id != new_agent_id {
+                previous_agent_id = Some(current_agent_id);
+                sqlx::query("UPDATE sessions SET agent_id = ?, updated_at = ? WHERE id = ?")
+                    .bind(new_agent_id.to_string())
+                    .bind(&now)
+                    .bind(&id_str)
+                    .execute(tx.as_mut())
+                    .await?;
+            }
         }
 
         if let Some(provider_profile_id) = provider_profile_id {
@@ -1116,7 +1109,8 @@ impl Repository for SqliteRepository {
 
         tx.commit().await?;
 
-        self.get_session(id).await
+        let session = self.get_session(id).await?;
+        Ok(session.map(|s| (s, previous_agent_id)))
     }
 
     // --- Source ---
@@ -1649,6 +1643,7 @@ impl Repository for SqliteRepository {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use tempfile::tempdir;
 
     use super::SqliteRepository;
@@ -1666,7 +1661,7 @@ mod tests {
             .await
             .expect("sqlite repository should be created");
 
-        let agent = repository
+        let (agent, _) = repository
             .create_agent(AgentSpec::new("gpt-4.1"))
             .await
             .expect("agent should be created");
@@ -1712,5 +1707,46 @@ mod tests {
 
         assert_eq!(updated_session.messages.len(), 1);
         assert_eq!(updated_session.title, Some("hello world".to_string()));
+    }
+
+    /// Concurrent `create_agent` calls with identical specs must converge
+    /// to a single row via the `UNIQUE(spec_json)` + `ON CONFLICT` upsert.
+    /// Verifies Finding #3 (CoW Principle E: DB-level atomicity).
+    #[tokio::test]
+    async fn concurrent_create_agent_deduplicates_by_spec() {
+        let temp_dir = tempdir().expect("temp dir should be created");
+        let db_path = temp_dir.path().join("app.db");
+        let db_url = format!("sqlite://{}", db_path.display());
+
+        let repository = Arc::new(
+            SqliteRepository::new(&db_url)
+                .await
+                .expect("sqlite repository should be created"),
+        );
+
+        let concurrency = 10;
+        let handles: Vec<_> = (0..concurrency)
+            .map(|_| {
+                let repo = Arc::clone(&repository);
+                tokio::spawn(async move { repo.create_agent(AgentSpec::new("gpt-4.1")).await })
+            })
+            .collect();
+
+        let mut ids = std::collections::HashSet::new();
+        for handle in handles {
+            let (agent, _) = handle
+                .await
+                .expect("task should join")
+                .expect("agent should be returned");
+            ids.insert(agent.id);
+        }
+
+        assert_eq!(ids.len(), 1, "all concurrent calls should return the same agent id");
+
+        let agents = repository
+            .list_agents()
+            .await
+            .expect("agents should be listed");
+        assert_eq!(agents.len(), 1, "exactly one agent row should exist in DB");
     }
 }

--- a/backend/src/repository/sqlite.rs
+++ b/backend/src/repository/sqlite.rs
@@ -1733,15 +1733,26 @@ mod tests {
             .collect();
 
         let mut ids = std::collections::HashSet::new();
+        let mut created_count = 0usize;
         for handle in handles {
-            let (agent, _) = handle
+            let (agent, created) = handle
                 .await
                 .expect("task should join")
                 .expect("agent should be returned");
             ids.insert(agent.id);
+            if created {
+                created_count += 1;
+            }
         }
 
         assert_eq!(ids.len(), 1, "all concurrent calls should return the same agent id");
+        // The `created` flag drives the handler's 201-vs-200 decision. Under
+        // concurrency, exactly one caller may observe `created=true` — all
+        // others must see the existing row via ON CONFLICT DO UPDATE.
+        assert_eq!(
+            created_count, 1,
+            "exactly one concurrent call should have inserted the row"
+        );
 
         let agents = repository
             .list_agents()

--- a/backend/src/services/agent.rs
+++ b/backend/src/services/agent.rs
@@ -1,25 +1,21 @@
 use uuid::Uuid;
 
 use crate::models::Agent;
-use crate::repository::{RepositoryError, normalize_spec};
+use crate::repository::RepositoryError;
 use crate::state::AppState;
 
 /// Find an existing agent with the same normalized spec, or create a new one.
 ///
-/// Returns `(agent, created)` where `created` is true if a new agent was inserted.
+/// Returns `(agent, created)` where `created` is true if the returned agent is
+/// freshly inserted. Atomicity is guaranteed at the DB layer by
+/// `UNIQUE(spec_json)` + `INSERT ... ON CONFLICT DO UPDATE RETURNING` inside
+/// `create_agent`. Concurrent identical requests converge to the same row.
 ///
-/// NOTE: Not atomic — concurrent identical requests may create duplicates.
-/// Acceptable for dev stage single-user; revisit with UNIQUE constraint for production.
 pub async fn find_or_create_agent(
     state: &AppState,
     spec: ailoy::AgentSpec,
 ) -> Result<(Agent, bool), RepositoryError> {
-    let normalized = normalize_spec(&spec)?;
-    if let Some(existing) = state.repository.find_agent_by_spec(&normalized).await? {
-        return Ok((existing, false));
-    }
-    let agent = state.repository.create_agent(spec).await?;
-    Ok((agent, true))
+    state.repository.create_agent(spec).await
 }
 
 /// Best-effort cleanup: delete an agent if no sessions reference it anymore.

--- a/backend/src/services/agent.rs
+++ b/backend/src/services/agent.rs
@@ -32,6 +32,7 @@ pub async fn cleanup_orphaned_agent(state: &AppState, agent_id: Uuid) {
                 tracing::warn!(agent_id = %agent_id, "failed to cleanup orphaned agent: {e}");
             }
         }
-        _ => {} // has sessions or error — skip
+        Ok(true) => {} // has sessions — skip
+        Err(e) => tracing::warn!(agent_id = %agent_id, "failed to check orphan status: {e}"),
     }
 }

--- a/backend/src/services/agent.rs
+++ b/backend/src/services/agent.rs
@@ -1,0 +1,37 @@
+use uuid::Uuid;
+
+use crate::models::Agent;
+use crate::repository::{RepositoryError, normalize_spec};
+use crate::state::AppState;
+
+/// Find an existing agent with the same normalized spec, or create a new one.
+///
+/// Returns `(agent, created)` where `created` is true if a new agent was inserted.
+///
+/// NOTE: Not atomic — concurrent identical requests may create duplicates.
+/// Acceptable for dev stage single-user; revisit with UNIQUE constraint for production.
+pub async fn find_or_create_agent(
+    state: &AppState,
+    spec: ailoy::AgentSpec,
+) -> Result<(Agent, bool), RepositoryError> {
+    let normalized = normalize_spec(&spec)?;
+    if let Some(existing) = state.repository.find_agent_by_spec(&normalized).await? {
+        return Ok((existing, false));
+    }
+    let agent = state.repository.create_agent(spec).await?;
+    Ok((agent, true))
+}
+
+/// Best-effort cleanup: delete an agent if no sessions reference it anymore.
+///
+/// Errors are logged as warnings but never propagate — the caller's success is unaffected.
+pub async fn cleanup_orphaned_agent(state: &AppState, agent_id: Uuid) {
+    match state.repository.has_sessions_for_agent(agent_id).await {
+        Ok(false) => {
+            if let Err(e) = state.repository.delete_agent(agent_id).await {
+                tracing::warn!(agent_id = %agent_id, "failed to cleanup orphaned agent: {e}");
+            }
+        }
+        _ => {} // has sessions or error — skip
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod indexing;
 pub mod session;
 pub mod speedwagon;

--- a/backend/src/services/session.rs
+++ b/backend/src/services/session.rs
@@ -124,7 +124,7 @@ pub async fn update_session(
     }
 
     // Atomic update via transaction
-    let session = state
+    let (session, previous_agent_id) = state
         .repository
         .update_session_atomic(
             id,
@@ -139,6 +139,12 @@ pub async fn update_session(
 
     // Invalidate cache once after successful commit
     state.invalidate_session_runtime(id);
+
+    // CoW symmetry: if the agent pointer was swapped, the previous agent may now be
+    // orphaned. Mirror delete_session's cleanup so immutable agents don't accumulate.
+    if let Some(prev) = previous_agent_id {
+        super::agent::cleanup_orphaned_agent(state, prev).await;
+    }
 
     Ok(session)
 }

--- a/backend/src/services/session.rs
+++ b/backend/src/services/session.rs
@@ -101,12 +101,20 @@ pub async fn create_session(
     Ok(session)
 }
 
-/// Update a session atomically (title, provider, speedwagons, sources) and invalidate runtime cache.
+/// Update a session atomically (title, agent, provider, speedwagons, sources) and invalidate runtime cache.
 pub async fn update_session(
     state: &AppState,
     id: Uuid,
     req: UpdateSessionRequest,
 ) -> Result<Session, SessionError> {
+    // Validate agent if provided
+    if let Some(agent_id) = req.agent_id {
+        match state.repository.get_agent(agent_id).await? {
+            Some(_) => {}
+            None => return Err(SessionError::AgentNotFound),
+        }
+    }
+
     // Validate provider profile if provided
     if let Some(pp_id) = req.provider_profile_id {
         match state.repository.get_provider_profile(pp_id).await? {
@@ -121,6 +129,7 @@ pub async fn update_session(
         .update_session_atomic(
             id,
             req.title,
+            req.agent_id,
             req.provider_profile_id,
             req.speedwagon_ids,
             req.source_ids,
@@ -134,13 +143,25 @@ pub async fn update_session(
     Ok(session)
 }
 
-/// Delete a session and invalidate its runtime cache.
+/// Delete a session, invalidate its runtime cache, and cascade-delete orphaned agent.
 pub async fn delete_session(state: &AppState, id: Uuid) -> Result<(), SessionError> {
+    // Fetch session first to remember agent_id for potential orphan cleanup
+    let session = state
+        .repository
+        .get_session(id)
+        .await?
+        .ok_or(SessionError::NotFound)?;
+    let agent_id = session.agent_id;
+
     let deleted = state.repository.delete_session(id).await?;
     if !deleted {
         return Err(SessionError::NotFound);
     }
     state.invalidate_session_runtime(id);
+
+    // Best-effort: clean up agent if no sessions reference it anymore
+    super::agent::cleanup_orphaned_agent(state, agent_id).await;
+
     Ok(())
 }
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -73,12 +73,6 @@ impl AppState {
         }
     }
 
-    pub fn invalidate_runtimes_by_agent_id(&self, agent_id: Uuid) {
-        if let Ok(mut cache) = self.runtime_cache.lock() {
-            cache.retain(|_, runtime| runtime.agent_id != agent_id);
-        }
-    }
-
     pub fn invalidate_runtimes_by_provider_profile_id(&self, provider_profile_id: Uuid) {
         if let Ok(mut cache) = self.runtime_cache.lock() {
             cache.retain(|_, runtime| runtime.provider_profile_id != provider_profile_id);

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -115,6 +115,13 @@ backend/src/
 | 구조체/Enum | PascalCase | `Agent`, `ProviderProfile`, `MessageRole` |
 | 상수 | SCREAMING_SNAKE_CASE | `DEFAULT_DATABASE_URL` |
 
+### 포맷팅
+
+- `rustfmt` 기본 설정 준수 (커스텀 `rustfmt.toml` 없음)
+- 줄 너비 100자 제한, 초과 시 인자/필드별 줄바꿈 + trailing comma
+- 메서드 체인이 길면 `.method()` 단위로 줄바꿈
+- VSCode `formatOnSave` 활성화 (`.vscode/settings.json`)
+
 ### Import 규칙
 
 - `use` 문은 파일 최상단에 배치. **인라인 정규화 경로 금지** (`crate::models::X::new()` 등)

--- a/frontend/components/chat/chat-view.tsx
+++ b/frontend/components/chat/chat-view.tsx
@@ -52,6 +52,8 @@ export function ChatView({ sessionId }: ChatViewProps) {
   // Mid-session 모델 변경 핸들러
   const handleModelChange = useCallback(
     async (provider: ProviderName, model: string, profileId: string) => {
+      if (!currentAgentId) return;
+
       const prevProvider = selectedProvider;
       const prevModel = selectedModel;
       const prevProfileId = currentProfileId;
@@ -60,8 +62,13 @@ export function ChatView({ sessionId }: ChatViewProps) {
       setSelectedModel(provider, model, profileId);
 
       try {
-        // 1. 새 Agent 생성 (copy-on-write)
-        const agent = await createAgent({ spec: { lm: model, tools: [] } });
+        // 1. 현재 Agent spec을 로드해 instruction/tools를 보존한 채
+        //    lm만 덮어써서 새 Agent를 구한다 (copy-on-write).
+        //    동일 spec이라면 백엔드 UNIQUE 제약이 기존 Agent를 그대로 반환한다.
+        const currentAgent = await getAgent(currentAgentId);
+        const agent = await createAgent({
+          spec: { ...currentAgent.spec, lm: model },
+        });
 
         // 2. Session에 새 Agent 연결 (agent_id 변경된 경우) + Provider 변경 시 provider_profile_id도 업데이트
         const sessionUpdate: { agent_id?: string; provider_profile_id?: string } = {};

--- a/frontend/components/chat/chat-view.tsx
+++ b/frontend/components/chat/chat-view.tsx
@@ -9,7 +9,7 @@ import { IndexStatusBanner } from "@/components/chat/index-status-banner";
 import { ModelSelector } from "@/components/chat/model-selector";
 import { useAppStore } from "@/lib/store";
 import { toast } from "sonner";
-import { getSession, getAgent, updateAgent, updateSession } from "@/lib/api";
+import { getSession, getAgent, createAgent, updateSession } from "@/lib/api";
 import type { ProviderName } from "@/lib/constants";
 
 interface ChatViewProps {
@@ -60,15 +60,21 @@ export function ChatView({ sessionId }: ChatViewProps) {
       setSelectedModel(provider, model, profileId);
 
       try {
-        // 1. Agent 모델 변경
-        if (currentAgentId) {
-          await updateAgent(currentAgentId, { spec: { lm: model, tools: [] } });
-        }
+        // 1. 새 Agent 생성 (copy-on-write)
+        const agent = await createAgent({ spec: { lm: model, tools: [] } });
 
-        // 2. Provider가 변경된 경우 Session의 provider_profile_id 업데이트
+        // 2. Session에 새 Agent 연결 (agent_id 변경된 경우) + Provider 변경 시 provider_profile_id도 업데이트
+        const sessionUpdate: { agent_id?: string; provider_profile_id?: string } = {};
+        if (agent.id !== currentAgentId) {
+          sessionUpdate.agent_id = agent.id;
+          setCurrentAgentId(agent.id);
+        }
         if (profileId !== currentProfileId) {
-          await updateSession(sessionId, { provider_profile_id: profileId });
+          sessionUpdate.provider_profile_id = profileId;
           setCurrentProfileId(profileId);
+        }
+        if (Object.keys(sessionUpdate).length > 0) {
+          await updateSession(sessionId, sessionUpdate);
         }
       } catch {
         // Rollback on error

--- a/frontend/components/chat/chat-view.tsx
+++ b/frontend/components/chat/chat-view.tsx
@@ -67,14 +67,20 @@ export function ChatView({ sessionId }: ChatViewProps) {
         const sessionUpdate: { agent_id?: string; provider_profile_id?: string } = {};
         if (agent.id !== currentAgentId) {
           sessionUpdate.agent_id = agent.id;
-          setCurrentAgentId(agent.id);
         }
         if (profileId !== currentProfileId) {
           sessionUpdate.provider_profile_id = profileId;
-          setCurrentProfileId(profileId);
         }
         if (Object.keys(sessionUpdate).length > 0) {
           await updateSession(sessionId, sessionUpdate);
+        }
+
+        // Update local state only after successful backend call
+        if (sessionUpdate.agent_id) {
+          setCurrentAgentId(agent.id);
+        }
+        if (sessionUpdate.provider_profile_id) {
+          setCurrentProfileId(profileId);
         }
       } catch {
         // Rollback on error

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,7 +2,6 @@ import type {
   ApiProviderProfile,
   ApiAgent,
   ApiSession,
-  ApiSessionMessage,
   ApiSessionToolCall,
   ApiSource,
   ApiSpeedwagon,
@@ -11,7 +10,6 @@ import type {
   CreateProviderProfileRequest,
   UpdateProviderProfileRequest,
   CreateAgentRequest,
-  UpdateAgentRequest,
   CreateSessionRequest,
   UpdateSessionRequest,
   CreateSpeedwagonRequest,
@@ -133,16 +131,6 @@ export async function createAgent(data: CreateAgentRequest): Promise<ApiAgent> {
 
 export async function getAgent(id: string): Promise<ApiAgent> {
   return fetchApi<ApiAgent>(`/agents/${id}`);
-}
-
-export async function updateAgent(
-  id: string,
-  data: UpdateAgentRequest,
-): Promise<ApiAgent> {
-  return fetchApi<ApiAgent>(`/agents/${id}`, {
-    method: "PUT",
-    body: JSON.stringify(data),
-  });
 }
 
 // --- Sessions ---

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -127,14 +127,6 @@ export interface CreateAgentRequest {
   };
 }
 
-export interface UpdateAgentRequest {
-  spec: {
-    lm: string;
-    instruction?: string;
-    tools?: unknown[];
-  };
-}
-
 export interface CreateSessionRequest {
   agent_id: string;
   provider_profile_id?: string;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -145,6 +145,7 @@ export interface CreateSessionRequest {
 
 export interface UpdateSessionRequest {
   title?: string;
+  agent_id?: string;
   provider_profile_id?: string;
   speedwagon_ids?: string[];
   source_ids?: string[];


### PR DESCRIPTION
## Overview

Apply immutable, spec-based Agent reuse.

This PR changes Agent lifecycle from "mutate an existing Agent" to "find or create an Agent by normalized spec, then point the Session at that Agent." Identical `AgentSpec`s now converge to one DB row, model changes use copy-on-write, and orphaned Agents are cleaned up when Sessions stop referencing them.

Closes #13

## Background

Previously, every new chat or mid-session model change could create or mutate Agent rows in ways that did not match the domain model:

- `POST /agents` inserted rows even when the same spec already existed.
- `PUT /agents/{id}` mutated an Agent that could be shared by multiple Sessions.
- Model changes could accidentally affect other Sessions pointing at the same Agent.
- Agent rows could accumulate after the last Session reference disappeared.

The intended invariant is:

```text
Agent identity = normalized AgentSpec
Session owns the choice of which Agent it points to
Agent specs are immutable after creation
```

## Flow: Before vs After

### Before

```mermaid
flowchart TD
    A["User changes model"] --> B["Frontend calls updateAgent"]
    B --> C["PUT agents by id"]
    C --> D["Backend mutates Agent spec_json"]
    D --> E["Invalidate runtimes by Agent id"]
    E --> F["Other Sessions sharing that Agent can observe the changed spec"]
```

Problems:

- Shared Agent mutation could leak model/spec changes across Sessions.
- Agent identity was row-id based, not spec based.
- Runtime invalidation needed to reason about every Session referencing that Agent.

### After

```mermaid
flowchart TD
    A["User changes model"] --> B["Load current Agent"]
    B --> C["Preserve instruction and tools; replace lm"]
    C --> D["POST agents with new spec"]
    D --> E{"Same normalized spec exists"}
    E -->|"yes"| F["Return existing Agent with 200 OK"]
    E -->|"no"| G["Insert new Agent with 201 Created"]
    F --> H["Update Session agent_id when changed"]
    G --> H
    H --> I["Invalidate only this Session runtime"]
    I --> J["Cleanup previous Agent if orphaned"]
```

This keeps model switching scoped to the active Session while still deduplicating identical Agent specs.

## Key Decisions

| Decision | Current behavior | Why |
|----------|------------------|-----|
| Agent identity | Normalized `spec_json` | Keeps scope small while making identical specs reusable. |
| Deduplication | SQLite `UNIQUE(spec_json)` + `ON CONFLICT ... RETURNING` | Makes find-or-create atomic at the DB layer. |
| Agent updates | Remove `PUT /agents/{id}` | Agents are immutable; changing model/spec means selecting another Agent. |
| Session model change | `createAgent()` then `updateSession({ agent_id })` | Keeps API responsibilities explicit. |
| Orphan cleanup | Best-effort after Session delete or agent swap | Cleanup failure should not turn a successful Session operation into a misleading client failure. |

## Code-Level Notes

### 1. Agent spec normalization defines identity

`normalize_spec()` canonicalizes only the fields that matter for comparing current `AgentSpec`s:

```rust
pub fn normalize_spec(spec: &AgentSpec) -> RepositoryResult<String> {
    let mut normalized = spec.clone();
    normalized.tools.sort();
    normalized.tools.dedup();
    normalized.instruction = normalized
        .instruction
        .map(|s| s.trim().to_string())
        .filter(|s| !s.is_empty());
    serde_json::to_string(&normalized).map_err(RepositoryError::from)
}
```

So these match:

```json
{ "lm": "gpt-4.1", "instruction": null, "tools": ["a", "b"] }
{ "lm": "gpt-4.1", "instruction": "",   "tools": ["b", "a"] }
```

### 2. `POST /agents` is now atomic find-or-create

SQLite now enforces uniqueness:

```sql
CREATE TABLE IF NOT EXISTS agents (
    id TEXT PRIMARY KEY,
    spec_json TEXT NOT NULL UNIQUE,
    created_at TEXT NOT NULL,
    updated_at TEXT NOT NULL
);
```

The insert path returns either the newly inserted row or the existing conflict row:

```rust
INSERT INTO agents (id, spec_json, created_at, updated_at)
VALUES (?, ?, ?, ?)
ON CONFLICT(spec_json) DO UPDATE SET updated_at = excluded.updated_at
RETURNING id, spec_json, created_at, updated_at;
```

The repository returns `(Agent, created)` by comparing the returned id to the id attempted for this insert. That avoids timestamp-based `201`/`200` ambiguity.

### 3. `PUT /agents/{id}` is removed

The route now exposes read/delete for individual Agents, but no update:

```rust
.api_route("/agents", get(list_agents).post(create_agent))
.api_route(
    "/agents/{id}",
    get(get_agent).delete(delete_agent),
)
```

This prevents direct mutation of shared Agent specs.

### 4. Session updates can relink `agent_id`

`UpdateSessionRequest` now accepts an optional `agent_id`:

```rust
pub struct UpdateSessionRequest {
    pub title: Option<String>,
    pub agent_id: Option<Uuid>,
    pub provider_profile_id: Option<Uuid>,
    pub speedwagon_ids: Option<Vec<Uuid>>,
    pub source_ids: Option<Vec<Uuid>>,
}
```

`update_session_atomic()` returns the updated Session plus the previous `agent_id` when a real swap happened:

```rust
RepositoryResult<Option<(Session, Option<Uuid>)>>
```

The service then invalidates only the changed Session runtime and cleans up the previous Agent if it is now orphaned:

```rust
state.invalidate_session_runtime(id);

if let Some(prev) = previous_agent_id {
    super::agent::cleanup_orphaned_agent(state, prev).await;
}
```

### 5. Frontend model changes preserve the rest of the Agent spec

The model selector no longer calls `updateAgent()`. It fetches the current Agent, changes only `lm`, creates/reuses an Agent, and relinks the Session if needed:

```tsx
const currentAgent = await getAgent(currentAgentId);
const agent = await createAgent({
  spec: { ...currentAgent.spec, lm: model },
});

const sessionUpdate: { agent_id?: string; provider_profile_id?: string } = {};
if (agent.id !== currentAgentId) {
  sessionUpdate.agent_id = agent.id;
}
if (profileId !== currentProfileId) {
  sessionUpdate.provider_profile_id = profileId;
}

if (Object.keys(sessionUpdate).length > 0) {
  await updateSession(sessionId, sessionUpdate);
}
```

This preserves `instruction` and `tools` across model switches.

## Changes

### Backend

| File | Change |
|------|--------|
| `backend/src/repository/mod.rs` | Add `normalize_spec()`. Change `create_agent()` to return `(Agent, created)`. Add previous-agent return value to `update_session_atomic()`. |
| `backend/src/repository/sqlite.rs` | Add `UNIQUE(spec_json)` and explicit unique index. Implement atomic upsert with `ON CONFLICT ... RETURNING`. Return previous `agent_id` from session relinks. |
| `backend/src/repository/postgres.rs` | Keep matching trait stubs for the updated repository contract. |
| `backend/src/services/agent.rs` | Add `find_or_create_agent()` and orphan cleanup helper. |
| `backend/src/services/session.rs` | Validate optional `agent_id`, relink Sessions, invalidate per-session runtime, clean up previous orphan Agents. |
| `backend/src/handlers.rs` | Remove `PUT /agents/{id}`. Return `201 Created` for new Agents and `200 OK` for reused Agents. Add integration coverage. |
| `backend/src/models/agent.rs` | Remove `UpdateAgentRequest`. |
| `backend/src/models/session.rs` | Add `agent_id` to `UpdateSessionRequest`. |
| `backend/src/state.rs` | Remove agent-wide runtime invalidation path that was only needed for mutable Agents. |

### Frontend

| File | Change |
|------|--------|
| `frontend/components/chat/chat-view.tsx` | Replace model-change `updateAgent()` flow with fetch-current-Agent → `createAgent()` → `updateSession()` copy-on-write flow. |
| `frontend/lib/api.ts` | Remove `updateAgent()`. |
| `frontend/lib/types.ts` | Remove `UpdateAgentRequest`; add `agent_id?: string` to `UpdateSessionRequest`. |

### Docs

| File | Change |
|------|--------|
| `docs/conventions.md` | Add Rust formatting conventions. |

## Test Coverage

Backend integration/unit tests cover:

| Test | Verifies |
|------|----------|
| `find_or_create_same_spec_returns_same_id` | Same spec returns same Agent id; first request is `201`, reuse is `200`. |
| `find_or_create_tools_order_independent` | Tool order does not affect Agent identity. |
| `find_or_create_empty_instruction_variants_match` | `null`, empty, and whitespace-only instructions normalize together. |
| `find_or_create_different_lm_creates_new_agent` | Different model creates a distinct Agent. |
| `concurrent_create_agent_deduplicates_by_spec` | Concurrent identical creates converge to one row. |
| `update_session_agent_id_relinks_session` | `PUT /sessions/{id}` can move a Session to another Agent. |
| `delete_session_cascade_deletes_orphaned_agent` | Last Session deletion removes its orphaned Agent. |
| `delete_session_keeps_agent_when_other_sessions_exist` | Shared Agent survives when another Session still references it. |
| `update_session_agent_swap_cascade_deletes_orphaned_previous_agent` | Agent swap deletes the previous Agent when it becomes orphaned. |
| `update_session_agent_swap_keeps_previous_agent_when_other_sessions_exist` | Agent swap preserves the previous Agent when still referenced. |

Verified locally:

```text
cargo test -p agentwebui_backend -- --test-threads=1
28 passed

cd frontend && pnpm lint
exit 0
```

Note: backend tests are run serially because runtime/tool initialization can contend on shared local cache paths when run in parallel.

## Known Limitations

1. **Orphan cleanup is best-effort.** The primary Session operation succeeds even if orphan cleanup fails. A failed cleanup can leave an unused Agent row, but it does not corrupt Session references.
2. **Existing duplicate `spec_json` rows block the new unique index.** This is acceptable for the current dev-stage DB policy; deleting `backend/data/app.db` resolves old duplicate data.
3. **`normalize_spec()` must be reviewed when `ailoy::AgentSpec` changes.** The unique identity depends on deterministic serialization of the current fields.

## Architectural Note

`normalize_spec()` and JSON blob comparison are still a scoped solution. They make the current behavior correct without mixing in a larger schema refactor. A future schema could flatten Agent spec fields into SQL-native columns such as `lm`, `instruction`, and `tools_json` for clearer indexing and comparison.

This PR keeps that separate so reviewers can focus on the lifecycle behavior:

```text
Agent rows are immutable spec snapshots.
Sessions choose which Agent snapshot they use.
Identical snapshots are reused.
Unused snapshots are cleaned up when possible.
```

