### PR TITLE
fix(backend): handle ChatCompletion schema when bootstrapping openai-default profile

### DIFF
--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -287,10 +287,18 @@ impl AppState {
 
             let provider = AgentProvider {
                 lm: match schema {
+                    LangModelAPISchema::ChatCompletion => LangModelProvider::chat_completion(
+                        "https://api.openai.com/v1/chat/completions",
+                        Some(api_key),
+                    )
+                    .map_err(|e| {
+                        RepositoryError::InvalidData(format!(
+                            "invalid OpenAI chat_completion URL: {e}"
+                        ))
+                    })?,
                     LangModelAPISchema::Anthropic => LangModelProvider::anthropic(api_key),
                     LangModelAPISchema::Gemini => LangModelProvider::gemini(api_key),
                     LangModelAPISchema::OpenAI => LangModelProvider::openai(api_key),
-                    _ => panic!("unsupported api schema"),
                 },
                 tools: vec![],
             };

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -263,7 +263,7 @@ impl AppState {
             (
                 "OPENAI_API_KEY",
                 "openai-default",
-                LangModelAPISchema::ChatCompletion,
+                LangModelAPISchema::OpenAI,
             ),
             (
                 "ANTHROPIC_API_KEY",
@@ -287,18 +287,15 @@ impl AppState {
 
             let provider = AgentProvider {
                 lm: match schema {
-                    LangModelAPISchema::ChatCompletion => LangModelProvider::chat_completion(
-                        "https://api.openai.com/v1/chat/completions",
-                        Some(api_key),
-                    )
-                    .map_err(|e| {
-                        RepositoryError::InvalidData(format!(
-                            "invalid OpenAI chat_completion URL: {e}"
-                        ))
-                    })?,
+                    LangModelAPISchema::OpenAI => LangModelProvider::openai(api_key),
                     LangModelAPISchema::Anthropic => LangModelProvider::anthropic(api_key),
                     LangModelAPISchema::Gemini => LangModelProvider::gemini(api_key),
-                    LangModelAPISchema::OpenAI => LangModelProvider::openai(api_key),
+                    LangModelAPISchema::ChatCompletion => {
+                        return Err(RepositoryError::InvalidData(format!(
+                            "`{name}` cannot be bootstrapped with ChatCompletion schema; \
+                             create the provider profile via POST /provider-profiles"
+                        )));
+                    }
                 },
                 tools: vec![],
             };


### PR DESCRIPTION
## Summary

`agentwebui_backend` panics on startup when `OPENAI_API_KEY` is set, because `overwrite_default_provider_profiles_from_env` routed `OPENAI_API_KEY` to `LangModelAPISchema::ChatCompletion` but the match that converts `schema` into a `LangModelProvider` omitted that arm and fell through to `_ => panic!("unsupported api schema")`.

## Fix

- Route `OPENAI_API_KEY` to `LangModelAPISchema::OpenAI` (`/v1/responses`) instead of `ChatCompletion`.
- Drop the `_ => panic!(...)` wildcard. The match now handles every `LangModelAPISchema` variant explicitly, so future additions surface as compile errors instead of runtime panics.

## Verification

- [x] `OPENAI_API_KEY=sk-... ./agentwebui_backend` boots without panic (`server listening on http://127.0.0.1:...`)
- [x] `GET /provider-profiles` returns `openai-default` with `lm.schema == "openai"` and `lm.url == "https://api.openai.com/v1/responses"`
- [x] `cargo check -p agentwebui_backend` clean
- [x] `cargo test -p agentwebui_backend` — 19 passed, 0 failed

## Scope

Single-file change: `backend/src/state.rs`. No changes to public REST API, DB schema, or agent/tool behavior.

Closes #33
