### PR TITLE
Add purpose metadata field to Store ingest

### DIFF
--- a/speedwagon/src/store/document.rs
+++ b/speedwagon/src/store/document.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct Document {
     pub id: String,
     pub title: String,
+    pub purpose: String,
     pub content: Option<String>,
     pub len: usize,
 }
@@ -27,8 +28,8 @@ impl fmt::Display for Document {
         };
         write!(
             f,
-            "{{ id: {}, title: {}, len: {}, content: {} }}",
-            self.id, self.title, self.len, content
+            "{{ id: {}, title: {}, purpose: {}, len: {}, content: {} }}",
+            self.id, self.title, self.purpose, self.len, content
         )
     }
 }

--- a/speedwagon/src/store/indexer.rs
+++ b/speedwagon/src/store/indexer.rs
@@ -5,39 +5,75 @@ use tantivy::{
     Index, IndexWriter, TantivyDocument, Term,
     collector::TopDocs,
     query::{AllQuery, BooleanQuery, Occur, Query, TermQuery},
-    schema::{IndexRecordOption, OwnedValue, STORED, STRING, TEXT},
+    schema::{IndexRecordOption, OwnedValue, STORED, STRING, Schema, TEXT},
 };
 
 use super::Document;
 
+fn build_schema() -> Schema {
+    let mut sb = Schema::builder();
+    sb.add_text_field("id", STRING | STORED);
+    sb.add_text_field("title", TEXT | STORED);
+    sb.add_text_field("purpose", TEXT | STORED);
+    sb.add_text_field("content", TEXT | STORED);
+    sb.build()
+}
+
+fn schema_matches(existing: &Schema, expected: &Schema) -> bool {
+    for (_, expected_entry) in expected.fields() {
+        let name = expected_entry.name();
+        match existing.get_field(name) {
+            Ok(_) => continue,
+            Err(_) => return false,
+        }
+    }
+    true
+}
+
 pub fn open_or_create(index_dir: &Path) -> Result<Index> {
-    let index = if index_dir.exists() {
-        Index::open_in_dir(index_dir)?
-    } else {
-        fs::create_dir_all(index_dir)?;
+    let expected = build_schema();
 
-        let mut sb = tantivy::schema::Schema::builder();
-        sb.add_text_field("id", STRING | STORED);
-        sb.add_text_field("title", TEXT | STORED);
-        sb.add_text_field("content", TEXT | STORED);
-        let schema = sb.build();
+    if index_dir.exists() {
+        match Index::open_in_dir(index_dir) {
+            Ok(index) if schema_matches(&index.schema(), &expected) => return Ok(index),
+            Ok(_) => {
+                log::info!(
+                    "speedwagon index schema is outdated at {index_dir:?}; removing and rebuilding (corpus is preserved)"
+                );
+                fs::remove_dir_all(index_dir)?;
+            }
+            Err(e) => {
+                log::warn!(
+                    "failed to open existing index at {index_dir:?} ({e}); removing and rebuilding"
+                );
+                fs::remove_dir_all(index_dir)?;
+            }
+        }
+    }
 
-        Index::create_in_dir(index_dir, schema)?
-    };
-
+    fs::create_dir_all(index_dir)?;
+    let index = Index::create_in_dir(index_dir, expected)?;
     Ok(index)
 }
 
