### PR TITLE
refactor(knowledge-agent): remove redundant tool description from system prompt

### DIFF
--- a/knowledge-agent/src/agent/config.rs
+++ b/knowledge-agent/src/agent/config.rs
@@ -3,53 +3,6 @@ use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_SYSTEM_PROMPT: &str = r#"You are an expert research assistant. Your task is to answer questions by systematically searching through a document corpus using the provided tools. Think step by step.
 
-# Tools
-
-You have access to eight tools organized by purpose. Choose the right tool for each situation.
-
-## Discovery tools — find candidate documents
-
-- **glob_document** — Find files by filename pattern.
-  - Input: `pattern` (required), `limit` (optional, default 100)
-  - Output: List of matching files with `filepath` and `size`
-  - Best when the entity name likely appears in filenames (e.g. `*3M*2018*`, `*pride*`)
-
-- **search_document** — Find files by content relevance (BM25 full-text search).
-  - Input: `query` (required), `top_k` (optional: 1-5, default 3)
-  - Output: Documents with `filepath` and `score` only — use inspection tools to read content.
-
-## Inspection tools — read and locate within a document
-
-- **find_in_document** — Locate specific passages within a document.
-  - Input: `filepath` (required), `query` (required: keywords/regex)
-  - Output: Matching line numbers with content
-
-- **open_document** — Read a range of lines from a document.
-  - Input: `filepath` (required), `start_line` (optional), `end_line` (optional)
-  - Output: Line-numbered content (max 200 lines per call)
-  - Keep ranges small (20-40 lines). Make multiple calls if needed.
-
-- **summarize_document** — Get a concise summary of a long document.
-  - Input: `filepath` (required), `max_length` (optional, default 500 chars), `focus` (optional: topic to focus on)
-  - Use when you need a high-level overview before diving into details.
-
-## Computation tools — calculate and process data
-
-- **calculate** — Evaluate a mathematical expression.
-  - Input: `expression` (required, e.g. `"15 * 1.08"`, `"sqrt(144)"`)
-  - Use for simple arithmetic, unit conversions, percentages. Avoids numeric errors from mental math.
-
-- **run_python** — Write and execute Python code.
-  - Input: `code` (required: multi-line Python), `timeout_ms` (optional, default 30000)
-  - Use for complex calculations, data transformations, multi-step logic that calculate cannot handle.
-  - **Always use print() to output results** — stdout is the only way to capture output.
-  - Safe modules only (math, json, re, datetime, collections, etc.). No file I/O or network.
-
-- **run_bash** — Execute a read-only shell command.
-  - Input: `command` (required), `timeout_ms` (optional, default 10000)
-  - Use for system queries: `wc -l`, `grep`, `jq`, `diff`, etc.
-  - Only whitelisted read-only commands are allowed. Writes, redirects, and destructive operations are blocked.
-
 # Strategy
 
 Follow this ReAct (Reason + Act) approach:

--- a/knowledge-agent/src/tools/open.rs
+++ b/knowledge-agent/src/tools/open.rs
@@ -80,9 +80,9 @@ pub fn build_open_document_tool(
     let desc = ToolDescBuilder::new("open_document")
             .description(
                 "Read a range of lines from a specific document. \
-                 Returns line-numbered content. \
+                 Returns line-numbered content. Max 200 lines per call. \
                  Use filepath from search_document results and line numbers from find_in_document. \
-                 Keep ranges small (20-40 lines) to be efficient."
+                 Keep ranges small (20-40 lines); make multiple calls if needed."
             )
             .parameters(json!({
                 "type": "object",

--- a/knowledge-agent/src/tools/python.rs
+++ b/knowledge-agent/src/tools/python.rs
@@ -311,6 +311,7 @@ pub fn build_run_python_tool() -> ToolRuntime {
     let desc = ToolDescBuilder::new("run_python")
         .description(
             "Write and execute Python code for data processing, complex calculations, or multi-step logic. \
+             Always use print() to output results — stdout is the only return channel. \
              Only safe modules are allowed (math, json, re, datetime, collections, etc.). \
              File I/O, network access, and system calls are blocked.",
         )


### PR DESCRIPTION
## Summary

- `config.rs`의 `# Tools` 섹션 제거 — 각 tool의 schema description이 이미 동일한 내용을 LLM에 전달하므로 system prompt 내 복사본은 중복
- `open_document` tool description에 `"Max 200 lines per call"` 추가 — system prompt에만 있던 유일한 제약을 schema로 이동
- `run_python` tool description에 `"Always use print() to capture output"` 추가 — 동일한 이유

Strategy / Finding information / Computation / Error recovery / Choosing / Rules 섹션은 유지 — tool schema로 표현 불가한 워크플로우 가이던스.

## Test plan

- [x] `cargo build` 통과
- [x] unit/bash/calculator 테스트 127개 all pass
- [x] FinanceBench 10-question e2e: doc hit 10/10 (100%)