### PR TITLE
feat(setup-data): add cuad corpus and index

### DIFF
--- a/scripts/setup-data.sh
+++ b/scripts/setup-data.sh
@@ -18,30 +18,37 @@ DATA_PATH="$PROJECT_ROOT/$DATA_DIR"
 echo "=== Setting up $DATA_PATH ==="
 
 # 1. Config
-echo "[1/4] Downloading knowledge_agents.json..."
+echo "[1/5] Downloading knowledge_agents.json..."
 mkdir -p "$DATA_PATH"
 aws s3 cp "$BUCKET/agentwebui/knowledge_agents.json" "$DATA_PATH/knowledge_agents.json"
 
 # 2. Corpus — finance (.md only, skip .pdf)
-echo "[2/4] Downloading finance corpus..."
+echo "[2/5] Downloading finance corpus..."
 mkdir -p "$DATA_PATH/corpus/finance"
 aws s3 sync "$BUCKET/PatronusAI__financebench/" "$DATA_PATH/corpus/finance/" \
   --exclude "*" --include "*.md"
 
-# 3. Corpus — novel (.txt only) + QA file
-echo "[3/4] Downloading novel corpus..."
+# 3. Corpus — cuad (.md only, skip .pdf and README)
+echo "[3/5] Downloading cuad corpus..."
+mkdir -p "$DATA_PATH/corpus/cuad"
+aws s3 sync "$BUCKET/TheAtticusProject__cuad/" "$DATA_PATH/corpus/cuad/" \
+  --exclude "*" --include "*.md" --exclude "README.md"
+
+# 4. Corpus — novel (.txt only) + QA file
+echo "[4/5] Downloading novel corpus..."
 mkdir -p "$DATA_PATH/corpus/novel"
 aws s3 sync "$BUCKET/NovelQA__NovelQA/books/" "$DATA_PATH/corpus/novel/"
 aws s3 cp "$BUCKET/NovelQA__NovelQA/novelqa_merged.json" "$DATA_PATH/corpus/novel/novelqa_merged.json"
 
-# 4. Indexes
-echo "[4/4] Downloading indexes..."
-mkdir -p "$DATA_PATH/index/finance" "$DATA_PATH/index/novel"
+# 5. Indexes
+echo "[5/5] Downloading indexes..."
+mkdir -p "$DATA_PATH/index/finance" "$DATA_PATH/index/cuad" "$DATA_PATH/index/novel"
 aws s3 sync "$BUCKET/agentwebui/index/finance/" "$DATA_PATH/index/finance/"
+aws s3 sync "$BUCKET/agentwebui/index/cuad/" "$DATA_PATH/index/cuad/"
 aws s3 sync "$BUCKET/agentwebui/index/novel/" "$DATA_PATH/index/novel/"
 
 echo ""
 echo "=== Done ==="
 echo "  Config:  $DATA_PATH/knowledge_agents.json"
-echo "  Corpus:  $DATA_PATH/corpus/{finance,novel} (novel includes novelqa_merged.json)"
-echo "  Index:   $DATA_PATH/index/{finance,novel}"
+echo "  Corpus:  $DATA_PATH/corpus/{finance,cuad,novel} (novel includes novelqa_merged.json)"
+echo "  Index:   $DATA_PATH/index/{finance,cuad,novel}"


### PR DESCRIPTION
## Summary

Adds CUAD (TheAtticusProject/cuad) as a third knowledge base alongside finance and novel.

- Downloads `corpus/cuad/` from `s3://ne-rag-dataset/TheAtticusProject__cuad/` (`.md` only, skip `.pdf` and `README.md`)
- Downloads `index/cuad/` from `s3://ne-rag-dataset/agentwebui/index/cuad/`
- Renumber steps `[1/4]` → `[1/5]` and update the final summary

## Dataset

- 510 commercial legal contracts from [CUAD v1](https://www.atticusprojectai.org/cuad) (CC BY 4.0)
- Markdown generated via docling 2.77.0 with the same pipeline options used by ailoy's `convert_pdf_to_md` builtin (no OCR, accurate table structure, enrichment disabled)
- Tantivy BM25 index pre-built and uploaded to S3

## Test plan

- [x] `./scripts/setup-data.sh` runs end-to-end without error (~20s total)
- [x] `backend/data/corpus/cuad/` contains 510 `.md` files, 0 `.pdf`, 0 `README.md` (29 MB)
- [x] `backend/data/index/cuad/` opens successfully via `SearchIndex::open` — "Index is up to date (510 files, 0 failed, 0 skipped)"

### Reproduction

```
$ ./scripts/setup-data.sh
...
=== Done ===
  Config:  backend/data/knowledge_agents.json
  Corpus:  backend/data/corpus/{finance,cuad,novel} (novel includes novelqa_merged.json)
  Index:   backend/data/index/{finance,cuad,novel}

$ ls backend/data/corpus/cuad/*.md | wc -l
     510
$ ls backend/data/corpus/cuad/*.pdf 2>/dev/null | wc -l
       0

$ cargo run --release --bin knowledge-agent -- \
    --target-paths backend/data/corpus/cuad \
    --index-dir    backend/data/index/cuad \
    --index-only
Index is up to date (510 files, built at 2026-04-21T07:31:48Z, 0.9s).
Files: 510 total, 510 success, 0 failed, 0 skipped
```