### PR TITLE
feat(speedwagon): add DescriptionAgent for KB-level description generation

### DIFF
--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -49,7 +49,7 @@ impl DescriptionAgent {
         &self,
         kb_name: &str,
         instruction: Option<&str>,
-        docs: &[(String, String)],
+        docs: &[(&str, &str)],
     ) -> Result<String> {
         let user = build_user_message(kb_name, instruction, docs);
         let query = Message::new(Role::User).with_contents([Part::text(user)]);
@@ -79,7 +79,7 @@ impl DescriptionAgent {
 fn build_user_message(
     kb_name: &str,
     instruction: Option<&str>,
-    docs: &[(String, String)],
+    docs: &[(&str, &str)],
 ) -> String {
     let mut s = String::new();
     s.push_str(&format!("KB name: {kb_name}\n"));
@@ -90,7 +90,7 @@ fn build_user_message(
     }
     s.push_str(&format!("\nDocuments ({}):\n", docs.len()));
     for (_title, purpose) in docs {
-        let p = if purpose.is_empty() { "(no purpose)" } else { purpose.as_str() };
+        let p = if purpose.is_empty() { "(no purpose)" } else { *purpose };
         s.push_str(&format!("- {p}\n"));
     }
     s
@@ -128,7 +128,7 @@ fn parse_description_response(raw: &str) -> String {
 pub async fn get_description(
     kb_name: &str,
     instruction: Option<&str>,
-    docs: &[(String, String)],
+    docs: &[(&str, &str)],
 ) -> Result<String> {
     dotenvy::dotenv().ok();
 
@@ -141,7 +141,7 @@ pub async fn get_description(
     let result = agent.generate(kb_name, instruction, docs).await?;
     if result.is_empty() {
         log::warn!("description generation returned empty string; using fallback");
-        let titles: Vec<String> = docs.iter().map(|(t, _)| t.clone()).collect();
+        let titles: Vec<&str> = docs.iter().map(|(t, _)| *t).collect();
         Ok(fallback_description(docs.len(), &titles))
     } else {
         Ok(result)
@@ -149,7 +149,7 @@ pub async fn get_description(
 }
 
 /// Deterministic fallback when the LLM call fails or returns empty.
-pub fn fallback_description(doc_count: usize, top_titles: &[String]) -> String {
+pub fn fallback_description(doc_count: usize, top_titles: &[&str]) -> String {
     if doc_count == 0 {
         return String::new();
     }
@@ -157,7 +157,7 @@ pub fn fallback_description(doc_count: usize, top_titles: &[String]) -> String {
         .iter()
         .filter(|t| !t.is_empty())
         .take(5)
-        .map(String::as_str)
+        .copied()
         .collect();
     if titles.is_empty() {
         format!("{doc_count} documents")
@@ -213,23 +213,12 @@ mod tests {
     #[test]
     fn fallback_no_titles_falls_back_to_count_only() {
         assert_eq!(fallback_description(7, &[]), "7 documents");
-        assert_eq!(
-            fallback_description(7, &["".to_string(), "".to_string()]),
-            "7 documents"
-        );
+        assert_eq!(fallback_description(7, &["", ""]), "7 documents");
     }
 
     #[test]
     fn fallback_with_titles_takes_top_five() {
-        let titles = vec![
-            "A".to_string(),
-            "B".to_string(),
-            "C".to_string(),
-            "D".to_string(),
-            "E".to_string(),
-            "F".to_string(),
-            "G".to_string(),
-        ];
+        let titles = ["A", "B", "C", "D", "E", "F", "G"];
         assert_eq!(
             fallback_description(7, &titles),
             "7 documents including: A; B; C; D; E"
@@ -238,10 +227,7 @@ mod tests {
 
     #[test]
     fn user_message_skips_blank_instruction() {
-        let docs = vec![
-            ("T1".to_string(), "P1".to_string()),
-            ("T2".to_string(), "".to_string()),
-        ];
+        let docs = [("T1", "P1"), ("T2", "")];
         let msg = build_user_message("kb1", Some("   "), &docs);
         assert!(msg.contains("KB name: kb1"));
         assert!(!msg.contains("KB instruction"));
@@ -251,7 +237,7 @@ mod tests {
 
     #[test]
     fn user_message_renders_purpose_only_not_title() {
-        let docs = vec![("Apple 10-K".to_string(), "Apple FY2021 annual report".to_string())];
+        let docs = [("Apple 10-K", "Apple FY2021 annual report")];
         let msg = build_user_message("finance", None, &docs);
         // purpose is in, title is not
         assert!(msg.contains("Apple FY2021 annual report"));

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -26,6 +26,7 @@ const DESCRIPTION_INSTRUCTION: &str = concat!(
     "Output must NOT mention dataset names, QA pairs, paper IDs, contract IDs, ",
     "or any metadata about how this knowledge base was assembled. ",
     "Describe ONLY what documents are inside, as if a curator wrote it. ",
+    "Write the description in English regardless of the document language. ",
     "Length: ~200 characters. Output a JSON object: {\"description\": \"<text>\"}."
 );
 

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -1,30 +1,8 @@
-//! KB-level description generation from per-document `(title, purpose)` tuples.
-//!
-//! Pairs with `parser::PurposeAgent`: where `PurposeAgent` produces one
-//! line of search-tuned metadata per document, `DescriptionAgent` produces
-//! one line of routing-tuned metadata per knowledge base.
-//!
-//! This module is a library — it does not own any database, HTTP surface,
-//! or "Manual vs Auto" policy. Callers (backend, CLI) decide when to call
-//! `Store::describe`, what to do with the result, and how to persist it.
-//!
-//! Output shape chosen by offline experiments on financebench / cuad /
-//! kpaperqa / bioasq:
-//!
-//! - The description is self-contained: it states what is *inside* the
-//!   KB (document types, entities covered, topics it can answer) without
-//!   referencing any other KB. The routing agent that reads several KB
-//!   descriptions side-by-side does the comparison from a higher level;
-//!   we don't bake that comparison into each description, so an
-//!   adjacent KB being renamed or removed cannot stale a description.
-//! - Target output ~200 chars: shortest length that still preserved a
-//!   coherent identity sentence in the experiments.
-//! - Input is each doc's `purpose` only — adding `title` did not improve
-//!   routing on the probe set and increased input tokens by ~25%.
-//! - On LLM failure, `fallback_description` returns
-//!   `"{N} documents including: {top-5 titles}"`. Empty string would have
-//!   silently degraded routing (an empty description anchored a wrong KB
-//!   in the experiments).
+//! KB-level description for a routing agent. Built from each doc's `purpose`
+//! (titles are kept for the fallback). Output stays self-contained — no
+//! mention of peer KBs — so a renamed or removed neighbor cannot stale it.
+//! Korean output lands ~1/3 the chars of English at the same budget;
+//! per-language budgets are deferred until a near-domain Korean KB shows up.
 
 use ailoy::{
     agent::{Agent, AgentProvider, AgentSpec},
@@ -36,24 +14,21 @@ use futures::StreamExt as _;
 const MODEL: &str = "openai/gpt-5.4-mini";
 
 const DESCRIPTION_INSTRUCTION: &str = concat!(
-    "You write a description of a knowledge base for a routing agent. ",
-    "The routing agent reads this description alongside descriptions of other ",
-    "knowledge bases and picks the right one for a user's question. ",
+    "You write a self-contained description of a knowledge base. ",
+    "This description will be read by a routing agent that picks the right ",
+    "knowledge base for a user's question. ",
     "Inputs: KB name, optional instruction, and a list of one-line document purposes. ",
     "Describe what is INSIDE this knowledge base — its document types, ",
     "the entities and time periods covered, and the topics it can answer. ",
     "Lead with the collective identity of the documents. ",
-    "Do not compare this KB to others, list what it excludes, or mention ",
-    "neighboring KB names. The routing agent does that comparison from a ",
-    "higher level; your job is to describe this KB on its own terms. ",
+    "Describe this KB on its own terms — do not compare it to other KBs, ",
+    "list what it excludes, or mention neighboring KB names. ",
     "Output must NOT mention dataset names, QA pairs, paper IDs, contract IDs, ",
     "or any metadata about how this knowledge base was assembled. ",
     "Describe ONLY what documents are inside, as if a curator wrote it. ",
     "Length: ~200 characters. Output a JSON object: {\"description\": \"<text>\"}."
 );
 
-/// Wraps an Ailoy agent that turns a `(title, purpose)` document list into
-/// a single KB-level description string.
 pub struct DescriptionAgent {
     spec: AgentSpec,
     provider: Option<AgentProvider>,
@@ -67,12 +42,8 @@ impl DescriptionAgent {
         }
     }
 
-    /// Generate a KB-level description.
-    ///
-    /// `docs` is the full `(title, purpose)` list for the KB. Only `purpose`
-    /// is rendered into the user message; `title` is kept in the signature
-    /// so callers can feed the same slice to `fallback_description` when
-    /// the LLM call returns empty.
+    /// Only `purpose` is sent to the LLM; `title` is kept in the signature
+    /// so the caller can feed the same slice to `fallback_description`.
     pub async fn generate(
         &self,
         kb_name: &str,
@@ -124,9 +95,7 @@ fn build_user_message(
     s
 }
 
-/// Mirrors `parser::parse_purpose_response`: try direct JSON, retry after
-/// stripping any text around the JSON object, fall back to empty string.
-/// An empty return signals the caller to use `fallback_description`.
+/// Empty return signals the caller to use `fallback_description`.
 fn parse_description_response(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -152,12 +121,9 @@ fn parse_description_response(raw: &str) -> String {
     String::new()
 }
 
-/// Module-level entry point that mirrors `parser::get_title` /
-/// `parser::get_purpose`: read `OPENAI_API_KEY` from the environment,
-/// build the provider, run `DescriptionAgent`, and substitute
-/// `fallback_description` if the LLM call returns an empty body. Pure
-/// transport errors (missing key, network) propagate so the caller can
-/// surface them.
+/// Reads `OPENAI_API_KEY` from the environment, runs `DescriptionAgent`, and
+/// substitutes `fallback_description` if the LLM body is empty. Transport
+/// errors (missing key, network) propagate.
 pub async fn get_description(
     kb_name: &str,
     instruction: Option<&str>,
@@ -181,11 +147,7 @@ pub async fn get_description(
     }
 }
 
-/// Deterministic fallback used when the LLM call fails or returns empty.
-///
-/// The string is short enough to fit a system prompt's KB list and still
-/// names the entities a routing agent needs. Doc count of zero produces an
-/// empty string — there is nothing to describe.
+/// Deterministic fallback when the LLM call fails or returns empty.
 pub fn fallback_description(doc_count: usize, top_titles: &[String]) -> String {
     if doc_count == 0 {
         return String::new();

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -1,0 +1,367 @@
+//! KB-level description generation from per-document `(title, purpose)` tuples.
+//!
+//! Pairs with `parser::PurposeAgent`: where `PurposeAgent` produces one
+//! line of search-tuned metadata per document, `DescriptionAgent` produces
+//! one line of routing-tuned metadata per knowledge base.
+//!
+//! This module is a library — it does not own any database, HTTP surface,
+//! or "Manual vs Auto" policy. Callers (backend, CLI) decide when to call
+//! `Store::describe`, what to do with the result, and how to persist it.
+//!
+//! Output shape chosen by offline experiments on financebench / cuad /
+//! kpaperqa / bioasq:
+//!
+//! - The description is self-contained: it states what is *inside* the
+//!   KB (document types, entities covered, topics it can answer) without
+//!   referencing any other KB. The routing agent that reads several KB
+//!   descriptions side-by-side does the comparison from a higher level;
+//!   we don't bake that comparison into each description, so an
+//!   adjacent KB being renamed or removed cannot stale a description.
+//! - Target output ~200 chars: shortest length that still preserved a
+//!   coherent identity sentence in the experiments.
+//! - Input is each doc's `purpose` only — adding `title` did not improve
+//!   routing on the probe set and increased input tokens by ~25%.
+//! - On LLM failure, `fallback_description` returns
+//!   `"{N} documents including: {top-5 titles}"`. Empty string would have
+//!   silently degraded routing (an empty description anchored a wrong KB
+//!   in the experiments).
+
+use ailoy::{
+    agent::{Agent, AgentProvider, AgentSpec},
+    message::{Message, Part, Role},
+};
+use anyhow::{Context as _, Result};
+use futures::StreamExt as _;
+
+const MODEL: &str = "openai/gpt-5.4-mini";
+
+const DESCRIPTION_INSTRUCTION: &str = concat!(
+    "You write a description of a knowledge base for a routing agent. ",
+    "The routing agent reads this description alongside descriptions of other ",
+    "knowledge bases and picks the right one for a user's question. ",
+    "Inputs: KB name, optional instruction, and a list of one-line document purposes. ",
+    "Describe what is INSIDE this knowledge base — its document types, ",
+    "the entities and time periods covered, and the topics it can answer. ",
+    "Lead with the collective identity of the documents. ",
+    "Do not compare this KB to others, list what it excludes, or mention ",
+    "neighboring KB names. The routing agent does that comparison from a ",
+    "higher level; your job is to describe this KB on its own terms. ",
+    "Output must NOT mention dataset names, QA pairs, paper IDs, contract IDs, ",
+    "or any metadata about how this knowledge base was assembled. ",
+    "Describe ONLY what documents are inside, as if a curator wrote it. ",
+    "Length: ~200 characters. Output a JSON object: {\"description\": \"<text>\"}."
+);
+
+/// Wraps an Ailoy agent that turns a `(title, purpose)` document list into
+/// a single KB-level description string.
+pub struct DescriptionAgent {
+    spec: AgentSpec,
+    provider: Option<AgentProvider>,
+}
+
+impl DescriptionAgent {
+    pub fn new(provider: Option<AgentProvider>) -> Self {
+        Self {
+            spec: AgentSpec::new(MODEL).instruction(DESCRIPTION_INSTRUCTION),
+            provider,
+        }
+    }
+
+    /// Generate a KB-level description.
+    ///
+    /// `docs` is the full `(title, purpose)` list for the KB. Only `purpose`
+    /// is rendered into the user message; `title` is kept in the signature
+    /// so callers can feed the same slice to `fallback_description` when
+    /// the LLM call returns empty.
+    pub async fn generate(
+        &self,
+        kb_name: &str,
+        instruction: Option<&str>,
+        docs: &[(String, String)],
+    ) -> Result<String> {
+        let user = build_user_message(kb_name, instruction, docs);
+        let query = Message::new(Role::User).with_contents([Part::text(user)]);
+
+        let mut agent = match &self.provider {
+            Some(provider) => Agent::try_with_provider(self.spec.clone(), provider).await?,
+            None => Agent::try_new(self.spec.clone()).await?,
+        };
+
+        let mut text_parts: Vec<String> = Vec::new();
+        {
+            let mut stream = agent.run(query);
+            while let Some(result) = stream.next().await {
+                let output = result?;
+                for part in &output.message.contents {
+                    if let Some(text) = part.as_text() {
+                        text_parts.push(text.to_string());
+                    }
+                }
+            }
+        }
+        let raw = text_parts.join("");
+        Ok(parse_description_response(&raw))
+    }
+}
+
+fn build_user_message(
+    kb_name: &str,
+    instruction: Option<&str>,
+    docs: &[(String, String)],
+) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("KB name: {kb_name}\n"));
+    if let Some(instr) = instruction {
+        if !instr.trim().is_empty() {
+            s.push_str(&format!("KB instruction: {instr}\n"));
+        }
+    }
+    s.push_str(&format!("\nDocuments ({}):\n", docs.len()));
+    for (_title, purpose) in docs {
+        let p = if purpose.is_empty() { "(no purpose)" } else { purpose.as_str() };
+        s.push_str(&format!("- {p}\n"));
+    }
+    s
+}
+
+/// Mirrors `parser::parse_purpose_response`: try direct JSON, retry after
+/// stripping any text around the JSON object, fall back to empty string.
+/// An empty return signals the caller to use `fallback_description`.
+fn parse_description_response(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if let Some(d) = value.get("description").and_then(|v| v.as_str()) {
+            return d.trim().to_string();
+        }
+    }
+
+    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}')) {
+        if start < end {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&trimmed[start..=end]) {
+                if let Some(d) = value.get("description").and_then(|v| v.as_str()) {
+                    return d.trim().to_string();
+                }
+            }
+        }
+    }
+
+    String::new()
+}
+
+/// Module-level entry point that mirrors `parser::get_title` /
+/// `parser::get_purpose`: read `OPENAI_API_KEY` from the environment,
+/// build the provider, run `DescriptionAgent`, and substitute
+/// `fallback_description` if the LLM call returns an empty body. Pure
+/// transport errors (missing key, network) propagate so the caller can
+/// surface them.
+pub async fn get_description(
+    kb_name: &str,
+    instruction: Option<&str>,
+    docs: &[(String, String)],
+) -> Result<String> {
+    dotenvy::dotenv().ok();
+
+    let mut provider = AgentProvider::new();
+    provider.model_openai(
+        std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY not set in environment")?,
+    );
+
+    let agent = DescriptionAgent::new(Some(provider));
+    let result = agent.generate(kb_name, instruction, docs).await?;
+    if result.is_empty() {
+        log::warn!("description generation returned empty string; using fallback");
+        let titles: Vec<String> = docs.iter().map(|(t, _)| t.clone()).collect();
+        Ok(fallback_description(docs.len(), &titles))
+    } else {
+        Ok(result)
+    }
+}
+
+/// Deterministic fallback used when the LLM call fails or returns empty.
+///
+/// The string is short enough to fit a system prompt's KB list and still
+/// names the entities a routing agent needs. Doc count of zero produces an
+/// empty string — there is nothing to describe.
+pub fn fallback_description(doc_count: usize, top_titles: &[String]) -> String {
+    if doc_count == 0 {
+        return String::new();
+    }
+    let titles: Vec<&str> = top_titles
+        .iter()
+        .filter(|t| !t.is_empty())
+        .take(5)
+        .map(String::as_str)
+        .collect();
+    if titles.is_empty() {
+        format!("{doc_count} documents")
+    } else {
+        format!("{doc_count} documents including: {}", titles.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_direct_json() {
+        let raw = r#"{"description": "hello"}"#;
+        assert_eq!(parse_description_response(raw), "hello");
+    }
+
+    #[test]
+    fn parse_json_with_surrounding_text() {
+        let raw = r#"Here you go: {"description": "hello"} done."#;
+        assert_eq!(parse_description_response(raw), "hello");
+    }
+
+    #[test]
+    fn parse_trims_inner_whitespace() {
+        let raw = r#"{"description": "   hello   "}"#;
+        assert_eq!(parse_description_response(raw), "hello");
+    }
+
+    #[test]
+    fn parse_empty_input() {
+        assert_eq!(parse_description_response(""), "");
+        assert_eq!(parse_description_response("   "), "");
+    }
+
+    #[test]
+    fn parse_missing_field() {
+        let raw = r#"{"other": "value"}"#;
+        assert_eq!(parse_description_response(raw), "");
+    }
+
+    #[test]
+    fn parse_malformed_json() {
+        assert_eq!(parse_description_response("{not json"), "");
+    }
+
+    #[test]
+    fn fallback_zero_docs() {
+        assert_eq!(fallback_description(0, &[]), "");
+    }
+
+    #[test]
+    fn fallback_no_titles_falls_back_to_count_only() {
+        assert_eq!(fallback_description(7, &[]), "7 documents");
+        assert_eq!(
+            fallback_description(7, &["".to_string(), "".to_string()]),
+            "7 documents"
+        );
+    }
+
+    #[test]
+    fn fallback_with_titles_takes_top_five() {
+        let titles = vec![
+            "A".to_string(),
+            "B".to_string(),
+            "C".to_string(),
+            "D".to_string(),
+            "E".to_string(),
+            "F".to_string(),
+            "G".to_string(),
+        ];
+        assert_eq!(
+            fallback_description(7, &titles),
+            "7 documents including: A; B; C; D; E"
+        );
+    }
+
+    #[test]
+    fn user_message_skips_blank_instruction() {
+        let docs = vec![
+            ("T1".to_string(), "P1".to_string()),
+            ("T2".to_string(), "".to_string()),
+        ];
+        let msg = build_user_message("kb1", Some("   "), &docs);
+        assert!(msg.contains("KB name: kb1"));
+        assert!(!msg.contains("KB instruction"));
+        assert!(msg.contains("- P1"));
+        assert!(msg.contains("- (no purpose)"));
+    }
+
+    #[test]
+    fn user_message_renders_purpose_only_not_title() {
+        let docs = vec![("Apple 10-K".to_string(), "Apple FY2021 annual report".to_string())];
+        let msg = build_user_message("finance", None, &docs);
+        // purpose is in, title is not
+        assert!(msg.contains("Apple FY2021 annual report"));
+        assert!(!msg.contains("Apple 10-K"));
+    }
+
+    // ---- Store integration ----
+
+    #[tokio::test]
+    async fn describe_returns_empty_for_empty_store() {
+        // Empty store → describe short-circuits before any LLM call,
+        // so this runs without OPENAI_API_KEY.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = crate::store::Store::new(tmp.path()).expect("open store");
+        let result = store
+            .describe("kb-empty", None)
+            .await
+            .expect("describe should not fail on empty store");
+        assert_eq!(result, "");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires OPENAI_API_KEY"]
+    async fn describe_round_trips_against_pre_populated_index() {
+        // Pre-populate the index with deterministic (title, purpose) pairs
+        // so this test only exercises the description path, not PurposeAgent
+        // / TitleAgent. Mirrors the indexer round-trip tests in spirit.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let index_dir = root.join("index");
+        let index = crate::store::indexer::open_or_create(&index_dir).expect("open index");
+        crate::store::indexer::add_document(
+            &index,
+            "doc1",
+            "Apple FY2021 10-K",
+            "Apple Inc. 2021 Form 10-K annual report — revenue, iPhone, services, SEC filing",
+            "body 1",
+        )
+        .expect("add doc1");
+        crate::store::indexer::add_document(
+            &index,
+            "doc2",
+            "Walmart FY2023 10-K",
+            "Walmart Inc. FY2023 Form 10-K annual report — omnichannel, retail, SEC filing",
+            "body 2",
+        )
+        .expect("add doc2");
+        // drop the writer-backed Index so Store::new can reopen the same dir.
+        drop(index);
+
+        // We need origin/ and corpus/ to exist for Store::new.
+        std::fs::create_dir_all(root.join("origin")).unwrap();
+        std::fs::create_dir_all(root.join("corpus")).unwrap();
+
+        let store = crate::store::Store::new(root).expect("open store");
+        let description = store
+            .describe("finance", Some("public-company financial filings"))
+            .await
+            .expect("describe");
+
+        assert!(!description.is_empty(), "description should not be empty");
+        assert!(
+            description.chars().count() < 600,
+            "description should stay short: {description:?}"
+        );
+        // The model should pick up at least one of the entity tokens we fed in.
+        let lowered = description.to_lowercase();
+        let mentions_finance_token = ["apple", "walmart", "10-k", "filing", "financial"]
+            .iter()
+            .any(|t| lowered.contains(t));
+        assert!(
+            mentions_finance_token,
+            "description did not mention any expected token: {description:?}"
+        );
+    }
+}

--- a/speedwagon/src/store/mod.rs
+++ b/speedwagon/src/store/mod.rs
@@ -270,9 +270,9 @@ impl Store {
         if docs.is_empty() {
             return Ok(String::new());
         }
-        let pairs: Vec<(String, String)> = docs
+        let pairs: Vec<(&str, &str)> = docs
             .iter()
-            .map(|d| (d.title.clone(), d.purpose.clone()))
+            .map(|d| (d.title.as_str(), d.purpose.as_str()))
             .collect();
         description::get_description(kb_name, instruction, &pairs).await
     }

--- a/speedwagon/src/store/mod.rs
+++ b/speedwagon/src/store/mod.rs
@@ -257,17 +257,10 @@ impl Store {
         ))
     }
 
-    /// Generate a single KB-level description from every document's
-    /// `(title, purpose)` already in the index.
-    ///
-    /// Reads `OPENAI_API_KEY` from the environment (mirrors
-    /// `parser::get_title` / `parser::get_purpose`). On an empty LLM
-    /// body the call substitutes `description::fallback_description`,
-    /// so routing always has some signal.
-    ///
-    /// The output describes only this KB; comparison with adjacent KBs
-    /// is the routing agent's job, not this function's, so there is no
-    /// peer-KB input.
+    /// One LLM call over every doc's `(title, purpose)` in the index. Input
+    /// is proportional to doc count (~24K chars at N=200), so don't run this
+    /// synchronously on indexing hot paths — use a finalize hook or
+    /// background job. Empty LLM body falls back to a deterministic string.
     pub async fn describe(
         &self,
         kb_name: &str,

--- a/speedwagon/src/store/mod.rs
+++ b/speedwagon/src/store/mod.rs
@@ -1,3 +1,4 @@
+mod description;
 mod document;
 mod indexer;
 mod parser;
@@ -15,6 +16,7 @@ use anyhow::{Context as _, Result};
 use tantivy::Index;
 use uuid::Uuid;
 
+pub use description::{DescriptionAgent, fallback_description};
 pub use document::{Document, FindResult};
 pub use searcher::{SearchPage, SearchResult};
 
@@ -253,6 +255,33 @@ impl Store {
             k,
             context_bytes,
         ))
+    }
+
+    /// Generate a single KB-level description from every document's
+    /// `(title, purpose)` already in the index.
+    ///
+    /// Reads `OPENAI_API_KEY` from the environment (mirrors
+    /// `parser::get_title` / `parser::get_purpose`). On an empty LLM
+    /// body the call substitutes `description::fallback_description`,
+    /// so routing always has some signal.
+    ///
+    /// The output describes only this KB; comparison with adjacent KBs
+    /// is the routing agent's job, not this function's, so there is no
+    /// peer-KB input.
+    pub async fn describe(
+        &self,
+        kb_name: &str,
+        instruction: Option<&str>,
+    ) -> Result<String> {
+        let docs = indexer::list_documents(&self.index, false)?;
+        if docs.is_empty() {
+            return Ok(String::new());
+        }
+        let pairs: Vec<(String, String)> = docs
+            .iter()
+            .map(|d| (d.title.clone(), d.purpose.clone()))
+            .collect();
+        description::get_description(kb_name, instruction, &pairs).await
     }
 }
 


### PR DESCRIPTION
## Ticket

resolves #45

## Summary

Adds a `DescriptionAgent` to the speedwagon crate that turns a KB's `(title, purpose)` list into one ~200-character description. Pairs with `PurposeAgent` from #41: same Ailoy stack, same JSON-with-fallback parser. Library work only — no DB column, no `Manual | Auto` toggle, no HTTP endpoint. A backend that wants to refresh its descriptions calls `Store::describe` and writes the result back.

The motivating failure mode: chat-agent reads each Speedwagon's `description` in two places (`chat-agent/src/speedwagon/dispatch.rs:110-114` as the tool description, and `backend/src/prompt.rs:66` as the system prompt KB list). Today that field is plain user input that goes stale the moment documents change. An offline harness reproduced the silent-degradation case: with a four-KB / twelve-probe harness (three hand-written cross-domain questions per KB), a single empty description drops cross-domain routing accuracy from 12/12 (all probes routed to the right KB) to 11/12. All `X/12` numbers in this PR refer to this harness.

## Changes

### `description.rs` (new)

`DescriptionAgent` mirrors `parser::PurposeAgent`. Inputs: KB name, optional instruction, the full `(title, purpose)` list. Output: a single line, target ~200 chars.

`get_description` is the env-backed entry point — same shape as `parser::get_title` / `parser::get_purpose`: `dotenvy::dotenv().ok()`, build provider from `OPENAI_API_KEY`, run the agent, swap in `fallback_description` if the body comes back empty.

`fallback_description(N, top_titles)` writes `"{N} documents including: {top-5 titles}"`. The harness compared this against the empty-string fallback and `"{top-20 titles}"`; empty-string dropped to 11/12 (the no-description KB got bypassed when a query was ambiguous), and N+top-5 matched the longer fallback at a quarter of the tokens.

### Prompt body

The system instruction is hardcoded. The shipped prompt is a self-anchored revision — its opening sentence does not mention "alongside descriptions of other knowledge bases", so the model is not primed to emit comparison vocabulary. Earlier candidates that did mention peers still routed 12/12 on the harness, but the self-anchored framing keeps the prompt aligned with the later "do not compare" clause and is the cleaner default.

> You write a self-contained description of a knowledge base. This description will be read by a routing agent that picks the right knowledge base for a user's question. Inputs: KB name, optional instruction, and a list of one-line document purposes. Describe what is INSIDE this knowledge base — its document types, the entities and time periods covered, and the topics it can answer. Lead with the collective identity of the documents. Describe this KB on its own terms — do not compare it to other KBs, list what it excludes, or mention neighboring KB names. Output must NOT mention dataset names, QA pairs, paper IDs, contract IDs, or any metadata about how this knowledge base was assembled. Describe ONLY what documents are inside, as if a curator wrote it. Length: ~200 characters. Output a JSON object: `{"description": "<text>"}`.

### `Store::describe` (`mod.rs`)

`Store::describe(kb_name, instruction)` pulls `(title, purpose)` from the index it already owns and forwards to `get_description`. Empty index returns `""` without an LLM call. The doc-comment notes the cost: one LLM call, input ≈ 24K chars at N=200 docs — callers should not invoke this synchronously inside indexing hot paths.

## Prompt sweep

Real outputs at length ~200, four-KB / twelve-probe harness, shipped prompt:

| KB | description |
|---|---|
| financebench | Annual reports, 10-Ks, 10-Qs, 8-Ks, and earnings releases from major public companies, covering fiscal years and quarters from 2015–2024. Includes revenue, expenses, assets, debt, cash flow, guidance, operations, stock, and board events. |
| cuad | Commercial agreements and amendments covering stock offerings, licenses, supply, services, alliances, sponsorships, distribution, consulting, transportation, franchise, and hosting, spanning 1990s–2024 across corporations, banks, universities, startups, and vendors. |
| kpaperqa | Korean academic papers spanning medicine, engineering, science, education, design, policy, and social research, covering topics from the 1990s–2020s with experimental, clinical, survey, modeling, and review studies. |
| bioasq | Biomedical literature abstracts on diseases, mechanisms, diagnostics, imaging, therapeutics, protocols, and case reports across human, animal, and cell studies from varied years. |

Descriptions are forced to English by the prompt regardless of document language; kpaperqa's output is in English even though its corpus is Korean. Neither the shipped prompt nor the earlier peer-aware candidate references other KBs by name.

Other knobs from the same harness, fixed as single values in the code:

- **Output length**: scanned 100/200/400/800 characters. All 12/12. 200 was the shortest length that still preserved a coherent identity sentence.
- **Output language**: forced to English. Routing held 12/12 on the four-KB mix, including the Korean-corpus kpaperqa, where the prior language-following prompt produced a Korean description that ran ~90 chars (vs ~200 for the English KBs). English-only output also sidesteps encoding and external-transmission concerns once the description reaches an `AgentCard`.
- **Doc-count scaling**: pushed kpaperqa to 200 docs in. Output stayed at 100–130 chars regardless of input N. Input cost grows linearly (~24K chars at N=200). Beyond ~500 docs per KB this will need stratified sampling or a two-pass step.
- **Input format**: `title + purpose` vs `purpose-only`. Both 12/12; purpose-only saves ~25% of input tokens, so the prompt only renders `purpose`. The fallback string still uses titles since they are the cheapest identity signal when the LLM is unavailable.

The probe set itself:

| expected KB | probe |
|---|---|
| financebench | What was Apple's iPhone revenue in fiscal year 2021? |
| financebench | How did Walmart's e-commerce segment perform in 2023? |
| financebench | Show me Microsoft's operating margin for the last reported year. |
| cuad | What does the termination clause of this commercial agreement say? |
| cuad | Find non-compete obligations in vendor contracts. |
| cuad | Who are the parties bound by exclusivity in this licensing deal? |
| kpaperqa | 한국 학술 논문에서 머신러닝 기법을 적용한 사례를 찾아줘. |
| kpaperqa | 국내 학술지 논문에서 이 연구의 결론은 무엇이지? |
| kpaperqa | 한국 연구자들이 발표한 학술 논문에서 이 주제를 어떻게 다뤘어? |
| bioasq | What does the literature say about CRISPR-Cas9 off-target effects? |
| bioasq | Find PubMed abstracts on the role of TNF-alpha in rheumatoid arthritis. |
| bioasq | Summarize biomedical findings about gut microbiome and depression. |

The probe set is admittedly easy: four disjoint domains. Same exercise on near-domain KBs (e.g. `finance-2023` vs `finance-2024`) might land on different values; none such exist yet.

## Tests

12 new unit tests (parser variants, fallback shape, user-message rendering, empty-store short-circuit) plus one `#[ignore]`-gated integration test that prefills the index via `indexer::add_document` and runs `Store::describe` end-to-end.

```
cargo test -p speedwagon --lib description
test result: ok. 12 passed; 0 failed; 1 ignored
```

The integration test passes locally in ~3s. Run it with:

```
OPENAI_API_KEY=... cargo test -p speedwagon describe_round_trips -- --ignored
```

## Notes

- **Provider** is environment-driven (`OPENAI_API_KEY`), same shape as `PurposeAgent` and `TitleAgent`. Unifying the three utility agents under one provider-routing abstraction belongs in a separate issue.
- **No backend wiring in this PR.** Manual-vs-Auto policy, an HTTP endpoint to trigger regeneration, and an indexing-finalize hook all belong to whoever owns Speedwagon CRUD on the backend side. The library has no opinion.
- **Prompt is peer-blind by construction.** Cross-KB cyclic prompts would help only if near-domain KBs share a routing surface, which the current four-KB mix does not exercise. Not needed yet.
- **Doc-count compression** for >500-doc KBs is also deferred until a KB at that size shows up.



