### PR TITLE
fix(deps): bump ailoy to post-#391 (AgentBuilder + sandbox sharing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=c42231e1023ec91884014b17488aac3b61fb7067#c42231e1023ec91884014b17488aac3b61fb7067"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=098a8289272ccce3cf5719e20732050cb047d04a#098a8289272ccce3cf5719e20732050cb047d04a"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ members = [
 ]
 
 [workspace.dependencies]
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "c42231e1023ec91884014b17488aac3b61fb7067" }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "098a8289272ccce3cf5719e20732050cb047d04a" }

--- a/speedwagon/src/lib.rs
+++ b/speedwagon/src/lib.rs
@@ -1,7 +1,9 @@
 mod agent;
+mod provider;
 mod store;
 mod tool;
 
 pub use agent::*;
+pub use provider::*;
 pub use store::*;
 pub use tool::*;

--- a/speedwagon/src/main.rs
+++ b/speedwagon/src/main.rs
@@ -22,7 +22,9 @@ use anyhow::Result;
 use clap::Parser;
 use futures::StreamExt;
 use rustyline::{DefaultEditor, error::ReadlineError};
-use speedwagon::{FileType, SpeedwagonSpec, Store, build_toolset};
+use speedwagon::{
+    FileType, SpeedwagonSpec, Store, build_tool_provider, register_provider_from_env,
+};
 
 use speedwagon::preset::{PresetKind, setup_docset};
 
@@ -54,10 +56,13 @@ fn resolve_dir(path: &str) -> PathBuf {
 
 async fn build_agent(store_dir: &Path, model: &str) -> Result<Agent> {
     let store = Arc::new(Store::new(store_dir)?);
-    let toolset = build_toolset(store);
     let spec = SpeedwagonSpec::new().model(model).into_spec();
-    let provider = default_provider().await;
-    Agent::try_with_tools(spec, &provider, &toolset).await
+    // Clone the global provider, then override its tool registry with the
+    // store-bound speedwagon tools. ailoy no longer accepts a separate
+    // ToolSet argument — tool sources live on AgentProvider.tools.
+    let mut provider = default_provider().await.clone();
+    provider.tools = build_tool_provider(store);
+    Agent::try_with_provider(spec, &provider).await
 }
 
 async fn run_query(agent: &mut Agent, input: &str) -> Result<()> {
@@ -110,20 +115,9 @@ async fn main() -> Result<()> {
     };
 
     // Populate ailoy's process-global provider once at boot. Every
-    // `Agent::try_new`/`try_with_tools` (including speedwagon's title/purpose/
+    // `Agent::try_new`/`try_with_provider` (including speedwagon's title/purpose/
     // description helpers) reads from this singleton.
-    {
-        let mut default = default_provider_mut().await;
-        if let Ok(key) = std::env::var("OPENAI_API_KEY") {
-            default.model_openai(key);
-        }
-        if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
-            default.model_claude(key);
-        }
-        if let Ok(key) = std::env::var("GEMINI_API_KEY") {
-            default.model_gemini(key);
-        }
-    }
+    register_provider_from_env(&mut *default_provider_mut().await);
 
     if let Some(ref preset) = cli.preset {
         let mut store = Store::new(&store_dir)?;

--- a/speedwagon/src/provider.rs
+++ b/speedwagon/src/provider.rs
@@ -1,0 +1,56 @@
+//! Single registration site for ailoy [`LangModelProvider`] entries from
+//! environment variables. main.rs and integration tests both call
+//! [`register_provider_from_env`] so the env-key → glob-pattern mapping
+//! lives in exactly one place — preserving PR #49's invariant that helper
+//! modules never read env directly.
+
+use ailoy::{
+    agent::AgentProvider,
+    lang_model::{LangModelAPISchema, LangModelProviderElem},
+};
+use url::Url;
+
+/// Read the conventional API-key environment variables and register matching
+/// glob patterns on `provider.models`. Missing keys are silently skipped, so
+/// callers can register only the providers they actually have credentials for.
+///
+/// Patterns and URLs match the helper constructors that ailoy used to expose
+/// (`model_openai`, `model_claude`, `model_gemini`) before they were removed
+/// in the post-#391 registry refactor — keep them in sync if ailoy adds a
+/// canonical builder again.
+pub fn register_provider_from_env(provider: &mut AgentProvider) {
+    if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+        provider.models.insert(
+            "openai/*".into(),
+            LangModelProviderElem::API {
+                schema: LangModelAPISchema::OpenAI,
+                url: Url::parse("https://api.openai.com/v1/responses").unwrap(),
+                api_key: Some(key),
+                max_tokens: None,
+            },
+        );
+    }
+    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+        provider.models.insert(
+            "anthropic/claude-*".into(),
+            LangModelProviderElem::API {
+                schema: LangModelAPISchema::Anthropic,
+                url: Url::parse("https://api.anthropic.com/v1/messages").unwrap(),
+                api_key: Some(key),
+                max_tokens: None,
+            },
+        );
+    }
+    if let Ok(key) = std::env::var("GEMINI_API_KEY") {
+        provider.models.insert(
+            "google/gemini-*".into(),
+            LangModelProviderElem::API {
+                schema: LangModelAPISchema::Gemini,
+                url: Url::parse("https://generativelanguage.googleapis.com/v1beta/models/")
+                    .unwrap(),
+                api_key: Some(key),
+                max_tokens: None,
+            },
+        );
+    }
+}

