### PR TITLE
Integrating helper agents(`TitleAgent` / `PurposeAgent` / `DescriptionAgent`) into a common interface

### DIFF
--- a/speedwagon/src/main.rs
+++ b/speedwagon/src/main.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use ailoy::{
-    agent::{Agent, AgentProvider},
+    agent::{Agent, default_provider, default_provider_mut},
     message::{Message, Part, Role},
 };
 use anyhow::Result;
@@ -52,11 +52,12 @@ fn resolve_dir(path: &str) -> PathBuf {
     }
 }
 
-async fn build_agent(store_dir: &Path, model: &str, provider: &AgentProvider) -> Result<Agent> {
+async fn build_agent(store_dir: &Path, model: &str) -> Result<Agent> {
     let store = Arc::new(Store::new(store_dir)?);
     let toolset = build_toolset(store);
     let spec = SpeedwagonSpec::new().model(model).into_spec();
-    Agent::try_with_tools(spec, provider, &toolset).await
+    let provider = default_provider().await;
+    Agent::try_with_tools(spec, &provider, &toolset).await
 }
 
 async fn run_query(agent: &mut Agent, input: &str) -> Result<()> {
@@ -108,23 +109,28 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Populate ailoy's process-global provider once at boot. Every
+    // `Agent::try_new`/`try_with_tools` (including speedwagon's title/purpose/
+    // description helpers) reads from this singleton.
+    {
+        let mut default = default_provider_mut().await;
+        if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+            default.model_openai(key);
+        }
+        if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+            default.model_claude(key);
+        }
+        if let Ok(key) = std::env::var("GEMINI_API_KEY") {
+            default.model_gemini(key);
+        }
+    }
+
     if let Some(ref preset) = cli.preset {
         let mut store = Store::new(&store_dir)?;
         setup_docset(&mut store, preset).await?;
     }
 
-    let mut provider = AgentProvider::new();
-    if let Ok(key) = std::env::var("OPENAI_API_KEY") {
-        provider.model_openai(key);
-    }
-    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
-        provider.model_claude(key);
-    }
-    if let Ok(key) = std::env::var("GEMINI_API_KEY") {
-        provider.model_gemini(key);
-    }
-
-    let mut agent = build_agent(&store_dir, &cli.model, &provider).await?;
+    let mut agent = build_agent(&store_dir, &cli.model).await?;
     let doc_count = Store::new(&store_dir)?.count();
 
     println!();