-pub fn add_document(index: &Index, id: &str, title: &str, content: &str) -> Result<Document> {
+pub fn add_document(
+    index: &Index,
+    id: &str,
+    title: &str,
+    purpose: &str,
+    content: &str,
+) -> Result<Document> {
     let schema = index.schema();
     let id_f = schema.get_field("id")?;
     let title_f = schema.get_field("title")?;
+    let purpose_f = schema.get_field("purpose")?;
     let content_f = schema.get_field("content")?;
 
     let mut writer: IndexWriter = index.writer(128_000_000)?;
     let mut doc = TantivyDocument::default();
     doc.add_text(id_f, id);
     doc.add_text(title_f, title);
+    doc.add_text(purpose_f, purpose);
     doc.add_text(content_f, content);
     writer.add_document(doc)?;
     writer.commit()?;
@@ -45,12 +81,16 @@ pub fn add_document(index: &Index, id: &str, title: &str, content: &str) -> Resu
     Ok(Document {
         id: id.to_string(),
         title: title.to_string(),
+        purpose: purpose.to_string(),
         len: content.len(),
         content: Some(content.to_string()),
     })
 }
 
-pub fn add_documents(index: &Index, docs: &[(&str, &str, &str)]) -> Result<Vec<Document>> {
+pub fn add_documents(
+    index: &Index,
+    docs: &[(&str, &str, &str, &str)],
+) -> Result<Vec<Document>> {
     if docs.is_empty() {
         return Ok(vec![]);
     }
@@ -58,20 +98,23 @@ pub fn add_documents(index: &Index, docs: &[(&str, &str, &str)]) -> Result<Vec<D
     let schema = index.schema();
     let id_f = schema.get_field("id")?;
     let title_f = schema.get_field("title")?;
+    let purpose_f = schema.get_field("purpose")?;
     let content_f = schema.get_field("content")?;
 
     let mut writer: IndexWriter = index.writer(128_000_000)?;
     let mut result = Vec::with_capacity(docs.len());
 
-    for &(id, title, content) in docs {
+    for &(id, title, purpose, content) in docs {
         let mut doc = TantivyDocument::default();
         doc.add_text(id_f, id);
         doc.add_text(title_f, title);
+        doc.add_text(purpose_f, purpose);
         doc.add_text(content_f, content);
         writer.add_document(doc)?;
         result.push(Document {
             id: id.to_string(),
             title: title.to_string(),
+            purpose: purpose.to_string(),
             len: content.len(),
             content: Some(content.to_string()),
         });
@@ -96,6 +139,7 @@ pub fn delete_document(index: &Index, id: &str) -> Result<Option<Document>> {
     let schema = index.schema();
     let id_f = schema.get_field("id")?;
     let title_f = schema.get_field("title")?;
+    let purpose_f = schema.get_field("purpose")?;
     let content_f = schema.get_field("content")?;
 
     let doc = {
@@ -115,6 +159,7 @@ pub fn delete_document(index: &Index, id: &str) -> Result<Option<Document>> {
         Document {
             id: id.to_string(),
             title: get_str(&tdoc, title_f),
+            purpose: get_str(&tdoc, purpose_f),
             len: content.len(),
             content: Some(content),
         }
@@ -133,6 +178,7 @@ pub fn list_documents(index: &Index, include_content: bool) -> Result<Vec<Docume
     let schema = index.schema();
     let id_f = schema.get_field("id").unwrap();
     let title_f = schema.get_field("title").unwrap();
+    let purpose_f = schema.get_field("purpose").unwrap();
     let content_f = schema.get_field("content").unwrap();
 
     let total = searcher.num_docs() as usize;
@@ -149,6 +195,7 @@ pub fn list_documents(index: &Index, include_content: bool) -> Result<Vec<Docume
             Document {
                 id: get_str(&doc, id_f),
                 title: get_str(&doc, title_f),
+                purpose: get_str(&doc, purpose_f),
                 len: content.len(),
                 content: if include_content { Some(content) } else { None },
             }
@@ -167,6 +214,7 @@ pub fn get_document(index: &Index, id: &str) -> Result<Option<Document>> {
     let schema = index.schema();
     let id_f = schema.get_field("id")?;
     let title_f = schema.get_field("title")?;
+    let purpose_f = schema.get_field("purpose")?;
     let content_f = schema.get_field("content")?;
 
     let term = Term::from_field_text(id_f, id);
@@ -179,6 +227,7 @@ pub fn get_document(index: &Index, id: &str) -> Result<Option<Document>> {
         Document {
             id: id.to_string(),
             title: get_str(&doc, title_f),
+            purpose: get_str(&doc, purpose_f),
             len: content.len(),
             content: Some(content),
         }
@@ -195,6 +244,7 @@ pub fn get_documents(index: &Index, ids: &[&str]) -> Result<Vec<Document>> {
     let schema = index.schema();
     let id_f = schema.get_field("id")?;
     let title_f = schema.get_field("title")?;
+    let purpose_f = schema.get_field("purpose")?;
     let content_f = schema.get_field("content")?;
 
     let subqueries: Vec<(Occur, Box<dyn Query>)> = ids
@@ -218,6 +268,7 @@ pub fn get_documents(index: &Index, ids: &[&str]) -> Result<Vec<Document>> {
             Document {
                 id,
                 title: get_str(&doc, title_f),
+                purpose: get_str(&doc, purpose_f),
                 len: content.len(),
                 content: Some(content),
             }
@@ -229,5 +280,111 @@ fn get_str(doc: &TantivyDocument, field: tantivy::schema::Field) -> String {
     match doc.get_first(field) {
         Some(OwnedValue::Str(s)) => s.clone(),
         _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn schema_includes_purpose() {
+        let schema = build_schema();
+        assert!(schema.get_field("id").is_ok());
+        assert!(schema.get_field("title").is_ok());
+        assert!(schema.get_field("purpose").is_ok());
+        assert!(schema.get_field("content").is_ok());
+    }
+
+    #[test]
+    fn open_or_create_creates_new_index() {
+        let tmp = TempDir::new().unwrap();
+        let index = open_or_create(&tmp.path().join("idx")).unwrap();
+        assert!(index.schema().get_field("purpose").is_ok());
+    }
+
+    #[test]
+    fn open_or_create_reopens_matching_index() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("idx");
+        let _ = open_or_create(&path).unwrap();
+        // second call should reopen, not recreate
+        let index = open_or_create(&path).unwrap();
+        assert!(index.schema().get_field("purpose").is_ok());
+    }
+
+    #[test]
+    fn open_or_create_rebuilds_outdated_schema() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("idx");
+        fs::create_dir_all(&path).unwrap();
+
+        // build legacy schema (no purpose)
+        let mut sb = Schema::builder();
+        sb.add_text_field("id", STRING | STORED);
+        sb.add_text_field("title", TEXT | STORED);
+        sb.add_text_field("content", TEXT | STORED);
+        let legacy = sb.build();
+        Index::create_in_dir(&path, legacy).unwrap();
+
+        let index = open_or_create(&path).unwrap();
+        assert!(
+            index.schema().get_field("purpose").is_ok(),
+            "expected rebuilt schema to contain purpose field"
+        );
+    }
+
+    #[test]
+    fn add_document_round_trips_purpose() {
+        let tmp = TempDir::new().unwrap();
+        let index = open_or_create(&tmp.path().join("idx")).unwrap();
+
+        let purpose = "3M Company FY2018 10-K Annual Report — revenue, safety industrial, healthcare";
+        add_document(&index, "doc1", "3M 10-K", purpose, "body text").unwrap();
+
+        let doc = get_document(&index, "doc1").unwrap().unwrap();
+        assert_eq!(doc.purpose, purpose);
+        assert_eq!(doc.title, "3M 10-K");
+    }
+
+    #[test]
+    fn add_documents_batch_round_trips_purpose() {
+        let tmp = TempDir::new().unwrap();
+        let index = open_or_create(&tmp.path().join("idx")).unwrap();
+
+        let docs = vec![
+            ("a", "Title A", "purpose A", "content A"),
+            ("b", "Title B", "purpose B", "content B"),
+        ];
+        add_documents(&index, &docs).unwrap();
+
+        let result = get_documents(&index, &["a", "b"]).unwrap();
+        let purposes: std::collections::HashSet<_> =
+            result.iter().map(|d| d.purpose.clone()).collect();
+        assert!(purposes.contains("purpose A"));
+        assert!(purposes.contains("purpose B"));
+    }
+
+    #[test]
+    fn list_documents_includes_purpose() {
+        let tmp = TempDir::new().unwrap();
+        let index = open_or_create(&tmp.path().join("idx")).unwrap();
+        add_document(&index, "x", "T", "P-purpose", "body").unwrap();
+
+        let docs = list_documents(&index, false).unwrap();
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].purpose, "P-purpose");
+        assert!(docs[0].content.is_none());
+    }
+
+    #[test]
+    fn delete_document_returns_purpose() {
+        let tmp = TempDir::new().unwrap();
+        let index = open_or_create(&tmp.path().join("idx")).unwrap();
+        add_document(&index, "id1", "Title", "the-purpose", "body").unwrap();
+
+        let removed = delete_document(&index, "id1").unwrap().unwrap();
+        assert_eq!(removed.purpose, "the-purpose");
     }
 }

--- a/speedwagon/src/store/mod.rs
+++ b/speedwagon/src/store/mod.rs
@@ -79,9 +79,18 @@ impl Store {
         if !indexer::document_exists(&self.index, &id.to_string())? {
             let content = fs::read_to_string(&corpus_path)
                 .with_context(|| format!("failed to read corpus: {corpus_path:?}"))?;
-            let title = parser::get_title(&content).await?;
+            let (title, purpose) = tokio::try_join!(
+                parser::get_title(&content),
+                parser::get_purpose(&content),
+            )?;
 
-            indexer::add_document(&self.index, &id.to_string(), &title, &content)?;
+            indexer::add_document(
+                &self.index,
+                &id.to_string(),
+                &title,
+                &purpose,
+                &content,
+            )?;
         }
 
         Ok(id)
@@ -132,15 +141,20 @@ impl Store {
             return Ok(all_ids);
         }
 
-        let mut docs: Vec<(String, String, String)> = Vec::with_capacity(to_index.len());
+        let mut docs: Vec<(String, String, String, String)> = Vec::with_capacity(to_index.len());
         for (id, content) in to_index {
-            let title = parser::get_title(&content).await?;
-            docs.push((id.to_string(), title, content));
+            let (title, purpose) = tokio::try_join!(
+                parser::get_title(&content),
+                parser::get_purpose(&content),
+            )?;
+            docs.push((id.to_string(), title, purpose, content));
         }
 
-        let refs: Vec<(&str, &str, &str)> = docs
+        let refs: Vec<(&str, &str, &str, &str)> = docs
             .iter()
-            .map(|(id, title, content)| (id.as_str(), title.as_str(), content.as_str()))
+            .map(|(id, title, purpose, content)| {
+                (id.as_str(), title.as_str(), purpose.as_str(), content.as_str())
+            })
             .collect();
         indexer::add_documents(&self.index, &refs)?;
 

--- a/speedwagon/src/store/parser.rs
+++ b/speedwagon/src/store/parser.rs
@@ -94,3 +94,142 @@ pub async fn get_title(content: &str) -> Result<String> {
         }
     }
 }
+
+const PURPOSE_INSTRUCTION: &str = concat!(
+    "You are generating search metadata for a document retrieval system. ",
+    "Your output will be used as BM25 search terms — optimize for retrieval, NOT readability.\n\n",
+    "Given a document content preview (first 3000 characters), return ONLY a JSON object: ",
+    "{\"purpose\": \"<string>\"}.\n\n",
+    "purpose rules:\n",
+    "- ONE sentence, 80–150 characters\n",
+    "- MUST include: entity name(s), year/date, document type, 3–5 key topic terms\n",
+    "- Think: \"what search queries should find this document?\"\n",
+    "- Do NOT describe what the document says. Write what it IS and what it is FOR.\n\n",
+    "GOOD: \"3M Company FY2018 10-K Annual Report — revenue $32.8B, safety industrial, healthcare, EPS growth\"\n",
+    "BAD:  \"This document discusses the company's financial results\"",
+);
+
+const PURPOSE_PREVIEW_CHARS: usize = 3000;
+
+/// Wraps an Ailoy agent used to generate document purpose metadata via LLM.
+pub struct PurposeAgent {
+    spec: AgentSpec,
+    provider: Option<AgentProvider>,
+}
+
+impl PurposeAgent {
+    pub fn new(provider: Option<AgentProvider>) -> Self {
+        Self {
+            spec: AgentSpec::new("openai/gpt-5.4-mini").instruction(PURPOSE_INSTRUCTION),
+            provider,
+        }
+    }
+
+    pub async fn generate(&self, content: &str) -> Result<String> {
+        let snippet: String = content.chars().take(PURPOSE_PREVIEW_CHARS).collect();
+        let query = Message::new(Role::User).with_contents([Part::text(snippet)]);
+
+        let mut agent = match &self.provider {
+            Some(provider) => Agent::try_with_provider(self.spec.clone(), provider).await?,
+            None => Agent::try_new(self.spec.clone()).await?,
+        };
+
+        let mut text_parts: Vec<String> = Vec::new();
+        {
+            let mut stream = agent.run(query);
+            while let Some(result) = stream.next().await {
+                let output = result?;
+                for part in &output.message.contents {
+                    if let Some(text) = part.as_text() {
+                        text_parts.push(text.to_string());
+                    }
+                }
+            }
+        }
+
+        let raw = text_parts.join("");
+        Ok(parse_purpose_response(&raw))
+    }
+}
+
+fn parse_purpose_response(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed)
+        && let Some(p) = value.get("purpose").and_then(|v| v.as_str())
+    {
+        return p.trim().to_string();
+    }
+
+    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}'))
+        && start < end
+        && let Ok(value) = serde_json::from_str::<serde_json::Value>(&trimmed[start..=end])
+        && let Some(p) = value.get("purpose").and_then(|v| v.as_str())
+    {
+        return p.trim().to_string();
+    }
+
+    String::new()
+}
+
+pub async fn get_purpose(content: &str) -> Result<String> {
+    dotenvy::dotenv().ok();
+
+    let mut provider = AgentProvider::new();
+    provider.model_openai(
+        std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY not set in environment")?,
+    );
+
+    let purpose = PurposeAgent::new(Some(provider)).generate(content).await?;
+    if purpose.is_empty() {
+        log::warn!("purpose generation returned empty string; indexing without purpose metadata");
+    }
+    Ok(purpose)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_purpose_response_plain_json() {
+        let raw = r#"{"purpose": "3M Company FY2018 10-K Annual Report"}"#;
+        assert_eq!(
+            parse_purpose_response(raw),
+            "3M Company FY2018 10-K Annual Report"
+        );
+    }
+
+    #[test]
+    fn parse_purpose_response_with_whitespace() {
+        let raw = "\n  {\"purpose\": \"hello\"}  \n";
+        assert_eq!(parse_purpose_response(raw), "hello");
+    }
+
+    #[test]
+    fn parse_purpose_response_with_surrounding_text() {
+        let raw = "Sure, here you go: {\"purpose\": \"Costco 2023 Q1 earnings\"} — done.";
+        assert_eq!(parse_purpose_response(raw), "Costco 2023 Q1 earnings");
+    }
+
+    #[test]
+    fn parse_purpose_response_empty() {
+        assert_eq!(parse_purpose_response(""), "");
+        assert_eq!(parse_purpose_response("   "), "");
+    }
+
+    #[test]
+    fn parse_purpose_response_invalid_json() {
+        assert_eq!(parse_purpose_response("not json"), "");
+        assert_eq!(parse_purpose_response("{not: json}"), "");
+    }
+
+    #[test]
+    fn parse_purpose_response_missing_field() {
+        let raw = r#"{"other": "value"}"#;
+        assert_eq!(parse_purpose_response(raw), "");
+    }
+}

--- a/speedwagon/src/store/searcher.rs
+++ b/speedwagon/src/store/searcher.rs
@@ -34,9 +34,11 @@ pub fn search_page(
     let reader = index.reader()?;
     let searcher = reader.searcher();
     let schema = index.schema();
+    let title_f = schema.get_field("title").unwrap();
+    let purpose_f = schema.get_field("purpose").unwrap();
     let content_f = schema.get_field("content").unwrap();
 
-    let qp = tantivy::query::QueryParser::for_index(index, vec![content_f]);
+    let qp = tantivy::query::QueryParser::for_index(index, vec![title_f, purpose_f, content_f]);
     let (query, _) = qp.parse_query_lenient(query_str);
 
     let offset = (page * page_size) as usize;
@@ -81,6 +83,7 @@ fn doc_to_result(
         document: Document {
             id: get_str(doc, schema.get_field("id").unwrap()),
             title: get_str(doc, schema.get_field("title").unwrap()),
+            purpose: get_str(doc, schema.get_field("purpose").unwrap()),
             len: content.len(),
             content: Some(content),
         },
@@ -97,10 +100,11 @@ mod tests {
         schema::{STORED, STRING, TEXT},
     };
 
-    fn make_index(docs: &[(&str, &str, &str)]) -> Index {
+    fn make_index(docs: &[(&str, &str, &str, &str)]) -> Index {
         let mut sb = tantivy::schema::Schema::builder();
         sb.add_text_field("id", STRING | STORED);
         sb.add_text_field("title", TEXT | STORED);
+        sb.add_text_field("purpose", TEXT | STORED);
         sb.add_text_field("content", TEXT | STORED);
         let schema = sb.build();
         let index = Index::create_in_ram(schema);
@@ -109,11 +113,13 @@ mod tests {
             let schema = index.schema();
             let id_f = schema.get_field("id").unwrap();
             let title_f = schema.get_field("title").unwrap();
+            let purpose_f = schema.get_field("purpose").unwrap();
             let content_f = schema.get_field("content").unwrap();
-            for &(id, title, content) in docs {
+            for &(id, title, purpose, content) in docs {
                 let mut doc = TantivyDocument::default();
                 doc.add_text(id_f, id);
                 doc.add_text(title_f, title);
+                doc.add_text(purpose_f, purpose);
                 doc.add_text(content_f, content);
                 writer.add_document(doc).unwrap();
             }
@@ -128,9 +134,10 @@ mod tests {
             (
                 "doc1",
                 "Revenue Report",
+                "",
                 "quarterly revenue increased by 20%",
             ),
-            ("doc2", "Product Launch", "new product features announced"),
+            ("doc2", "Product Launch", "", "new product features announced"),
         ]);
         let page = search_page(&index, "revenue", 0, 10).unwrap();
         assert_eq!(page.results.len(), 1);
@@ -140,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_search_no_results() {
-        let index = make_index(&[("doc1", "Title", "some content here")]);
+        let index = make_index(&[("doc1", "Title", "", "some content here")]);
         let page = search_page(&index, "xyzzy", 0, 10).unwrap();
         assert!(page.results.is_empty());
         assert!(!page.has_more);
@@ -149,9 +156,9 @@ mod tests {
     #[test]
     fn test_search_has_more() {
         let index = make_index(&[
-            ("a", "Alpha", "rust programming language"),
-            ("b", "Beta", "rust memory safety"),
-            ("c", "Gamma", "rust async runtime"),
+            ("a", "Alpha", "", "rust programming language"),
+            ("b", "Beta", "", "rust memory safety"),
+            ("c", "Gamma", "", "rust async runtime"),
         ]);
         let page = search_page(&index, "rust", 0, 2).unwrap();
         assert_eq!(page.results.len(), 2);
@@ -161,9 +168,9 @@ mod tests {
     #[test]
     fn test_search_page_offset() {
         let index = make_index(&[
-            ("a", "Alpha", "rust programming language"),
-            ("b", "Beta", "rust memory safety"),
-            ("c", "Gamma", "rust async runtime"),
+            ("a", "Alpha", "", "rust programming language"),
+            ("b", "Beta", "", "rust memory safety"),
+            ("c", "Gamma", "", "rust async runtime"),
         ]);
         let page0_ids: Vec<_> = search_page(&index, "rust", 0, 2)
             .unwrap()
@@ -180,11 +187,32 @@ mod tests {
     #[test]
     fn test_content_preview_capped_at_2000_chars() {
         let content = "documentation ".repeat(200); // 2800 chars
-        let index = make_index(&[("doc1", "Long Doc", &content)]);
+        let index = make_index(&[("doc1", "Long Doc", "", &content)]);
         let page = search_page(&index, "documentation", 0, 10).unwrap();
         assert_eq!(page.results.len(), 1);
         assert_eq!(page.results[0].content_preview.chars().count(), 2000);
         assert!(page.results[0].document.len > 2000);
+    }
+
+    #[test]
+    fn test_search_matches_purpose_field() {
+        let index = make_index(&[
+            (
+                "doc1",
+                "Filing Cover",
+                "3M Company FY2018 10-K Annual Report — revenue, healthcare, safety industrial",
+                "boilerplate cover page text",
+            ),
+            (
+                "doc2",
+                "Other",
+                "Costco Wholesale 2023 Q1 earnings — net sales, comparable sales",
+                "different filler",
+            ),
+        ]);
+        let page = search_page(&index, "healthcare", 0, 10).unwrap();
+        assert_eq!(page.results.len(), 1);
+        assert_eq!(page.results[0].document.id, "doc1");
     }
 
     #[test]
@@ -193,6 +221,7 @@ mod tests {
             document: Document {
                 id: "id1".into(),
                 title: "T".into(),
+                purpose: "P".into(),
                 content: None,
                 len: 0,
             },


### PR DESCRIPTION
## Summary

Adds an LLM-generated `purpose` metadata field to the speedwagon `Store` ingest pipeline. This was the best-performing variant in the metadata ablation: **+15.3pp BM25 hit@5 on FinanceBench** (32.0% → 47.3%) over the title-only baseline, beating the alternative `intent + summary` two-field schema (+10.0pp) at lower generation cost.

Closes #37.

## Changes

### Schema
Tantivy schema gains a `purpose` field (`TEXT | STORED`) alongside `title` and `content`. `QueryParser` default fields are now `[title, purpose, content]` so purpose terms contribute to BM25 scoring at search time.

### Generation (`parser.rs`)
- New `PurposeAgent` mirrors the existing `TitleAgent` pattern (Ailoy `openai/gpt-5.4-mini`).
- Prompt and preview strategy reproduce the ablation v1 winner: first 3000 chars of content, JSON output (`{"purpose": "..."}`), one-sentence 80–150 char framing optimized for BM25 retrieval.
- Response parsing handles plain JSON and JSON wrapped in surrounding text. Empty/invalid responses fall back to `""` with a `log::warn!` so ingest still succeeds; transport-level errors propagate via `?`.

### Ingest (`mod.rs`)
`Store::ingest` and `Store::ingest_many` now run `get_title` and `get_purpose` in parallel via `tokio::try_join!` to avoid serializing the two LLM calls.

### Index compatibility (`indexer.rs`)
`open_or_create` detects schema mismatch on existing index directories and **automatically rebuilds the index** (`fs::remove_dir_all` + recreate). The corpus directory is preserved, so users only re-pay the LLM cost on first run after upgrade. A `log::info!` line announces the rebuild so the cost is visible. The `add_document` / `add_documents` / `delete_document` / `get_document` / `get_documents` / `list_documents` functions all round-trip the new field.

### Document struct (`document.rs`)
`Document` gains `pub purpose: String`. The `Display` impl is updated accordingly.

## Tests

13 new unit tests (parser response parsing, schema build, schema-mismatch rebuild path, purpose round-trip through every indexer function, search hits via purpose-only matches). Existing tests updated for the new `(id, title, purpose, content)` tuple shape.

```
cargo test --lib
test result: ok. 27 passed; 0 failed; 1 ignored
```

`cargo check --features internal` and `cargo clippy --features internal --tests` are clean for changed code.

## Notes

- The schema-rebuild policy is intentionally simple: delete and re-create. There is no migration helper. This is fine while `refactoring-applied` is pre-production; if migration becomes a concern later, a `.schema_hash` cache file can short-circuit unchanged-schema reopens.
- `get_purpose` always calls the LLM (no frontmatter fallback like `get_title`). The empty-string fallback on bad LLM output keeps the index at baseline quality rather than failing the whole ingest.