### PR TITLE
fix(knowledge-agent): relocate data paths to backend/data and fix test field references

### DIFF
--- a/knowledge-agent/settings.json
+++ b/knowledge-agent/settings.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "corpus_dirs": [
-      "../novelqa_downloader/books",
-      "data/financebench"
+      "../backend/data/txt",
+      "../backend/data/financebench/md"
     ],
-    "txt_dir": "../novelqa_downloader/books",
+    "txt_dir": "../backend/data/txt",
     "qa_file": "../novelqa_downloader/novelqa_merged.json",
     "index_dir": "./tantivy_index"
   },

--- a/knowledge-agent/settings.json
+++ b/knowledge-agent/settings.json
@@ -5,7 +5,7 @@
       "../backend/data/corpus/finance"
     ],
     "txt_dir": "../backend/data/corpus/novel",
-    "qa_file": "../novelqa_downloader/novelqa_merged.json",
+    "qa_file": "../backend/data/corpus/novel/novelqa_merged.json",
     "index_dir": "./tantivy_index"
   },
   "indexing": {

--- a/knowledge-agent/settings.json
+++ b/knowledge-agent/settings.json
@@ -1,10 +1,10 @@
 {
   "data": {
     "corpus_dirs": [
-      "../backend/data/txt",
-      "../backend/data/financebench/md"
+      "../backend/data/corpus/novel",
+      "../backend/data/corpus/finance"
     ],
-    "txt_dir": "../backend/data/txt",
+    "txt_dir": "../backend/data/corpus/novel",
     "qa_file": "../novelqa_downloader/novelqa_merged.json",
     "index_dir": "./tantivy_index"
   },

--- a/knowledge-agent/src/tools/search.rs
+++ b/knowledge-agent/src/tools/search.rs
@@ -18,9 +18,9 @@ use super::common::{extract_optional_i64, extract_required_str, result_to_value}
 pub struct SearchResult {
     pub filepath: String,
     pub score: f32,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing, default)]
     pub content_preview: String,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing, default)]
     pub content: String,
 }
 

--- a/knowledge-agent/tests/e2e_react_test.rs
+++ b/knowledge-agent/tests/e2e_react_test.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 // ─── Paths ───────────────────────────────────────────────────────────────────
 
 fn md_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/financebench")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../backend/data/financebench/md")
 }
 
 fn finance_index_dir() -> PathBuf {

--- a/knowledge-agent/tests/e2e_react_test.rs
+++ b/knowledge-agent/tests/e2e_react_test.rs
@@ -15,11 +15,11 @@ use serde::Deserialize;
 // ─── Paths ───────────────────────────────────────────────────────────────────
 
 fn md_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../backend/data/financebench/md")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../backend/data/corpus/finance")
 }
 
 fn finance_index_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/financebench/index/e2e_react")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../backend/data/index/finance")
 }
 
 fn books_dir() -> String {

--- a/knowledge-agent/tests/find_open_tests.rs
+++ b/knowledge-agent/tests/find_open_tests.rs
@@ -351,9 +351,9 @@ async fn test_search_find_open_tool_chain() {
     );
 
     // Step 3: open
-    let ctx_start = matches[0]["context_start"].as_u64().unwrap();
-    let ctx_end = matches[0]["context_end"].as_u64().unwrap();
-    let args = ailoy::to_value!({ "filepath": filepath, "start_line": ctx_start, "end_line": ctx_end + 10 });
+    let ctx_start = first_line.saturating_sub(2);
+    let ctx_end = first_line + 10;
+    let args = ailoy::to_value!({ "filepath": filepath, "start_line": ctx_start, "end_line": ctx_end });
     let result_msg = open_tool
         .run(Part::function("open_document", args))
         .await

--- a/scripts/setup-data.sh
+++ b/scripts/setup-data.sh
@@ -28,10 +28,11 @@ mkdir -p "$DATA_PATH/corpus/finance"
 aws s3 sync "$BUCKET/PatronusAI__financebench/" "$DATA_PATH/corpus/finance/" \
   --exclude "*" --include "*.md"
 
-# 3. Corpus — novel (.txt only)
+# 3. Corpus — novel (.txt only) + QA file
 echo "[3/4] Downloading novel corpus..."
 mkdir -p "$DATA_PATH/corpus/novel"
 aws s3 sync "$BUCKET/NovelQA__NovelQA/books/" "$DATA_PATH/corpus/novel/"
+aws s3 cp "$BUCKET/NovelQA__NovelQA/novelqa_merged.json" "$DATA_PATH/corpus/novel/novelqa_merged.json"
 
 # 4. Indexes
 echo "[4/4] Downloading indexes..."
@@ -42,5 +43,5 @@ aws s3 sync "$BUCKET/agentwebui/index/novel/" "$DATA_PATH/index/novel/"
 echo ""
 echo "=== Done ==="
 echo "  Config:  $DATA_PATH/knowledge_agents.json"
-echo "  Corpus:  $DATA_PATH/corpus/{finance,novel}"
+echo "  Corpus:  $DATA_PATH/corpus/{finance,novel} (novel includes novelqa_merged.json)"
 echo "  Index:   $DATA_PATH/index/{finance,novel}"


### PR DESCRIPTION
## Summary

- Align corpus data paths to `backend/data/corpus/` structure defined in `setup-data.sh`
- Fix stale `context_start`/`context_end` field references in `find_open_tests` (fields don't exist on `FindMatch`)
- Fix missing `#[serde(default)]` on `content_preview`/`content` in `SearchResult` causing deserialization failure in `search_tests`

## Data path changes

| Field | Before | After |
|-------|--------|-------|
| `corpus_dirs[0]` | `../novelqa_downloader/books` | `../backend/data/corpus/novel` |
| `corpus_dirs[1]` | `data/financebench` | `../backend/data/corpus/finance` |
| `txt_dir` | `../novelqa_downloader/books` | `../backend/data/corpus/novel` |
| e2e `md_dir` | `data/financebench/md` | `../backend/data/corpus/finance` |
| e2e `finance_index_dir` | `data/financebench/index/e2e_react` | `../backend/data/index/finance` |

Corpus files are not committed (covered by `.gitignore`). Use `scripts/setup-data.sh` to populate `backend/data/`.

## Test plan

- [x] `cargo build` — clean, no warnings
- [x] `cargo test --lib` — 6/6 passed
- [x] `cargo test --test find_open_tests` — 10/10 passed
- [x] `cargo test --test search_tests` — 2/2 passed
- [x] `cargo test --test find_comparison_test` — passed
- [x] `cargo test --test calculator_tests` — passed