@@ -154,7 +160,7 @@ async fn main() -> Result<()> {
         if input == "/exit" {
             break;
         } else if input == "/clear" {
-            agent = build_agent(&store_dir, &cli.model, &provider).await?;
+            agent = build_agent(&store_dir, &cli.model).await?;
             println!("Conversation cleared.");
         } else if input == "/list" {
             let store = Store::new(&store_dir)?;
@@ -191,7 +197,7 @@ async fn main() -> Result<()> {
             let mut write_store = Store::new(&store_dir)?;
             let id = write_store.ingest(bytes, filetype).await?;
             drop(write_store);
-            agent = build_agent(&store_dir, &cli.model, &provider).await?;
+            agent = build_agent(&store_dir, &cli.model).await?;
             println!("Ingested (id: {id})  —  agent rebuilt.");
         } else if let Some(id_str) = input.strip_prefix("/purge ") {
             let id_str = id_str.trim();
@@ -217,7 +223,7 @@ async fn main() -> Result<()> {
             match write_store.purge(id)? {
                 Some(doc) => {
                     drop(write_store);
-                    agent = build_agent(&store_dir, &cli.model, &provider).await?;
+                    agent = build_agent(&store_dir, &cli.model).await?;
                     println!("Purged '{}' — agent rebuilt.", doc.title);
                 }
                 None => eprintln!("Document not found: {id}"),

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -5,10 +5,10 @@
 //! per-language budgets are deferred until a near-domain Korean KB shows up.
 
 use ailoy::{
-    agent::{Agent, AgentProvider, AgentSpec},
+    agent::{Agent, AgentSpec},
     message::{Message, Part, Role},
 };
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use futures::StreamExt as _;
 
 const MODEL: &str = "openai/gpt-5.4-mini";
@@ -30,16 +30,21 @@ const DESCRIPTION_INSTRUCTION: &str = concat!(
     "Length: ~200 characters. Output a JSON object: {\"description\": \"<text>\"}."
 );
 
+/// Uses ailoy's process-global default provider (see `default_provider_mut`).
 pub struct DescriptionAgent {
     spec: AgentSpec,
-    provider: Option<AgentProvider>,
+}
+
+impl Default for DescriptionAgent {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DescriptionAgent {
-    pub fn new(provider: Option<AgentProvider>) -> Self {
+    pub fn new() -> Self {
         Self {
             spec: AgentSpec::new(MODEL).instruction(DESCRIPTION_INSTRUCTION),
-            provider,
         }
     }
 
@@ -54,10 +59,7 @@ impl DescriptionAgent {
         let user = build_user_message(kb_name, instruction, docs);
         let query = Message::new(Role::User).with_contents([Part::text(user)]);
 
-        let mut agent = match &self.provider {
-            Some(provider) => Agent::try_with_provider(self.spec.clone(), provider).await?,
-            None => Agent::try_new(self.spec.clone()).await?,
-        };
+        let mut agent = Agent::try_new(self.spec.clone()).await?;
 
         let mut text_parts: Vec<String> = Vec::new();
         {
@@ -122,23 +124,16 @@ fn parse_description_response(raw: &str) -> String {
     String::new()
 }
 
-/// Reads `OPENAI_API_KEY` from the environment, runs `DescriptionAgent`, and
-/// substitutes `fallback_description` if the LLM body is empty. Transport
-/// errors (missing key, network) propagate.
+/// Runs `DescriptionAgent` and substitutes `fallback_description` if the LLM
+/// body is empty. Transport errors propagate.
 pub async fn get_description(
     kb_name: &str,
     instruction: Option<&str>,
     docs: &[(&str, &str)],
 ) -> Result<String> {
-    dotenvy::dotenv().ok();
-
-    let mut provider = AgentProvider::new();
-    provider.model_openai(
-        std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY not set in environment")?,
-    );
-
-    let agent = DescriptionAgent::new(Some(provider));
-    let result = agent.generate(kb_name, instruction, docs).await?;
+    let result = DescriptionAgent::new()
+        .generate(kb_name, instruction, docs)
+        .await?;
     if result.is_empty() {
         log::warn!("description generation returned empty string; using fallback");
         let titles: Vec<&str> = docs.iter().map(|(t, _)| *t).collect();
@@ -291,6 +286,12 @@ mod tests {
         // We need origin/ and corpus/ to exist for Store::new.
         std::fs::create_dir_all(root.join("origin")).unwrap();
         std::fs::create_dir_all(root.join("corpus")).unwrap();
+
+        // Populate ailoy's process-global default provider for this test.
+        dotenvy::dotenv().ok();
+        ailoy::agent::default_provider_mut().await.model_openai(
+            std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY required for this test"),
+        );
 
         let store = crate::store::Store::new(root).expect("open store");
         let description = store

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -25,7 +25,7 @@ const DESCRIPTION_INSTRUCTION: &str = concat!(
     "or any metadata about how this knowledge base was assembled. ",
     "Describe ONLY what documents are inside, as if a curator wrote it. ",
     "Write the description in English regardless of the document language. ",
-    "Length: ~200 characters. Output a JSON object: {\"description\": \"<text>\"}."
+    "Length: ~200 characters. Output a JSON object: {\"result\": \"<string>\"}."
 );
 
 /// Borrowed input for `DescriptionAgent::generate`.
@@ -45,21 +45,18 @@ impl HelperAgent for DescriptionAgent {
     const MODEL: &'static str = MODEL;
     const INSTRUCTION: &'static str = DESCRIPTION_INSTRUCTION;
 
-    fn build_query(input: DescriptionInput<'_>) -> Message {
+    fn build_query(input: &DescriptionInput<'_>) -> Message {
         let user = build_user_message(input.kb_name, input.instruction, input.docs);
         Message::new(Role::User).with_contents([Part::text(user)])
     }
 
-    fn parse(raw: &str) -> String {
-        parse_description_response(raw)
+    fn fallback(input: &DescriptionInput<'_>) -> String {
+        let titles: Vec<&str> = input.docs.iter().map(|(t, _)| *t).collect();
+        fallback_description(input.docs.len(), &titles)
     }
 }
 
-fn build_user_message(
-    kb_name: &str,
-    instruction: Option<&str>,
-    docs: &[(&str, &str)],
-) -> String {
+fn build_user_message(kb_name: &str, instruction: Option<&str>, docs: &[(&str, &str)]) -> String {
     let mut s = String::new();
     s.push_str(&format!("KB name: {kb_name}\n"));
     if let Some(instr) = instruction {
@@ -69,58 +66,14 @@ fn build_user_message(
     }
     s.push_str(&format!("\nDocuments ({}):\n", docs.len()));
     for (_title, purpose) in docs {
-        let p = if purpose.is_empty() { "(no purpose)" } else { *purpose };
+        let p = if purpose.is_empty() {
+            "(no purpose)"
+        } else {
+            *purpose
+        };
         s.push_str(&format!("- {p}\n"));
     }
     s
-}
-
-/// Empty return signals the caller to use `fallback_description`.
-fn parse_description_response(raw: &str) -> String {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return String::new();
-    }
-
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
-        if let Some(d) = value.get("description").and_then(|v| v.as_str()) {
-            return d.trim().to_string();
-        }
-    }
-
-    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}')) {
-        if start < end {
-            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&trimmed[start..=end]) {
-                if let Some(d) = value.get("description").and_then(|v| v.as_str()) {
-                    return d.trim().to_string();
-                }
-            }
-        }
-    }
-
-    String::new()
-}
-
-/// Runs `DescriptionAgent` and substitutes `fallback_description` if the LLM
-/// body is empty. Transport errors propagate.
-pub(super) async fn get_description(
-    kb_name: &str,
-    instruction: Option<&str>,
-    docs: &[(&str, &str)],
-) -> Result<String> {
-    let result = DescriptionAgent::generate(DescriptionInput {
-        kb_name,
-        instruction,
-        docs,
-    })
-    .await?;
-    if result.is_empty() {
-        log::warn!("description generation returned empty string; using fallback");
-        let titles: Vec<&str> = docs.iter().map(|(t, _)| *t).collect();
-        Ok(fallback_description(docs.len(), &titles))
-    } else {
-        Ok(result)
-    }
 }
 
 /// Deterministic fallback when the LLM call fails or returns empty.
@@ -130,9 +83,9 @@ fn fallback_description(doc_count: usize, top_titles: &[&str]) -> String {
     }
     let titles: Vec<&str> = top_titles
         .iter()
+        .copied()
         .filter(|t| !t.is_empty())
         .take(5)
-        .copied()
         .collect();
     if titles.is_empty() {
         format!("{doc_count} documents")
@@ -141,44 +94,25 @@ fn fallback_description(doc_count: usize, top_titles: &[&str]) -> String {
     }
 }
 
+/// Runs `DescriptionAgent` over the index's `(title, purpose)` slice. An
+/// empty/malformed LLM response is substituted with `fallback_description`
+/// (a deterministic count + top-titles string). Transport errors propagate.
+pub(super) async fn get_description(
+    kb_name: &str,
+    instruction: Option<&str>,
+    docs: &[(&str, &str)],
+) -> Result<String> {
+    DescriptionAgent::generate(DescriptionInput {
+        kb_name,
+        instruction,
+        docs,
+    })
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_direct_json() {
-        let raw = r#"{"description": "hello"}"#;
-        assert_eq!(parse_description_response(raw), "hello");
-    }
-
-    #[test]
-    fn parse_json_with_surrounding_text() {
-        let raw = r#"Here you go: {"description": "hello"} done."#;
-        assert_eq!(parse_description_response(raw), "hello");
-    }
-
-    #[test]
-    fn parse_trims_inner_whitespace() {
-        let raw = r#"{"description": "   hello   "}"#;
-        assert_eq!(parse_description_response(raw), "hello");
-    }
-
-    #[test]
-    fn parse_empty_input() {
-        assert_eq!(parse_description_response(""), "");
-        assert_eq!(parse_description_response("   "), "");
-    }
-
-    #[test]
-    fn parse_missing_field() {
-        let raw = r#"{"other": "value"}"#;
-        assert_eq!(parse_description_response(raw), "");
-    }
-
-    #[test]
-    fn parse_malformed_json() {
-        assert_eq!(parse_description_response("{not json"), "");
-    }
 
     #[test]
     fn fallback_zero_docs() {

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -9,8 +9,6 @@ use anyhow::Result;
 
 use super::helper::HelperAgent;
 
-const MODEL: &str = "openai/gpt-5.4-mini";
-
 const DESCRIPTION_INSTRUCTION: &str = concat!(
     "You write a self-contained description of a knowledge base. ",
     "This description will be read by a routing agent that picks the right ",
@@ -42,7 +40,6 @@ struct DescriptionAgent;
 impl HelperAgent for DescriptionAgent {
     type Input<'a> = DescriptionInput<'a>;
     type Output = String;
-    const MODEL: &'static str = MODEL;
     const INSTRUCTION: &'static str = DESCRIPTION_INSTRUCTION;
 
     fn build_query(input: &DescriptionInput<'_>) -> Message {

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -4,12 +4,10 @@
 //! Korean output lands ~1/3 the chars of English at the same budget;
 //! per-language budgets are deferred until a near-domain Korean KB shows up.
 
-use ailoy::{
-    agent::{Agent, AgentSpec},
-    message::{Message, Part, Role},
-};
+use ailoy::message::{Message, Part, Role};
 use anyhow::Result;
-use futures::StreamExt as _;
+
+use super::helper::HelperAgent;
 
 const MODEL: &str = "openai/gpt-5.4-mini";
 
@@ -30,51 +28,30 @@ const DESCRIPTION_INSTRUCTION: &str = concat!(
     "Length: ~200 characters. Output a JSON object: {\"description\": \"<text>\"}."
 );
 
-/// Uses ailoy's process-global default provider (see `default_provider_mut`).
-pub struct DescriptionAgent {
-    spec: AgentSpec,
+/// Borrowed input for `DescriptionAgent::generate`.
+struct DescriptionInput<'a> {
+    kb_name: &'a str,
+    instruction: Option<&'a str>,
+    docs: &'a [(&'a str, &'a str)],
 }
 
-impl Default for DescriptionAgent {
-    fn default() -> Self {
-        Self::new()
+/// Generates a KB-level routing description via LLM. Reads from ailoy's
+/// process-global default provider.
+struct DescriptionAgent;
+
+impl HelperAgent for DescriptionAgent {
+    type Input<'a> = DescriptionInput<'a>;
+    type Output = String;
+    const MODEL: &'static str = MODEL;
+    const INSTRUCTION: &'static str = DESCRIPTION_INSTRUCTION;
+
+    fn build_query(input: DescriptionInput<'_>) -> Message {
+        let user = build_user_message(input.kb_name, input.instruction, input.docs);
+        Message::new(Role::User).with_contents([Part::text(user)])
     }
-}
 
-impl DescriptionAgent {
-    pub fn new() -> Self {
-        Self {
-            spec: AgentSpec::new(MODEL).instruction(DESCRIPTION_INSTRUCTION),
-        }
-    }
-
-    /// Only `purpose` is sent to the LLM; `title` is kept in the signature
-    /// so the caller can feed the same slice to `fallback_description`.
-    pub async fn generate(
-        &self,
-        kb_name: &str,
-        instruction: Option<&str>,
-        docs: &[(&str, &str)],
-    ) -> Result<String> {
-        let user = build_user_message(kb_name, instruction, docs);
-        let query = Message::new(Role::User).with_contents([Part::text(user)]);
-
-        let mut agent = Agent::try_new(self.spec.clone()).await?;
-
-        let mut text_parts: Vec<String> = Vec::new();
-        {
-            let mut stream = agent.run(query);
-            while let Some(result) = stream.next().await {
-                let output = result?;
-                for part in &output.message.contents {
-                    if let Some(text) = part.as_text() {
-                        text_parts.push(text.to_string());
-                    }
-                }
-            }
-        }
-        let raw = text_parts.join("");
-        Ok(parse_description_response(&raw))
+    fn parse(raw: &str) -> String {
+        parse_description_response(raw)
     }
 }
 
@@ -126,14 +103,17 @@ fn parse_description_response(raw: &str) -> String {
 
 /// Runs `DescriptionAgent` and substitutes `fallback_description` if the LLM
 /// body is empty. Transport errors propagate.
-pub async fn get_description(
+pub(super) async fn get_description(
     kb_name: &str,
     instruction: Option<&str>,
     docs: &[(&str, &str)],
 ) -> Result<String> {
-    let result = DescriptionAgent::new()
-        .generate(kb_name, instruction, docs)
-        .await?;
+    let result = DescriptionAgent::generate(DescriptionInput {
+        kb_name,
+        instruction,
+        docs,
+    })
+    .await?;
     if result.is_empty() {
         log::warn!("description generation returned empty string; using fallback");
         let titles: Vec<&str> = docs.iter().map(|(t, _)| *t).collect();
@@ -144,7 +124,7 @@ pub async fn get_description(
 }
 
 /// Deterministic fallback when the LLM call fails or returns empty.
-pub fn fallback_description(doc_count: usize, top_titles: &[&str]) -> String {
+fn fallback_description(doc_count: usize, top_titles: &[&str]) -> String {
     if doc_count == 0 {
         return String::new();
     }

--- a/speedwagon/src/store/helper.rs
+++ b/speedwagon/src/store/helper.rs
@@ -1,8 +1,16 @@
 //! Generic LLM helper trait. Implement `HelperAgent` once per helper — the
 //! trait supplies the dispatch boilerplate (agent construction, streaming,
-//! text concatenation) via a default `generate` body. All helpers read from
-//! ailoy's process-global default provider; populate it once at app boot via
+//! text concatenation, JSON-field extraction, empty-response fallback) via
+//! default method bodies. All helpers read from ailoy's process-global
+//! default provider; populate it once at app boot via
 //! `ailoy::agent::default_provider_mut`.
+//!
+//! # Hidden contract
+//!
+//! Every helper's `INSTRUCTION` must instruct the LLM to emit a JSON object
+//! of the form `{"result": "<string>"}`. The default `process` impl
+//! extracts the `"result"` field. Helpers with non-string outputs override
+//! `process` to use their own response shape.
 
 use ailoy::{
     agent::{Agent, AgentSpec},
@@ -11,29 +19,52 @@ use ailoy::{
 use anyhow::Result;
 use futures::StreamExt as _;
 
+const RESULT_FIELD: &str = "result";
+
 /// Per-helper definition. Implement this on a unit struct, then call
 /// `MyAgent::generate(input).await` directly.
 pub(super) trait HelperAgent {
-    /// Caller-supplied input. May borrow from the caller's stack.
+    /// Caller-supplied input. Borrowed by `build_query` / `fallback`, so the
+    /// type itself never needs to be `Copy` or `Clone`.
     type Input<'a>;
     /// Parsed response.
     type Output;
+
     /// Model id, e.g. `"openai/gpt-5.4-mini"`.
     const MODEL: &'static str;
-    /// System instruction for the agent.
+    /// System instruction. Must direct the LLM to emit
+    /// `{"result": "<string>"}` — see module-level docs for the contract.
     const INSTRUCTION: &'static str;
 
     /// Render `input` to a chat `Message` to send to the LLM.
-    fn build_query(input: Self::Input<'_>) -> Message;
-    /// Convert the joined raw text response into `Output`.
-    fn parse(raw: &str) -> Self::Output;
+    fn build_query(input: &Self::Input<'_>) -> Message;
+
+    /// Validate and convert the joined raw LLM response into `Output`, or
+    /// return `None` to signal that the response was unusable (empty /
+    /// malformed) and `fallback` should kick in.
+    ///
+    /// Default impl extracts the `"result"` string field. Override for
+    /// non-string outputs.
+    fn process(llm_resp: &str) -> Option<Self::Output>
+    where
+        Self::Output: From<String>,
+    {
+        extract_string_field(llm_resp, RESULT_FIELD).map(Into::into)
+    }
+
+    /// Deterministic substitute when `process` returns `None`.
+    fn fallback(input: &Self::Input<'_>) -> Self::Output;
 
     /// Dispatch a single LLM call against ailoy's process-global default
-    /// provider, then run the response through `parse`.
-    async fn generate(input: Self::Input<'_>) -> Result<Self::Output> {
+    /// provider, run the response through `process`, and substitute
+    /// `fallback` (with a warning log) if `process` returns `None`.
+    async fn generate(input: Self::Input<'_>) -> Result<Self::Output>
+    where
+        Self::Output: From<String>,
+    {
         let spec = AgentSpec::new(Self::MODEL).instruction(Self::INSTRUCTION);
         let mut agent = Agent::try_new(spec).await?;
-        let query = Self::build_query(input);
+        let query = Self::build_query(&input);
 
         let mut text_parts: Vec<String> = Vec::new();
         {
@@ -47,7 +78,109 @@ pub(super) trait HelperAgent {
                 }
             }
         }
-        let raw = text_parts.join("");
-        Ok(Self::parse(&raw))
+        let llm_resp = text_parts.join("");
+        match Self::process(&llm_resp) {
+            Some(v) => Ok(v),
+            None => {
+                let name = std::any::type_name::<Self>()
+                    .rsplit("::")
+                    .next()
+                    .unwrap_or("?");
+                log::warn!("{name} returned empty/malformed response; using fallback");
+                Ok(Self::fallback(&input))
+            }
+        }
+    }
+}
+
+/// Extract a string-valued field from a JSON-shaped LLM response. Tries
+/// `serde_json` directly first; if that fails (the model added prose), it
+/// falls back to extracting the `{...}` substring before parsing. Returns
+/// `None` for empty / malformed / field-missing / empty-value cases.
+fn extract_string_field(raw: &str, field: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed)
+        && let Some(s) = value.get(field).and_then(|v| v.as_str())
+    {
+        let s = s.trim();
+        if !s.is_empty() {
+            return Some(s.to_string());
+        }
+    }
+
+    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}'))
+        && start < end
+        && let Ok(value) = serde_json::from_str::<serde_json::Value>(&trimmed[start..=end])
+        && let Some(s) = value.get(field).and_then(|v| v.as_str())
+    {
+        let s = s.trim();
+        if !s.is_empty() {
+            return Some(s.to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_string_field;
+
+    #[test]
+    fn extract_field_plain_json() {
+        assert_eq!(
+            extract_string_field(r#"{"foo": "hello"}"#, "foo"),
+            Some("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_field_with_whitespace() {
+        assert_eq!(
+            extract_string_field("\n  {\"foo\": \"hello\"}  \n", "foo"),
+            Some("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_field_with_surrounding_text() {
+        assert_eq!(
+            extract_string_field(r#"Sure: {"foo": "hello"} done."#, "foo"),
+            Some("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_field_trims_inner_whitespace() {
+        assert_eq!(
+            extract_string_field(r#"{"foo": "   hello   "}"#, "foo"),
+            Some("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_field_empty_input() {
+        assert_eq!(extract_string_field("", "foo"), None);
+        assert_eq!(extract_string_field("   ", "foo"), None);
+    }
+
+    #[test]
+    fn extract_field_invalid_json() {
+        assert_eq!(extract_string_field("not json", "foo"), None);
+        assert_eq!(extract_string_field("{not: json}", "foo"), None);
+    }
+
+    #[test]
+    fn extract_field_missing_field() {
+        assert_eq!(extract_string_field(r#"{"other": "value"}"#, "foo"), None);
+    }
+
+    #[test]
+    fn extract_field_whitespace_only_value() {
+        assert_eq!(extract_string_field(r#"{"foo": "   "}"#, "foo"), None);
     }
 }

--- a/speedwagon/src/store/helper.rs
+++ b/speedwagon/src/store/helper.rs
@@ -1,0 +1,53 @@
+//! Generic LLM helper trait. Implement `HelperAgent` once per helper — the
+//! trait supplies the dispatch boilerplate (agent construction, streaming,
+//! text concatenation) via a default `generate` body. All helpers read from
+//! ailoy's process-global default provider; populate it once at app boot via
+//! `ailoy::agent::default_provider_mut`.
+
+use ailoy::{
+    agent::{Agent, AgentSpec},
+    message::Message,
+};
+use anyhow::Result;
+use futures::StreamExt as _;
+
+/// Per-helper definition. Implement this on a unit struct, then call
+/// `MyAgent::generate(input).await` directly.
+pub(super) trait HelperAgent {
+    /// Caller-supplied input. May borrow from the caller's stack.
+    type Input<'a>;
+    /// Parsed response.
+    type Output;
+    /// Model id, e.g. `"openai/gpt-5.4-mini"`.
+    const MODEL: &'static str;
+    /// System instruction for the agent.
+    const INSTRUCTION: &'static str;
+
+    /// Render `input` to a chat `Message` to send to the LLM.
+    fn build_query(input: Self::Input<'_>) -> Message;
+    /// Convert the joined raw text response into `Output`.
+    fn parse(raw: &str) -> Self::Output;
+
+    /// Dispatch a single LLM call against ailoy's process-global default
+    /// provider, then run the response through `parse`.
+    async fn generate(input: Self::Input<'_>) -> Result<Self::Output> {
+        let spec = AgentSpec::new(Self::MODEL).instruction(Self::INSTRUCTION);
+        let mut agent = Agent::try_new(spec).await?;
+        let query = Self::build_query(input);
+
+        let mut text_parts: Vec<String> = Vec::new();
+        {
+            let mut stream = agent.run(query);
+            while let Some(result) = stream.next().await {
+                let output = result?;
+                for part in &output.message.contents {
+                    if let Some(text) = part.as_text() {
+                        text_parts.push(text.to_string());
+                    }
+                }
+            }
+        }
+        let raw = text_parts.join("");
+        Ok(Self::parse(&raw))
+    }
+}

--- a/speedwagon/src/store/helper.rs
+++ b/speedwagon/src/store/helper.rs
@@ -1,9 +1,9 @@
 //! Generic LLM helper trait. Implement `HelperAgent` once per helper — the
-//! trait supplies the dispatch boilerplate (agent construction, streaming,
-//! text concatenation, JSON-field extraction, empty-response fallback) via
-//! default method bodies. All helpers read from ailoy's process-global
-//! default provider; populate it once at app boot via
-//! `ailoy::agent::default_provider_mut`.
+//! trait supplies the dispatch boilerplate (provider selection, agent
+//! construction, streaming, text concatenation, JSON-field extraction,
+//! empty-response fallback) via default method bodies. All helpers read
+//! from ailoy's process-global default provider; populate it once at app
+//! boot via `ailoy::agent::default_provider_mut`.
 //!
 //! # Hidden contract
 //!
@@ -21,6 +21,17 @@ use futures::StreamExt as _;
 
 const RESULT_FIELD: &str = "result";
 
+/// Default model preference list shared by all metadata-style helpers
+/// (Title / Purpose / Description). Order = preference. The default
+/// `generate` body picks the first one whose provider is registered in
+/// ailoy's process-global default; if none are registered, the helper
+/// falls back without making an LLM call.
+const DEFAULT_HELPER_MODELS: &[&str] = &[
+    "openai/gpt-5.4-mini",
+    "anthropic/claude-haiku-4-5-20251001",
+    "google/gemini-2.5-flash",
+];
+
 /// Per-helper definition. Implement this on a unit struct, then call
 /// `MyAgent::generate(input).await` directly.
 pub(super) trait HelperAgent {
@@ -30,8 +41,13 @@ pub(super) trait HelperAgent {
     /// Parsed response.
     type Output;
 
-    /// Model id, e.g. `"openai/gpt-5.4-mini"`.
-    const MODEL: &'static str;
+    /// Preferred + fallback model ids in order. The default `generate`
+    /// body picks the first one whose provider is registered in ailoy's
+    /// process-global default. If none of them are registered, the helper
+    /// logs a warning and runs `Self::fallback` without invoking the LLM.
+    /// Defaults to `DEFAULT_HELPER_MODELS` — override only if this helper
+    /// needs a different preference order.
+    const MODELS: &'static [&'static str] = DEFAULT_HELPER_MODELS;
     /// System instruction. Must direct the LLM to emit
     /// `{"result": "<string>"}` — see module-level docs for the contract.
     const INSTRUCTION: &'static str;
@@ -52,17 +68,42 @@ pub(super) trait HelperAgent {
         extract_string_field(llm_resp, RESULT_FIELD).map(Into::into)
     }
 
-    /// Deterministic substitute when `process` returns `None`.
+    /// Deterministic substitute when `process` returns `None` or no
+    /// provider is registered for any of `MODELS`.
     fn fallback(input: &Self::Input<'_>) -> Self::Output;
 
     /// Dispatch a single LLM call against ailoy's process-global default
     /// provider, run the response through `process`, and substitute
-    /// `fallback` (with a warning log) if `process` returns `None`.
+    /// `fallback` (with a warning log) if `process` returns `None` or no
+    /// provider is registered for any of `MODELS`.
     async fn generate(input: Self::Input<'_>) -> Result<Self::Output>
     where
         Self::Output: From<String>,
     {
-        let spec = AgentSpec::new(Self::MODEL).instruction(Self::INSTRUCTION);
+        let chosen_model = {
+            let provider = ailoy::agent::default_provider().await;
+            Self::MODELS
+                .iter()
+                .copied()
+                .find(|m| provider.get_model(m).is_some())
+        };
+
+        let model = match chosen_model {
+            Some(m) => m,
+            None => {
+                let name = std::any::type_name::<Self>()
+                    .rsplit("::")
+                    .next()
+                    .unwrap_or("?");
+                log::warn!(
+                    "{name}: no provider registered for any of {:?}; using fallback",
+                    Self::MODELS
+                );
+                return Ok(Self::fallback(&input));
+            }
+        };
+
+        let spec = AgentSpec::new(model).instruction(Self::INSTRUCTION);
         let mut agent = Agent::try_new(spec).await?;
         let query = Self::build_query(&input);
 
@@ -128,7 +169,8 @@ fn extract_string_field(raw: &str, field: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::extract_string_field;
+    use super::*;
+    use ailoy::message::{Part, Role};
 
     #[test]
     fn extract_field_plain_json() {
@@ -182,5 +224,34 @@ mod tests {
     #[test]
     fn extract_field_whitespace_only_value() {
         assert_eq!(extract_string_field(r#"{"foo": "   "}"#, "foo"), None);
+    }
+
+    /// A test-only helper that lists a bogus model id. ailoy's `get_model`
+    /// glob never matches it, so the trait's `generate` body always falls
+    /// back without making an LLM call — regardless of whatever else any
+    /// other test has registered on the global default.
+    struct UnreachableModelAgent;
+
+    impl HelperAgent for UnreachableModelAgent {
+        type Input<'a> = &'a str;
+        type Output = String;
+        const MODELS: &'static [&'static str] = &["nonexistent/never-registered"];
+        const INSTRUCTION: &'static str = "test";
+
+        fn build_query(_: &&str) -> Message {
+            Message::new(Role::User).with_contents([Part::text("")])
+        }
+
+        fn fallback(_: &&str) -> String {
+            "FALLBACK".to_string()
+        }
+    }
+
+    #[tokio::test]
+    async fn generate_falls_back_when_no_provider_registered() {
+        let result = UnreachableModelAgent::generate("anything")
+            .await
+            .expect("generate should succeed via fallback");
+        assert_eq!(result, "FALLBACK");
     }
 }

--- a/speedwagon/src/store/mod.rs
+++ b/speedwagon/src/store/mod.rs
@@ -1,5 +1,6 @@
 mod description;
 mod document;
+mod helper;
 mod indexer;
 mod parser;
 #[cfg(feature = "internal")]
@@ -16,7 +17,6 @@ use anyhow::{Context as _, Result};
 use tantivy::Index;
 use uuid::Uuid;
 
-pub use description::{DescriptionAgent, fallback_description};
 pub use document::{Document, FindResult};
 pub use searcher::{SearchPage, SearchResult};
 

--- a/speedwagon/src/store/mod.rs
+++ b/speedwagon/src/store/mod.rs
@@ -72,6 +72,9 @@ impl FileType {
 
 impl Store {
     /// Opens an existing store or creates a new one at `root`.
+    /// LLM-backed metadata (ingest's title/purpose, describe) reads from
+    /// ailoy's process-global default provider — populate it once at app
+    /// boot via `ailoy::agent::default_provider_mut`.
     pub fn new(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         fs::create_dir_all(root.join("origin"))?;

--- a/speedwagon/src/store/parser.rs
+++ b/speedwagon/src/store/parser.rs
@@ -1,9 +1,7 @@
-use ailoy::{
-    agent::{Agent, AgentSpec},
-    message::{Message, Part, Role},
-};
+use ailoy::message::{Message, Part, Role};
 use anyhow::Result;
-use futures::StreamExt as _;
+
+use super::helper::HelperAgent;
 
 fn parse_title(content: &str) -> Option<String> {
     if content.starts_with("---") {
@@ -43,62 +41,44 @@ fn parse_title(content: &str) -> Option<String> {
     None
 }
 
-/// Wraps an Ailoy agent used to generate document titles via LLM. Uses
-/// ailoy's process-global default provider (see `default_provider_mut`).
-pub struct TitleAgent {
-    spec: AgentSpec,
-}
+const TITLE_PREVIEW_CHARS: usize = 8192;
 
-impl Default for TitleAgent {
-    fn default() -> Self {
-        Self::new()
+const TITLE_INSTRUCTION: &str = concat!(
+    "You are a title generator. ",
+    "Given document content, reply with only a concise title under 10 words.",
+);
+
+/// Generates a document title via LLM. Reads from ailoy's process-global
+/// default provider.
+struct TitleAgent;
+
+impl HelperAgent for TitleAgent {
+    type Input<'a> = &'a str;
+    type Output = String;
+    const MODEL: &'static str = "openai/gpt-5.4-mini";
+    const INSTRUCTION: &'static str = TITLE_INSTRUCTION;
+
+    fn build_query(content: &str) -> Message {
+        let snippet: String = content.chars().take(TITLE_PREVIEW_CHARS).collect();
+        Message::new(Role::User).with_contents([Part::text(snippet)])
     }
-}
 
-impl TitleAgent {
-    pub fn new() -> Self {
-        Self {
-            spec: AgentSpec::new("openai/gpt-5.4-mini").instruction(concat!(
-                "You are a title generator. ",
-                "Given document content, reply with only a concise title under 10 words.",
-            )),
-        }
-    }
-
-    pub async fn generate(&self, content: &str) -> Result<String> {
-        let snippet: String = content.chars().take(8192).collect();
-        let query = Message::new(Role::User).with_contents([Part::text(snippet)]);
-
-        let mut agent = Agent::try_new(self.spec.clone()).await?;
-
-        let mut text_parts: Vec<String> = Vec::new();
-        {
-            let mut stream = agent.run(query);
-            while let Some(result) = stream.next().await {
-                let output = result?;
-                for part in &output.message.contents {
-                    if let Some(text) = part.as_text() {
-                        text_parts.push(text.to_string());
-                    }
-                }
-            }
-        }
-
-        let title = text_parts.join("").trim().to_string();
-        Ok(if title.is_empty() {
+    fn parse(raw: &str) -> String {
+        let title = raw.trim().to_string();
+        if title.is_empty() {
             "Untitled".to_string()
         } else {
             title
-        })
+        }
     }
 }
 
 /// Generates a title from `content`. The frontmatter/H1 fast path runs first;
 /// if neither is present, falls back to `TitleAgent`.
-pub async fn get_title(content: &str) -> Result<String> {
+pub(super) async fn get_title(content: &str) -> Result<String> {
     match parse_title(content) {
         Some(t) => Ok(t),
-        None => TitleAgent::new().generate(content).await,
+        None => TitleAgent::generate(content).await,
     }
 }
 
@@ -118,46 +98,23 @@ const PURPOSE_INSTRUCTION: &str = concat!(
 
 const PURPOSE_PREVIEW_CHARS: usize = 3000;
 
-/// Wraps an Ailoy agent used to generate document purpose metadata via LLM.
-/// Uses ailoy's process-global default provider (see `default_provider_mut`).
-pub struct PurposeAgent {
-    spec: AgentSpec,
-}
+/// Generates BM25-friendly search metadata for a document via LLM. Reads from
+/// ailoy's process-global default provider.
+struct PurposeAgent;
 
-impl Default for PurposeAgent {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+impl HelperAgent for PurposeAgent {
+    type Input<'a> = &'a str;
+    type Output = String;
+    const MODEL: &'static str = "openai/gpt-5.4-mini";
+    const INSTRUCTION: &'static str = PURPOSE_INSTRUCTION;
 
-impl PurposeAgent {
-    pub fn new() -> Self {
-        Self {
-            spec: AgentSpec::new("openai/gpt-5.4-mini").instruction(PURPOSE_INSTRUCTION),
-        }
-    }
-
-    pub async fn generate(&self, content: &str) -> Result<String> {
+    fn build_query(content: &str) -> Message {
         let snippet: String = content.chars().take(PURPOSE_PREVIEW_CHARS).collect();
-        let query = Message::new(Role::User).with_contents([Part::text(snippet)]);
+        Message::new(Role::User).with_contents([Part::text(snippet)])
+    }
 
-        let mut agent = Agent::try_new(self.spec.clone()).await?;
-
-        let mut text_parts: Vec<String> = Vec::new();
-        {
-            let mut stream = agent.run(query);
-            while let Some(result) = stream.next().await {
-                let output = result?;
-                for part in &output.message.contents {
-                    if let Some(text) = part.as_text() {
-                        text_parts.push(text.to_string());
-                    }
-                }
-            }
-        }
-
-        let raw = text_parts.join("");
-        Ok(parse_purpose_response(&raw))
+    fn parse(raw: &str) -> String {
+        parse_purpose_response(raw)
     }
 }
 
@@ -185,8 +142,8 @@ fn parse_purpose_response(raw: &str) -> String {
 }
 
 /// Runs `PurposeAgent` over `content`.
-pub async fn get_purpose(content: &str) -> Result<String> {
-    let purpose = PurposeAgent::new().generate(content).await?;
+pub(super) async fn get_purpose(content: &str) -> Result<String> {
+    let purpose = PurposeAgent::generate(content).await?;
     if purpose.is_empty() {
         log::warn!("purpose generation returned empty string; indexing without purpose metadata");
     }

--- a/speedwagon/src/store/parser.rs
+++ b/speedwagon/src/store/parser.rs
@@ -1,8 +1,8 @@
 use ailoy::{
-    agent::{Agent, AgentProvider, AgentSpec},
+    agent::{Agent, AgentSpec},
     message::{Message, Part, Role},
 };
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use futures::StreamExt as _;
 
 fn parse_title(content: &str) -> Option<String> {
@@ -43,20 +43,25 @@ fn parse_title(content: &str) -> Option<String> {
     None
 }
 
-/// Wraps an Ailoy agent used to generate document titles via LLM.
+/// Wraps an Ailoy agent used to generate document titles via LLM. Uses
+/// ailoy's process-global default provider (see `default_provider_mut`).
 pub struct TitleAgent {
     spec: AgentSpec,
-    provider: Option<AgentProvider>,
+}
+
+impl Default for TitleAgent {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TitleAgent {
-    pub fn new(provider: Option<AgentProvider>) -> Self {
+    pub fn new() -> Self {
         Self {
             spec: AgentSpec::new("openai/gpt-5.4-mini").instruction(concat!(
                 "You are a title generator. ",
                 "Given document content, reply with only a concise title under 10 words.",
             )),
-            provider,
         }
     }
 
@@ -64,10 +69,7 @@ impl TitleAgent {
         let snippet: String = content.chars().take(8192).collect();
         let query = Message::new(Role::User).with_contents([Part::text(snippet)]);
 
-        let mut agent = match &self.provider {
-            Some(provider) => Agent::try_with_provider(self.spec.clone(), provider).await?,
-            None => Agent::try_new(self.spec.clone()).await?,
-        };
+        let mut agent = Agent::try_new(self.spec.clone()).await?;
 
         let mut text_parts: Vec<String> = Vec::new();
         {
@@ -91,18 +93,12 @@ impl TitleAgent {
     }
 }
 
+/// Generates a title from `content`. The frontmatter/H1 fast path runs first;
+/// if neither is present, falls back to `TitleAgent`.
 pub async fn get_title(content: &str) -> Result<String> {
     match parse_title(content) {
         Some(t) => Ok(t),
-        None => {
-            dotenvy::dotenv().ok();
-
-            let mut provier = AgentProvider::new();
-            provier.model_openai(
-                std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY not set in environment")?,
-            );
-            TitleAgent::new(Some(provier)).generate(content).await
-        }
+        None => TitleAgent::new().generate(content).await,
     }
 }
 
@@ -123,16 +119,21 @@ const PURPOSE_INSTRUCTION: &str = concat!(
 const PURPOSE_PREVIEW_CHARS: usize = 3000;
 
 /// Wraps an Ailoy agent used to generate document purpose metadata via LLM.
+/// Uses ailoy's process-global default provider (see `default_provider_mut`).
 pub struct PurposeAgent {
     spec: AgentSpec,
-    provider: Option<AgentProvider>,
+}
+
+impl Default for PurposeAgent {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PurposeAgent {
-    pub fn new(provider: Option<AgentProvider>) -> Self {
+    pub fn new() -> Self {
         Self {
             spec: AgentSpec::new("openai/gpt-5.4-mini").instruction(PURPOSE_INSTRUCTION),
-            provider,
         }
     }
 
@@ -140,10 +141,7 @@ impl PurposeAgent {
         let snippet: String = content.chars().take(PURPOSE_PREVIEW_CHARS).collect();
         let query = Message::new(Role::User).with_contents([Part::text(snippet)]);
 
-        let mut agent = match &self.provider {
-            Some(provider) => Agent::try_with_provider(self.spec.clone(), provider).await?,
-            None => Agent::try_new(self.spec.clone()).await?,
-        };
+        let mut agent = Agent::try_new(self.spec.clone()).await?;
 
         let mut text_parts: Vec<String> = Vec::new();
         {
@@ -186,15 +184,9 @@ fn parse_purpose_response(raw: &str) -> String {
     String::new()
 }
 
+/// Runs `PurposeAgent` over `content`.
 pub async fn get_purpose(content: &str) -> Result<String> {
-    dotenvy::dotenv().ok();
-
-    let mut provider = AgentProvider::new();
-    provider.model_openai(
-        std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY not set in environment")?,
-    );
-
-    let purpose = PurposeAgent::new(Some(provider)).generate(content).await?;
+    let purpose = PurposeAgent::new().generate(content).await?;
     if purpose.is_empty() {
         log::warn!("purpose generation returned empty string; indexing without purpose metadata");
     }

--- a/speedwagon/src/store/parser.rs
+++ b/speedwagon/src/store/parser.rs
@@ -62,7 +62,6 @@ struct TitleAgent;
 impl HelperAgent for TitleAgent {
     type Input<'a> = &'a str;
     type Output = String;
-    const MODEL: &'static str = "openai/gpt-5.4-mini";
     const INSTRUCTION: &'static str = TITLE_INSTRUCTION;
 
     fn build_query(&content: &&str) -> Message {
@@ -108,7 +107,6 @@ struct PurposeAgent;
 impl HelperAgent for PurposeAgent {
     type Input<'a> = &'a str;
     type Output = String;
-    const MODEL: &'static str = "openai/gpt-5.4-mini";
     const INSTRUCTION: &'static str = PURPOSE_INSTRUCTION;
 
     fn build_query(&content: &&str) -> Message {

--- a/speedwagon/src/store/parser.rs
+++ b/speedwagon/src/store/parser.rs
@@ -3,7 +3,10 @@ use anyhow::Result;
 
 use super::helper::HelperAgent;
 
-fn parse_title(content: &str) -> Option<String> {
+/// Pulls a title out of a YAML frontmatter `title:` field or the first H1
+/// heading. Returns `None` when neither is present — caller falls back to
+/// `TitleAgent`.
+fn extract_title(content: &str) -> Option<String> {
     if content.starts_with("---") {
         if let Some(end) = content[3..].find("\n---") {
             let frontmatter = &content[3..end + 3];
@@ -44,8 +47,12 @@ fn parse_title(content: &str) -> Option<String> {
 const TITLE_PREVIEW_CHARS: usize = 8192;
 
 const TITLE_INSTRUCTION: &str = concat!(
-    "You are a title generator. ",
-    "Given document content, reply with only a concise title under 10 words.",
+    "You are generating a title for a document. ",
+    "Given document content, return ONLY a JSON object: ",
+    "{\"result\": \"<string>\"}.\n\n",
+    "title rules:\n",
+    "- Concise, under 10 words.\n",
+    "- Plain text. No markdown, no surrounding quotes inside the value.",
 );
 
 /// Generates a document title via LLM. Reads from ailoy's process-global
@@ -58,35 +65,31 @@ impl HelperAgent for TitleAgent {
     const MODEL: &'static str = "openai/gpt-5.4-mini";
     const INSTRUCTION: &'static str = TITLE_INSTRUCTION;
 
-    fn build_query(content: &str) -> Message {
+    fn build_query(&content: &&str) -> Message {
         let snippet: String = content.chars().take(TITLE_PREVIEW_CHARS).collect();
         Message::new(Role::User).with_contents([Part::text(snippet)])
     }
 
-    fn parse(raw: &str) -> String {
-        let title = raw.trim().to_string();
-        if title.is_empty() {
-            "Untitled".to_string()
-        } else {
-            title
-        }
+    fn fallback(_: &&str) -> String {
+        "Untitled".to_string()
     }
 }
 
 /// Generates a title from `content`. The frontmatter/H1 fast path runs first;
-/// if neither is present, falls back to `TitleAgent`.
+/// if neither is present, falls back to `TitleAgent` (which substitutes
+/// `"Untitled"` for an empty/malformed LLM response).
 pub(super) async fn get_title(content: &str) -> Result<String> {
-    match parse_title(content) {
-        Some(t) => Ok(t),
-        None => TitleAgent::generate(content).await,
+    if let Some(t) = extract_title(content) {
+        return Ok(t);
     }
+    TitleAgent::generate(content).await
 }
 
 const PURPOSE_INSTRUCTION: &str = concat!(
     "You are generating search metadata for a document retrieval system. ",
     "Your output will be used as BM25 search terms — optimize for retrieval, NOT readability.\n\n",
     "Given a document content preview (first 3000 characters), return ONLY a JSON object: ",
-    "{\"purpose\": \"<string>\"}.\n\n",
+    "{\"result\": \"<string>\"}.\n\n",
     "purpose rules:\n",
     "- ONE sentence, 80–150 characters\n",
     "- MUST include: entity name(s), year/date, document type, 3–5 key topic terms\n",
@@ -108,147 +111,85 @@ impl HelperAgent for PurposeAgent {
     const MODEL: &'static str = "openai/gpt-5.4-mini";
     const INSTRUCTION: &'static str = PURPOSE_INSTRUCTION;
 
-    fn build_query(content: &str) -> Message {
+    fn build_query(&content: &&str) -> Message {
         let snippet: String = content.chars().take(PURPOSE_PREVIEW_CHARS).collect();
         Message::new(Role::User).with_contents([Part::text(snippet)])
     }
 
-    fn parse(raw: &str) -> String {
-        parse_purpose_response(raw)
+    /// Empty string is the documented fallback — `Store::ingest` indexes
+    /// the document without purpose metadata in that case.
+    fn fallback(_: &&str) -> String {
+        String::new()
     }
 }
 
-fn parse_purpose_response(raw: &str) -> String {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return String::new();
-    }
-
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed)
-        && let Some(p) = value.get("purpose").and_then(|v| v.as_str())
-    {
-        return p.trim().to_string();
-    }
-
-    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}'))
-        && start < end
-        && let Ok(value) = serde_json::from_str::<serde_json::Value>(&trimmed[start..=end])
-        && let Some(p) = value.get("purpose").and_then(|v| v.as_str())
-    {
-        return p.trim().to_string();
-    }
-
-    String::new()
-}
-
-/// Runs `PurposeAgent` over `content`.
+/// Runs `PurposeAgent` over `content`. An empty/malformed LLM response is
+/// substituted with `""` (which `Store::ingest` indexes as missing purpose
+/// metadata).
 pub(super) async fn get_purpose(content: &str) -> Result<String> {
-    let purpose = PurposeAgent::generate(content).await?;
-    if purpose.is_empty() {
-        log::warn!("purpose generation returned empty string; indexing without purpose metadata");
-    }
-    Ok(purpose)
+    PurposeAgent::generate(content).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn parse_purpose_response_plain_json() {
-        let raw = r#"{"purpose": "3M Company FY2018 10-K Annual Report"}"#;
-        assert_eq!(
-            parse_purpose_response(raw),
-            "3M Company FY2018 10-K Annual Report"
-        );
-    }
-
-    #[test]
-    fn parse_purpose_response_with_whitespace() {
-        let raw = "\n  {\"purpose\": \"hello\"}  \n";
-        assert_eq!(parse_purpose_response(raw), "hello");
-    }
-
-    #[test]
-    fn parse_purpose_response_with_surrounding_text() {
-        let raw = "Sure, here you go: {\"purpose\": \"Costco 2023 Q1 earnings\"} — done.";
-        assert_eq!(parse_purpose_response(raw), "Costco 2023 Q1 earnings");
-    }
-
-    #[test]
-    fn parse_purpose_response_empty() {
-        assert_eq!(parse_purpose_response(""), "");
-        assert_eq!(parse_purpose_response("   "), "");
-    }
-
-    #[test]
-    fn parse_purpose_response_invalid_json() {
-        assert_eq!(parse_purpose_response("not json"), "");
-        assert_eq!(parse_purpose_response("{not: json}"), "");
-    }
-
-    #[test]
-    fn parse_purpose_response_missing_field() {
-        let raw = r#"{"other": "value"}"#;
-        assert_eq!(parse_purpose_response(raw), "");
-    }
-
     fn frontmatter_with_title(line: &str) -> String {
         format!("---\n{line}\n---\n\nbody\n")
     }
 
     #[test]
-    fn parse_title_single_quoted_plain() {
+    fn extract_title_single_quoted_plain() {
         let doc = frontmatter_with_title("title: 'Hello world'");
-        assert_eq!(parse_title(&doc).as_deref(), Some("Hello world"));
+        assert_eq!(extract_title(&doc).as_deref(), Some("Hello world"));
     }
 
     #[test]
-    fn parse_title_single_quoted_with_apostrophe() {
+    fn extract_title_single_quoted_with_apostrophe() {
         // `'` is escaped as `''` in YAML single-quoted style.
         let doc = frontmatter_with_title("title: 'Don''t stop'");
-        assert_eq!(parse_title(&doc).as_deref(), Some("Don't stop"));
+        assert_eq!(extract_title(&doc).as_deref(), Some("Don't stop"));
     }
 
     #[test]
-    fn parse_title_single_quoted_with_double_quote_and_backslash() {
+    fn extract_title_single_quoted_with_double_quote_and_backslash() {
         // `"` and `\` pass through literally — no escaping in this style.
         let doc = frontmatter_with_title(r#"title: 'That "Smart" Move with C:\path'"#);
         assert_eq!(
-            parse_title(&doc).as_deref(),
+            extract_title(&doc).as_deref(),
             Some(r#"That "Smart" Move with C:\path"#),
         );
     }
 
     #[test]
-    fn parse_title_single_quoted_with_all_special_chars() {
+    fn extract_title_single_quoted_with_all_special_chars() {
         let doc = frontmatter_with_title(r#"title: 'Mix ''a'' "b" c\d'"#);
         assert_eq!(
-            parse_title(&doc).as_deref(),
+            extract_title(&doc).as_deref(),
             Some(r#"Mix 'a' "b" c\d"#),
         );
     }
 
     #[test]
-    fn parse_title_unquoted_returned_literally() {
+    fn extract_title_unquoted_returned_literally() {
         let doc = frontmatter_with_title("title: Plain Title");
-        assert_eq!(parse_title(&doc).as_deref(), Some("Plain Title"));
+        assert_eq!(extract_title(&doc).as_deref(), Some("Plain Title"));
     }
 
     #[test]
-    fn parse_title_double_quoted_strips_outer_only() {
+    fn extract_title_double_quoted_strips_outer_only() {
         // YAML-style outer `"` is treated as syntax (one stripped from each
         // side); backslash escapes inside are left literal.
         let doc = frontmatter_with_title(r#"title: "Hello \"World\"""#);
         assert_eq!(
-            parse_title(&doc).as_deref(),
+            extract_title(&doc).as_deref(),
             Some(r#"Hello \"World\""#),
         );
     }
 
     #[test]
-    fn parse_title_falls_back_to_h1_when_frontmatter_missing() {
+    fn extract_title_falls_back_to_h1_when_frontmatter_missing() {
         let doc = "# Heading Title\n\nbody\n";
-        assert_eq!(parse_title(doc).as_deref(), Some("Heading Title"));
+        assert_eq!(extract_title(doc).as_deref(), Some("Heading Title"));
     }
 }


### PR DESCRIPTION
## Ticket
#49 

## Summary
- Centralize provider configuration on ailoy's process-global default — `main.rs` populates it once at boot; helpers stop reading env directly.
- Lift the duplicated dispatch shell of `TitleAgent` / `PurposeAgent` / `DescriptionAgent` into a single `HelperAgent` trait with a fixed `{"result": "<string>"}` JSON contract.
- Pick the first registered model from a preference list per helper; fall back gracefully when no provider is registered.
- Scope all helper internals to module-private — `Store` is the sole public entry point for LLM-backed metadata.

## Why
Helpers each called `dotenvy::dotenv()` + `OPENAI_API_KEY` and copy-pasted ~25 lines of agent setup / streaming / parsing. Without `OPENAI_API_KEY` — even with Anthropic or Gemini keys — `Store::ingest` and `Store::describe` died with `"No provider found for model …"`.

## What changes
- `main.rs` populates `ailoy::agent::default_provider_mut` once at boot; `build_agent` reads via `default_provider()`.
- `HelperAgent` trait owns dispatch, streaming, JSON-field extraction, response-empty fallback, and model selection. Helpers declare only `INSTRUCTION`, `build_query`, `fallback`.
- `MODELS` defaults to `["openai/gpt-5.4-mini", "anthropic/claude-haiku-4-5-20251001", "google/gemini-2.5-flash"]` (override per helper if a different preference order is needed) and is checked against ailoy's registered glob patterns (`openai/*`, `anthropic/claude-*`, `google/gemini-*`); first match wins. Nothing registered → `log::warn!` + `fallback` without an LLM call.
- Response contract is `{"result": "<string>"}`; the trait extracts and substitutes `fallback` (logging the agent via `std::any::type_name`) on empty / malformed responses.

## Adding a new helper

```rust
use ailoy::message::{Message, Part, Role};
use super::helper::HelperAgent;

struct SummaryAgent;

impl HelperAgent for SummaryAgent {
    type Input<'a> = &'a str;
    type Output = String;
    // const MODELS: &'static [&'static str] = &[...];  // override if needed
    const INSTRUCTION: &'static str = concat!(
        "Summarize the document in 3 sentences. ",
        "Return ONLY a JSON object: {\"result\": \"<string>\"}.",
    );
    fn build_query(&content: &&str) -> Message {
        Message::new(Role::User).with_contents([Part::text(content.to_string())])
    }
    fn fallback(_: &&str) -> String { String::new() }
}

// SummaryAgent::generate(content).await
```

`MODELS`, `process`, `generate`, agent identifier, model-availability check, and fallback path all come from trait defaults.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p speedwagon --lib` 
- [x] LLM round-trip: `OPENAI_API_KEY=… cargo test -p speedwagon --lib -- --ignored describe_round_trips_against_pre_populated_index`
- [ ] Manual: only `ANTHROPIC_API_KEY` (or only `GEMINI_API_KEY`) set → ingest succeeds via that provider.