--- a/speedwagon/src/store/description.rs
+++ b/speedwagon/src/store/description.rs
@@ -198,11 +198,12 @@ mod tests {
         std::fs::create_dir_all(root.join("origin")).unwrap();
         std::fs::create_dir_all(root.join("corpus")).unwrap();
 
-        // Populate ailoy's process-global default provider for this test.
+        // Populate ailoy's process-global default provider for this test
+        // through the same helper main.rs uses, so the env-key → glob-pattern
+        // mapping has a single source of truth.
         dotenvy::dotenv().ok();
-        ailoy::agent::default_provider_mut().await.model_openai(
-            std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY required for this test"),
-        );
+        std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY required for this test");
+        crate::register_provider_from_env(&mut *ailoy::agent::default_provider_mut().await);
 
         let store = crate::store::Store::new(root).expect("open store");
         let description = store

--- a/speedwagon/src/store/helper.rs
+++ b/speedwagon/src/store/helper.rs
@@ -85,7 +85,7 @@ pub(super) trait HelperAgent {
             Self::MODELS
                 .iter()
                 .copied()
-                .find(|m| provider.get_model(m).is_some())
+                .find(|m| provider.models.get(m).is_some())
         };
 
         let model = match chosen_model {

--- a/speedwagon/src/tool/mod.rs
+++ b/speedwagon/src/tool/mod.rs
@@ -5,7 +5,7 @@ mod search;
 
 use std::sync::Arc;
 
-use ailoy::tool::ToolSet;
+use ailoy::tool::{ToolFactory, ToolProvider};
 pub use calculate::*;
 pub use find::*;
 pub use read::*;
@@ -13,16 +13,16 @@ pub use search::*;
 
 use crate::store::Store;
 
-pub fn build_toolset(store: Arc<Store>) -> ToolSet {
-    let mut toolset = ToolSet::new();
+pub fn build_tool_provider(store: Arc<Store>) -> ToolProvider {
+    let mut provider = ToolProvider::new();
 
     let (desc, func) = make_search_document_tool(store.clone());
-    toolset.insert("search_document", desc, func);
+    provider = provider.custom(ToolFactory::simple(desc, func));
     let (desc, func) = build_find_in_document_tool(store.clone());
-    toolset.insert("find_in_document", desc, func);
+    provider = provider.custom(ToolFactory::simple(desc, func));
     let (desc, func) = build_read_document_tool(store.clone());
-    toolset.insert("read_document", desc, func);
+    provider = provider.custom(ToolFactory::simple(desc, func));
     let (desc, func) = build_calculate_tool();
-    toolset.insert("calculate", desc, func);
-    toolset
+    provider = provider.custom(ToolFactory::simple(desc, func));
+    provider
 }


### PR DESCRIPTION
## Summary

Bumps ailoy from `c42231e1` (2026-04-21) to `098a8289` ([brekkylab/ailoy#391](https://github.com/brekkylab/ailoy/pull/391), 2026-05-04). Pulls in 27 commits worth of breaking changes; this PR only patches `speedwagon` to compile and pass tests against the new API.

## Why

Speedwagon's pinned ailoy was three substantive refactors behind: `ToolFactory` introduction (#389), `RunEnv` trait + sandbox feature split (#390), and the registry overhaul that removed `ToolSet` / `model_openai` helpers / `Agent::try_with_tools` (#391). Each is a hard breaking change. Without this bump, speedwagon's API surface diverges from current ailoy, blocking any future work that wants to use both.

## Breaking changes absorbed

| ailoy change | speedwagon-side adjustment |
|---|---|
| `ToolSet` removed; `ToolFactory` introduced | `tool/mod.rs`: `build_toolset(store) -> ToolSet` renamed to `build_tool_provider(store) -> ToolProvider`, using `ToolProvider::new().custom(ToolFactory::simple(desc, func))` per tool. |
| `Agent::try_with_tools(spec, provider, toolset)` removed; tools live on `provider.tools` | `main.rs::build_agent`: clones the global provider, overrides `provider.tools` with the store-bound tool registry, then `Agent::try_with_provider(spec, &provider)`. |
| `AgentProvider::get_model(name)` removed; replaced by `AgentProvider.models.get(name)` | `store/helper.rs:88`: same call rewritten. Same semantics, new accessor location. |
| `AgentProvider::model_openai/model_claude/model_gemini` helper constructors removed | New module `speedwagon::provider` with `register_provider_from_env(&mut AgentProvider)` that reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` and registers the same glob patterns the removed helpers used (`openai/*`, `anthropic/claude-*`, `google/gemini-*`). `main.rs` and the `description.rs` integration test both call this — keeps the env-key → glob-pattern mapping in one place, preserving #49's invariant that helper modules never read env directly. |
| `RunEnv` trait + sandbox feature split | No direct touch — speedwagon never constructs sandboxes. The default `Local` runenv gets used implicitly when an `Agent` is built without `.runenv()`. |

## Out of scope

`chat-agent`, `backend`, and `knowledge-agent` are **already broken on `refactoring-applied`** independent of this PR — none of them are workspace members nor explicitly excluded, so cargo refuses to build them ("current package believes it's in a workspace when it's not"). I confirmed this against an unmodified `origin/refactoring-applied` clone before scoping this PR. These directories are not on the active development path of this branch, so reviving them is not planned here.

## Verification

```
cargo check  -p speedwagon --tests --all-features  # clean
cargo test   -p speedwagon --lib   --all-features  # 71 passed; 0 failed; 2 ignored
```

The two ignored tests gate on `OPENAI_API_KEY` and `network access & docling` respectively — same as before.

## Test plan

- [x] `cargo check -p speedwagon --tests --all-features` is clean
- [x] `cargo test -p speedwagon --lib --all-features` passes 71/71 (excluding the 2 ignored tests)
- [x] `cargo run -p speedwagon` boots the REPL with `OPENAI_API_KEY` registered, prints the prompt banner, and exits cleanly on `/exit`
- [x] `register_provider_from_env` glob patterns match the helper preference list one-to-one (verified by ad-hoc unit test, not committed): each of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` registered in isolation matches exactly one entry of `[openai/gpt-5.4-mini, anthropic/claude-haiku-4-5-20251001, google/gemini-2.5-flash]`; with no key registered, the helper returns `None` and falls back without an LLM call