### PR TITLE
feat(reflect-agent): LLM-driven reflect mode with cross-model escalation

### DIFF
--- a/reflect-agent/src/agent.rs
+++ b/reflect-agent/src/agent.rs
@@ -8,21 +8,19 @@
 //! Tools run on the agent's [`ailoy::runenv::RunEnv`]. The default is
 //! [`ailoy::runenv::Local`] (host-native execution); when the `sandbox`
 //! feature is enabled, the caller may pass an [`Arc<Sandbox>`] wrapper
-//! through a future builder option.
+//! through the builder.
 //!
-//! Construction is split in two so the verify gate (Phase 1) and reflect
-//! gate (Phase 2) can be layered on top without changing the call site.
+//! Construction is split in two so the verify gate and reflect gate can
+//! be layered on top without changing the call site.
 
 use ailoy::{
     agent::{Agent, AgentBuilder, AgentProvider, default_provider_mut},
-    datatype::Value,
-    message::{Message, MessageOutput, Part, Role, ToolDescBuilder},
-    tool::{ToolContext, ToolFactory, ToolFunc},
+    message::{Message, MessageOutput, Part, Role},
 };
 use anyhow::Result;
 use futures::StreamExt as _;
 
-use crate::reflect::{DEFAULT_REFLECT_MODEL, ReflectMode, ReflectVerdict, reflect_call};
+use crate::reflect::{LOW_CONFIDENCE_THRESHOLD, ReflectMode, ReflectVerdict, reflect_call};
 use crate::verify::{VerifyConfig, VerifyReport, verify_run};
 
 /// Default model. Anthropic Haiku — fast, cheap, suitable for an interactive lead.
@@ -79,84 +77,53 @@ pub async fn run_with_verify(
     Ok((outputs, report))
 }
 
-/// System prompt fragment appended in [`ReflectMode::Self_`]. The
-/// "MUST + do not skip" framing is the strongest of the three variants
-/// we surveyed off-tree against operationally-realistic tasks (PyTorch
-/// release listing, arXiv abstract summary, OSS DB release-date table,
-/// ripgrep `Cargo.toml` parse) — it produced the highest verify-tool
-/// invocation rate per turn. Even so, the call is best-effort: nothing
-/// in the runtime *forces* it, so this mode remains self-discipline
-/// driven and the verify-tool invocation rate falls off sharply on
-/// trivial tasks where the LLM judges its draft as obviously correct.
-const SELF_MODE_SYSTEM_PROMPT: &str = "\
-You MUST call the `verify` tool with your draft answer before sending \
-any final response. Do not skip this step. The verify tool returns a \
-JSON verdict with `verdict` set to either \"stop\" or \"retry\". If \
-`stop`, deliver your draft as the final answer. If `retry`, treat the \
-returned `next_query` as a corrected task description and try again, \
-calling `verify` again on the new draft. Limit yourself to one retry \
-per user turn; on the second retry verdict, deliver whatever you have.";
-
 /// Build the same agent as [`build_agent`], but with the reflect mode
-/// applied. `Off` is identical to [`build_agent`]; `Self_` registers a
-/// `verify` tool and prepends the self-mode instruction; `Forced` builds
-/// the plain agent (the wrapper is applied at run time, not build time).
-pub async fn build_agent_with_mode(model: &str, mode: ReflectMode) -> Result<Agent> {
-    let mut provider = default_provider_mut().await.clone();
-    attach_default_tools(&mut provider);
-
-    let mut spec_instruction: Option<String> = None;
-
-    if mode == ReflectMode::Self_ {
-        // Tool: register the `verify` tool source on the provider so the
-        // builder can resolve it by key below.
-        provider.tools = std::mem::take(&mut provider.tools)
-            .custom(verify_tool_factory(provider.clone(), DEFAULT_REFLECT_MODEL.to_string()));
-        spec_instruction = Some(SELF_MODE_SYSTEM_PROMPT.to_string());
-    }
-
-    let mut builder = AgentBuilder::new(model)
-        .provider(provider)
-        .tool("bash")
-        .tool("python_repl")
-        .tool("web_search");
-    if mode == ReflectMode::Self_ {
-        builder = builder.tool("verify");
-    }
-    if let Some(inst) = spec_instruction {
-        builder = builder.instruction(inst);
-    }
-    builder.build().await
+/// applied. Both `Off` and `Forced` build the same plain agent — Forced's
+/// reflect wrapper is applied at run time by [`run_with_forced_reflect`],
+/// not at build time. The function is kept on the public surface so the
+/// CLI can dispatch on mode without leaking the construction detail.
+pub async fn build_agent_with_mode(model: &str, _mode: ReflectMode) -> Result<Agent> {
+    build_agent(model).await
 }
 
-/// Outcome of one [`run_with_forced_reflect`] call. Carries everything the
-/// CLI / a test wants to inspect: the agent outputs (one or two turns
-/// worth, depending on whether a retry fired), the deterministic verify
-/// report, and the chain of reflect verdicts that drove the retry loop.
+/// Outcome of one [`run_with_forced_reflect`] call. Carries everything
+/// the CLI or a test wants to inspect: the agent outputs (one or two
+/// turns worth depending on whether a retry fired), the deterministic
+/// verify report, the verdict chain (one Haiku verdict per turn plus the
+/// optional Sonnet escalation verdict), the retry count, and the number
+/// of escalations to the stronger model.
 #[derive(Debug)]
 pub struct ForcedReflectOutcome {
     pub outputs: Vec<MessageOutput>,
     pub verify_report: VerifyReport,
     pub reflect_verdicts: Vec<ReflectVerdict>,
     pub retry_count: usize,
+    /// How many times the first-pass verdict was a low-confidence `Stop`
+    /// that triggered an escalation reflect call to the stronger model.
+    /// `0` means the run stayed entirely on the first-pass model.
+    pub escalations: usize,
 }
 
-/// Forced-mode wrapper around [`Agent::run`]. Drives one user turn to
-/// completion, runs [`reflect_call`] on the draft answer, and — if the
-/// verdict is `Retry` and the budget hasn't been spent — re-invokes the
-/// agent with the verifier's `next_query`. The deterministic verify pass
-/// from PR #53 also runs internally so the caller can compare what each
-/// layer fired on without having to invoke them separately.
+/// Forced-mode wrapper around [`Agent::run`]. After each turn the wrapper
+/// runs [`reflect_call`] on the draft with `reflect_model`. When the
+/// first-pass verdict is a `Stop` whose confidence is below
+/// [`LOW_CONFIDENCE_THRESHOLD`], the wrapper escalates: a second
+/// `reflect_call` is made with `escalate_model` and that verdict becomes
+/// final for this turn. The escalation model's `Stop` is honoured; its
+/// `Retry` verdict is ignored, because the calibration data for this PR
+/// found same-model retry never recovered the answer in those cases.
 ///
-/// The retry budget is fixed at one per outer call. The second `Retry`
-/// verdict (or a malformed one that coerces to `Stop`) terminates the
-/// loop with whatever draft the agent produced last.
+/// First-pass `Retry` verdicts are honoured with a one-attempt budget
+/// ([`crate::reflect::RETRY_BUDGET`]). The second `Retry` verdict (or a
+/// malformed one that coerces to `Stop`) terminates the loop with the
+/// last draft.
 pub async fn run_with_forced_reflect(
     agent: &mut Agent,
     initial_query: Message,
     verify_config: &VerifyConfig,
     provider: &AgentProvider,
     reflect_model: &str,
+    escalate_model: &str,
 ) -> Result<ForcedReflectOutcome> {
     use crate::reflect::RETRY_BUDGET;
 
@@ -164,6 +131,7 @@ pub async fn run_with_forced_reflect(
     let mut outputs: Vec<MessageOutput> = Vec::new();
     let mut verdicts: Vec<ReflectVerdict> = Vec::new();
     let mut retry_count = 0usize;
+    let mut escalations = 0usize;
     let mut next_query = initial_query;
 
     loop {
@@ -182,10 +150,33 @@ pub async fn run_with_forced_reflect(
             None => break,
         };
 
-        let verdict = reflect_call(provider, reflect_model, &draft, &[]).await?;
-        verdicts.push(verdict.clone());
+        // First-pass verdict from the cheap model.
+        let first_verdict = reflect_call(provider, reflect_model, &draft, &[]).await?;
+        verdicts.push(first_verdict.clone());
 
-        match verdict {
+        // Decide whether this turn's effective verdict needs to come from
+        // the stronger model: only when the first-pass verdict is a Stop
+        // with reported confidence below the threshold. Retry verdicts
+        // are passed through unchanged so the standard retry budget runs.
+        let effective_verdict = match &first_verdict {
+            ReflectVerdict::Stop {
+                confidence: Some(c),
+                ..
+            } if *c < LOW_CONFIDENCE_THRESHOLD => {
+                escalations += 1;
+                let strong = reflect_call(provider, escalate_model, &draft, &[]).await?;
+                verdicts.push(strong.clone());
+                // Stronger-model Retry verdicts are ignored — see Q3 of the
+                // PR's calibration report. We accept the original draft.
+                match strong {
+                    ReflectVerdict::Stop { .. } => strong,
+                    ReflectVerdict::Retry { .. } => first_verdict,
+                }
+            }
+            _ => first_verdict,
+        };
+
+        match effective_verdict {
             ReflectVerdict::Stop { .. } => break,
             ReflectVerdict::Retry { next_query: nq, .. } => {
                 if retry_count >= RETRY_BUDGET {
@@ -205,142 +196,8 @@ pub async fn run_with_forced_reflect(
         verify_report,
         reflect_verdicts: verdicts,
         retry_count,
+        escalations,
     })
-}
-
-/// Outcome of one [`run_with_hybrid`] call. Like [`ForcedReflectOutcome`]
-/// plus per-turn verify reports — Hybrid mode runs the deterministic
-/// verifier on the slice that each agent turn produced (not just the
-/// final one), so a retry triggered by the verifier's hints can be
-/// inspected against the issues the verifier saw at that point.
-#[derive(Debug)]
-pub struct HybridReflectOutcome {
-    pub outputs: Vec<MessageOutput>,
-    /// One report per agent turn, oldest first. `len()` is `1 + retry_count`.
-    pub per_turn_verify_reports: Vec<VerifyReport>,
-    /// Final-state verify report computed over the whole new history slice.
-    pub verify_report: VerifyReport,
-    pub reflect_verdicts: Vec<ReflectVerdict>,
-    pub retry_count: usize,
-    /// Set when at least one `Stop` verdict was promoted to a retry because
-    /// its `confidence` was below [`crate::reflect::HYBRID_LOW_CONFIDENCE_THRESHOLD`].
-    /// Useful in the CLI's verbose output and in tests that want to assert
-    /// the threshold is wired up correctly.
-    pub low_confidence_promotions: usize,
-}
-
-/// Hybrid wrapper. Runs the agent, verifies its output deterministically,
-/// and feeds the verifier's findings into the reflect call as hints —
-/// the LLM gets to read the deterministic flags before deciding `stop`
-/// or `retry`. Adds one rule on top of [`run_with_forced_reflect`]: a
-/// `Stop` verdict whose `confidence` is below
-/// [`crate::reflect::HYBRID_LOW_CONFIDENCE_THRESHOLD`] is promoted to a
-/// retry within the standard retry budget. The retry's `next_query`
-/// comes from the verifier itself ("you said stop with low confidence
-/// — try the same task again"), so we don't strand the loop.
-///
-/// On `Retry` the wrapper combines the verifier's `next_query` with the
-/// freshest set of deterministic hints, keeping the next attempt aware
-/// of what the previous one tripped.
-pub async fn run_with_hybrid(
-    agent: &mut Agent,
-    initial_query: Message,
-    verify_config: &VerifyConfig,
-    provider: &AgentProvider,
-    reflect_model: &str,
-) -> Result<HybridReflectOutcome> {
-    use crate::reflect::{HYBRID_LOW_CONFIDENCE_THRESHOLD, RETRY_BUDGET};
-
-    let history_before = agent.get_history().len();
-    let mut outputs: Vec<MessageOutput> = Vec::new();
-    let mut per_turn_reports: Vec<VerifyReport> = Vec::new();
-    let mut verdicts: Vec<ReflectVerdict> = Vec::new();
-    let mut retry_count = 0usize;
-    let mut low_conf_promos = 0usize;
-    let mut next_query = initial_query;
-
-    loop {
-        let turn_start = agent.get_history().len();
-
-        let mut stream = agent.run(next_query);
-        while let Some(item) = stream.next().await {
-            outputs.push(item?);
-        }
-        drop(stream);
-
-        // Verify what this single turn produced, not the whole accumulated
-        // slice — Hybrid feeds *fresh* signals into each reflect call.
-        let turn_report = verify_run(&agent.get_history()[turn_start..], verify_config);
-        let hints = render_verify_hints(&turn_report);
-        per_turn_reports.push(turn_report);
-
-        let draft = match last_assistant_text(&agent.get_history()[history_before..]) {
-            Some(t) => t,
-            None => break,
-        };
-
-        let verdict = reflect_call(provider, reflect_model, &draft, &hints).await?;
-        verdicts.push(verdict.clone());
-
-        // Promote a low-confidence Stop into a synthetic Retry — the goal
-        // is to give the agent one more shot rather than silently honour
-        // an "I'm not sure" verdict.
-        let effective_verdict = match &verdict {
-            ReflectVerdict::Stop {
-                confidence: Some(c),
-                ..
-            } if *c < HYBRID_LOW_CONFIDENCE_THRESHOLD && retry_count < RETRY_BUDGET => {
-                low_conf_promos += 1;
-                ReflectVerdict::Retry {
-                    rationale: format!(
-                        "verifier confidence {c:.2} below {HYBRID_LOW_CONFIDENCE_THRESHOLD:.2}; retrying"
-                    ),
-                    next_query: "Please reattempt the previous task more carefully — your last \
-                                 draft scored below the confidence threshold."
-                        .to_string(),
-                    confidence: Some(*c),
-                }
-            }
-            _ => verdict.clone(),
-        };
-
-        match effective_verdict {
-            ReflectVerdict::Stop { .. } => break,
-            ReflectVerdict::Retry { next_query: nq, .. } => {
-                if retry_count >= RETRY_BUDGET {
-                    break;
-                }
-                retry_count += 1;
-                // Re-pose the task; verifier hints will be regenerated from
-                // the next turn's slice when we re-enter the loop.
-                next_query = Message::new(Role::User).with_contents([Part::text(nq)]);
-            }
-        }
-    }
-
-    let verify_report = verify_run(&agent.get_history()[history_before..], verify_config);
-    Ok(HybridReflectOutcome {
-        outputs,
-        per_turn_verify_reports: per_turn_reports,
-        verify_report,
-        reflect_verdicts: verdicts,
-        retry_count,
-        low_confidence_promotions: low_conf_promos,
-    })
-}
-
-/// Render a [`VerifyReport`]'s issues as the bullet-list strings the
-/// reflect call expects. Empty report → empty vec, which means
-/// `reflect_call` falls back to its baseline (no-hints) prompt.
-fn render_verify_hints(report: &VerifyReport) -> Vec<String> {
-    if report.is_empty() {
-        return Vec::new();
-    }
-    report
-        .format()
-        .lines()
-        .filter_map(|l| l.strip_prefix("- ").map(str::to_string))
-        .collect()
 }
 
 fn last_assistant_text(history: &[Message]) -> Option<String> {
@@ -355,98 +212,6 @@ fn last_assistant_text(history: &[Message]) -> Option<String> {
         }
     }
     if text.is_empty() { None } else { Some(text) }
-}
-
-/// Construct the `verify` [`ToolFactory`] used by [`ReflectMode::Self_`].
-/// The returned factory closes over a snapshot of the provider so each
-/// `verify` invocation can spin up its own [`ailoy::lang_model::LangModel`]
-/// for the reflect call, independent of the main agent's model.
-fn verify_tool_factory(provider: AgentProvider, reflect_model: String) -> ToolFactory {
-    let desc = ToolDescBuilder::new("verify")
-        .description(
-            "Self-check your draft answer before delivering it to the user. \
-             Returns a JSON object with `verdict` (\"stop\" or \"retry\"), \
-             `rationale`, and (when retry) `next_query`. Always call this \
-             once on your draft before emitting your final answer.",
-        )
-        .parameters(ailoy::to_value!({
-            "type": "object",
-            "properties": {
-                "draft_answer": {
-                    "type": "string",
-                    "description": "Your draft final answer, exactly as you would send it to the user."
-                }
-            },
-            "required": ["draft_answer"]
-        }))
-        .build();
-
-    let func = ToolFunc::new(move |args: Value, _ctx: ToolContext| {
-        let provider = provider.clone();
-        let reflect_model = reflect_model.clone();
-        async move {
-            let draft = args
-                .pointer("/draft_answer")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            if draft.trim().is_empty() {
-                return ailoy::to_value!({
-                    "verdict": "stop",
-                    "rationale": "verify called with empty draft_answer; coerced to stop",
-                });
-            }
-            match reflect_call(&provider, &reflect_model, &draft, &[]).await {
-                Ok(verdict) => verdict_to_tool_value(&verdict),
-                Err(e) => ailoy::to_value!({
-                    "verdict": "stop",
-                    "rationale": format!("reflect_call failed: {e}; coerced to stop"),
-                }),
-            }
-        }
-    });
-
-    ToolFactory::simple(desc, func)
-}
-
-/// Render a [`ReflectVerdict`] back into the JSON object the calling LLM
-/// expects from the `verify` tool. `confidence` is included only when the
-/// verifier produced a usable value — nothing leaks for fail-open or
-/// out-of-range cases.
-fn verdict_to_tool_value(v: &ReflectVerdict) -> ailoy::datatype::Value {
-    match v {
-        ReflectVerdict::Stop {
-            rationale,
-            confidence,
-        } => match confidence {
-            Some(c) => ailoy::to_value!({
-                "verdict": "stop",
-                "rationale": rationale.as_str(),
-                "confidence": *c as f64,
-            }),
-            None => ailoy::to_value!({
-                "verdict": "stop",
-                "rationale": rationale.as_str(),
-            }),
-        },
-        ReflectVerdict::Retry {
-            rationale,
-            next_query,
-            confidence,
-        } => match confidence {
-            Some(c) => ailoy::to_value!({
-                "verdict": "retry",
-                "rationale": rationale.as_str(),
-                "next_query": next_query.as_str(),
-                "confidence": *c as f64,
-            }),
-            None => ailoy::to_value!({
-                "verdict": "retry",
-                "rationale": rationale.as_str(),
-                "next_query": next_query.as_str(),
-            }),
-        },
-    }
 }
 
 #[cfg(test)]
@@ -473,29 +238,5 @@ mod tests {
         attach_default_tools(&mut provider);
         // 1 (initial bash) + 3 (default tools) = 4
         assert_eq!(provider.tools.iter().count(), 4);
-    }
-
-    /// `verify_tool_factory` should produce a [`ToolFactory`] whose name
-    /// is `"verify"` and whose schema requires the `draft_answer` field.
-    /// Doesn't run the closure (that needs an LLM); just inspects the
-    /// resolved [`Tool`] descriptor.
-    #[test]
-    fn verify_tool_factory_describes_a_verify_tool() {
-        let factory = verify_tool_factory(AgentProvider::new(), "test/model".to_string());
-        assert_eq!(factory.get_name(), "verify");
-
-        // Resolve to a Tool against an empty spec to inspect the desc.
-        let spec = ailoy::agent::AgentSpec::new("test/model");
-        let tool = factory.make(&spec);
-        let desc = tool.get_desc();
-        assert_eq!(desc.name, "verify");
-
-        let required = desc
-            .parameters
-            .pointer("/required")
-            .and_then(|v| v.as_array())
-            .expect("schema should declare required[]");
-        let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
-        assert!(required_names.contains(&"draft_answer"));
     }
 }

--- a/reflect-agent/src/agent.rs
+++ b/reflect-agent/src/agent.rs
@@ -15,11 +15,14 @@
 
 use ailoy::{
     agent::{Agent, AgentBuilder, AgentProvider, default_provider_mut},
-    message::{Message, MessageOutput},
+    datatype::Value,
+    message::{Message, MessageOutput, Part, Role, ToolDescBuilder},
+    tool::{ToolContext, ToolFactory, ToolFunc},
 };
 use anyhow::Result;
 use futures::StreamExt as _;
 
+use crate::reflect::{DEFAULT_REFLECT_MODEL, ReflectMode, ReflectVerdict, reflect_call};
 use crate::verify::{VerifyConfig, VerifyReport, verify_run};
 
 /// Default model. Anthropic Haiku — fast, cheap, suitable for an interactive lead.
@@ -76,6 +79,376 @@ pub async fn run_with_verify(
     Ok((outputs, report))
 }
 
+/// System prompt fragment appended in [`ReflectMode::Self_`]. The
+/// "MUST + do not skip" framing is the strongest of the three variants
+/// we surveyed off-tree against operationally-realistic tasks (PyTorch
+/// release listing, arXiv abstract summary, OSS DB release-date table,
+/// ripgrep `Cargo.toml` parse) — it produced the highest verify-tool
+/// invocation rate per turn. Even so, the call is best-effort: nothing
+/// in the runtime *forces* it, so this mode remains self-discipline
+/// driven and the verify-tool invocation rate falls off sharply on
+/// trivial tasks where the LLM judges its draft as obviously correct.
+const SELF_MODE_SYSTEM_PROMPT: &str = "\
+You MUST call the `verify` tool with your draft answer before sending \
+any final response. Do not skip this step. The verify tool returns a \
+JSON verdict with `verdict` set to either \"stop\" or \"retry\". If \
+`stop`, deliver your draft as the final answer. If `retry`, treat the \
+returned `next_query` as a corrected task description and try again, \
+calling `verify` again on the new draft. Limit yourself to one retry \
+per user turn; on the second retry verdict, deliver whatever you have.";
+
+/// Build the same agent as [`build_agent`], but with the reflect mode
+/// applied. `Off` is identical to [`build_agent`]; `Self_` registers a
+/// `verify` tool and prepends the self-mode instruction; `Forced` builds
+/// the plain agent (the wrapper is applied at run time, not build time).
+pub async fn build_agent_with_mode(model: &str, mode: ReflectMode) -> Result<Agent> {
+    let mut provider = default_provider_mut().await.clone();
+    attach_default_tools(&mut provider);
+
+    let mut spec_instruction: Option<String> = None;
+
+    if mode == ReflectMode::Self_ {
+        // Tool: register the `verify` tool source on the provider so the
+        // builder can resolve it by key below.
+        provider.tools = std::mem::take(&mut provider.tools)
+            .custom(verify_tool_factory(provider.clone(), DEFAULT_REFLECT_MODEL.to_string()));
+        spec_instruction = Some(SELF_MODE_SYSTEM_PROMPT.to_string());
+    }
+
+    let mut builder = AgentBuilder::new(model)
+        .provider(provider)
+        .tool("bash")
+        .tool("python_repl")
+        .tool("web_search");
+    if mode == ReflectMode::Self_ {
+        builder = builder.tool("verify");
+    }
+    if let Some(inst) = spec_instruction {
+        builder = builder.instruction(inst);
+    }
+    builder.build().await
+}
+
+/// Outcome of one [`run_with_forced_reflect`] call. Carries everything the
+/// CLI / a test wants to inspect: the agent outputs (one or two turns
+/// worth, depending on whether a retry fired), the deterministic verify
+/// report, and the chain of reflect verdicts that drove the retry loop.
+#[derive(Debug)]
+pub struct ForcedReflectOutcome {
+    pub outputs: Vec<MessageOutput>,
+    pub verify_report: VerifyReport,
+    pub reflect_verdicts: Vec<ReflectVerdict>,
+    pub retry_count: usize,
+}
+
+/// Forced-mode wrapper around [`Agent::run`]. Drives one user turn to
+/// completion, runs [`reflect_call`] on the draft answer, and — if the
+/// verdict is `Retry` and the budget hasn't been spent — re-invokes the
+/// agent with the verifier's `next_query`. The deterministic verify pass
+/// from PR #53 also runs internally so the caller can compare what each
+/// layer fired on without having to invoke them separately.
+///
+/// The retry budget is fixed at one per outer call. The second `Retry`
+/// verdict (or a malformed one that coerces to `Stop`) terminates the
+/// loop with whatever draft the agent produced last.
+pub async fn run_with_forced_reflect(
+    agent: &mut Agent,
+    initial_query: Message,
+    verify_config: &VerifyConfig,
+    provider: &AgentProvider,
+    reflect_model: &str,
+) -> Result<ForcedReflectOutcome> {
+    use crate::reflect::RETRY_BUDGET;
+
+    let history_before = agent.get_history().len();
+    let mut outputs: Vec<MessageOutput> = Vec::new();
+    let mut verdicts: Vec<ReflectVerdict> = Vec::new();
+    let mut retry_count = 0usize;
+    let mut next_query = initial_query;
+
+    loop {
+        // Drive one full turn to completion.
+        let mut stream = agent.run(next_query);
+        while let Some(item) = stream.next().await {
+            outputs.push(item?);
+        }
+        drop(stream);
+
+        // Extract the draft from the final assistant message in the new
+        // history slice. If the agent didn't emit an assistant message at
+        // all, there's nothing to verify — break with whatever we have.
+        let draft = match last_assistant_text(&agent.get_history()[history_before..]) {
+            Some(t) => t,
+            None => break,
+        };
+
+        let verdict = reflect_call(provider, reflect_model, &draft, &[]).await?;
+        verdicts.push(verdict.clone());
+
+        match verdict {
+            ReflectVerdict::Stop { .. } => break,
+            ReflectVerdict::Retry { next_query: nq, .. } => {
+                if retry_count >= RETRY_BUDGET {
+                    // Budget spent — accept the last draft regardless.
+                    break;
+                }
+                retry_count += 1;
+                next_query = Message::new(Role::User).with_contents([Part::text(nq)]);
+                // Loop continues: run a fresh turn with the verifier-supplied query.
+            }
+        }
+    }
+
+    let verify_report = verify_run(&agent.get_history()[history_before..], verify_config);
+    Ok(ForcedReflectOutcome {
+        outputs,
+        verify_report,
+        reflect_verdicts: verdicts,
+        retry_count,
+    })
+}
+
+/// Outcome of one [`run_with_hybrid`] call. Like [`ForcedReflectOutcome`]
+/// plus per-turn verify reports — Hybrid mode runs the deterministic
+/// verifier on the slice that each agent turn produced (not just the
+/// final one), so a retry triggered by the verifier's hints can be
+/// inspected against the issues the verifier saw at that point.
+#[derive(Debug)]
+pub struct HybridReflectOutcome {
+    pub outputs: Vec<MessageOutput>,
+    /// One report per agent turn, oldest first. `len()` is `1 + retry_count`.
+    pub per_turn_verify_reports: Vec<VerifyReport>,
+    /// Final-state verify report computed over the whole new history slice.
+    pub verify_report: VerifyReport,
+    pub reflect_verdicts: Vec<ReflectVerdict>,
+    pub retry_count: usize,
+    /// Set when at least one `Stop` verdict was promoted to a retry because
+    /// its `confidence` was below [`crate::reflect::HYBRID_LOW_CONFIDENCE_THRESHOLD`].
+    /// Useful in the CLI's verbose output and in tests that want to assert
+    /// the threshold is wired up correctly.
+    pub low_confidence_promotions: usize,
+}
+
+/// Hybrid wrapper. Runs the agent, verifies its output deterministically,
+/// and feeds the verifier's findings into the reflect call as hints —
+/// the LLM gets to read the deterministic flags before deciding `stop`
+/// or `retry`. Adds one rule on top of [`run_with_forced_reflect`]: a
+/// `Stop` verdict whose `confidence` is below
+/// [`crate::reflect::HYBRID_LOW_CONFIDENCE_THRESHOLD`] is promoted to a
+/// retry within the standard retry budget. The retry's `next_query`
+/// comes from the verifier itself ("you said stop with low confidence
+/// — try the same task again"), so we don't strand the loop.
+///
+/// On `Retry` the wrapper combines the verifier's `next_query` with the
+/// freshest set of deterministic hints, keeping the next attempt aware
+/// of what the previous one tripped.
+pub async fn run_with_hybrid(
+    agent: &mut Agent,
+    initial_query: Message,
+    verify_config: &VerifyConfig,
+    provider: &AgentProvider,
+    reflect_model: &str,
+) -> Result<HybridReflectOutcome> {
+    use crate::reflect::{HYBRID_LOW_CONFIDENCE_THRESHOLD, RETRY_BUDGET};
+
+    let history_before = agent.get_history().len();
+    let mut outputs: Vec<MessageOutput> = Vec::new();
+    let mut per_turn_reports: Vec<VerifyReport> = Vec::new();
+    let mut verdicts: Vec<ReflectVerdict> = Vec::new();
+    let mut retry_count = 0usize;
+    let mut low_conf_promos = 0usize;
+    let mut next_query = initial_query;
+
+    loop {
+        let turn_start = agent.get_history().len();
+
+        let mut stream = agent.run(next_query);
+        while let Some(item) = stream.next().await {
+            outputs.push(item?);
+        }
+        drop(stream);
+
+        // Verify what this single turn produced, not the whole accumulated
+        // slice — Hybrid feeds *fresh* signals into each reflect call.
+        let turn_report = verify_run(&agent.get_history()[turn_start..], verify_config);
+        let hints = render_verify_hints(&turn_report);
+        per_turn_reports.push(turn_report);
+
+        let draft = match last_assistant_text(&agent.get_history()[history_before..]) {
+            Some(t) => t,
+            None => break,
+        };
+
+        let verdict = reflect_call(provider, reflect_model, &draft, &hints).await?;
+        verdicts.push(verdict.clone());
+
+        // Promote a low-confidence Stop into a synthetic Retry — the goal
+        // is to give the agent one more shot rather than silently honour
+        // an "I'm not sure" verdict.
+        let effective_verdict = match &verdict {
+            ReflectVerdict::Stop {
+                confidence: Some(c),
+                ..
+            } if *c < HYBRID_LOW_CONFIDENCE_THRESHOLD && retry_count < RETRY_BUDGET => {
+                low_conf_promos += 1;
+                ReflectVerdict::Retry {
+                    rationale: format!(
+                        "verifier confidence {c:.2} below {HYBRID_LOW_CONFIDENCE_THRESHOLD:.2}; retrying"
+                    ),
+                    next_query: "Please reattempt the previous task more carefully — your last \
+                                 draft scored below the confidence threshold."
+                        .to_string(),
+                    confidence: Some(*c),
+                }
+            }
+            _ => verdict.clone(),
+        };
+
+        match effective_verdict {
+            ReflectVerdict::Stop { .. } => break,
+            ReflectVerdict::Retry { next_query: nq, .. } => {
+                if retry_count >= RETRY_BUDGET {
+                    break;
+                }
+                retry_count += 1;
+                // Re-pose the task; verifier hints will be regenerated from
+                // the next turn's slice when we re-enter the loop.
+                next_query = Message::new(Role::User).with_contents([Part::text(nq)]);
+            }
+        }
+    }
+
+    let verify_report = verify_run(&agent.get_history()[history_before..], verify_config);
+    Ok(HybridReflectOutcome {
+        outputs,
+        per_turn_verify_reports: per_turn_reports,
+        verify_report,
+        reflect_verdicts: verdicts,
+        retry_count,
+        low_confidence_promotions: low_conf_promos,
+    })
+}
+
+/// Render a [`VerifyReport`]'s issues as the bullet-list strings the
+/// reflect call expects. Empty report → empty vec, which means
+/// `reflect_call` falls back to its baseline (no-hints) prompt.
+fn render_verify_hints(report: &VerifyReport) -> Vec<String> {
+    if report.is_empty() {
+        return Vec::new();
+    }
+    report
+        .format()
+        .lines()
+        .filter_map(|l| l.strip_prefix("- ").map(str::to_string))
+        .collect()
+}
+
+fn last_assistant_text(history: &[Message]) -> Option<String> {
+    let msg = history
+        .iter()
+        .rev()
+        .find(|m| m.role == Role::Assistant && !m.contents.is_empty())?;
+    let mut text = String::new();
+    for part in &msg.contents {
+        if let Some(t) = part.as_text() {
+            text.push_str(t);
+        }
+    }
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Construct the `verify` [`ToolFactory`] used by [`ReflectMode::Self_`].
+/// The returned factory closes over a snapshot of the provider so each
+/// `verify` invocation can spin up its own [`ailoy::lang_model::LangModel`]
+/// for the reflect call, independent of the main agent's model.
+fn verify_tool_factory(provider: AgentProvider, reflect_model: String) -> ToolFactory {
+    let desc = ToolDescBuilder::new("verify")
+        .description(
+            "Self-check your draft answer before delivering it to the user. \
+             Returns a JSON object with `verdict` (\"stop\" or \"retry\"), \
+             `rationale`, and (when retry) `next_query`. Always call this \
+             once on your draft before emitting your final answer.",
+        )
+        .parameters(ailoy::to_value!({
+            "type": "object",
+            "properties": {
+                "draft_answer": {
+                    "type": "string",
+                    "description": "Your draft final answer, exactly as you would send it to the user."
+                }
+            },
+            "required": ["draft_answer"]
+        }))
+        .build();
+
+    let func = ToolFunc::new(move |args: Value, _ctx: ToolContext| {
+        let provider = provider.clone();
+        let reflect_model = reflect_model.clone();
+        async move {
+            let draft = args
+                .pointer("/draft_answer")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if draft.trim().is_empty() {
+                return ailoy::to_value!({
+                    "verdict": "stop",
+                    "rationale": "verify called with empty draft_answer; coerced to stop",
+                });
+            }
+            match reflect_call(&provider, &reflect_model, &draft, &[]).await {
+                Ok(verdict) => verdict_to_tool_value(&verdict),
+                Err(e) => ailoy::to_value!({
+                    "verdict": "stop",
+                    "rationale": format!("reflect_call failed: {e}; coerced to stop"),
+                }),
+            }
+        }
+    });
+
+    ToolFactory::simple(desc, func)
+}
+
+/// Render a [`ReflectVerdict`] back into the JSON object the calling LLM
+/// expects from the `verify` tool. `confidence` is included only when the
+/// verifier produced a usable value — nothing leaks for fail-open or
+/// out-of-range cases.
+fn verdict_to_tool_value(v: &ReflectVerdict) -> ailoy::datatype::Value {
+    match v {
+        ReflectVerdict::Stop {
+            rationale,
+            confidence,
+        } => match confidence {
+            Some(c) => ailoy::to_value!({
+                "verdict": "stop",
+                "rationale": rationale.as_str(),
+                "confidence": *c as f64,
+            }),
+            None => ailoy::to_value!({
+                "verdict": "stop",
+                "rationale": rationale.as_str(),
+            }),
+        },
+        ReflectVerdict::Retry {
+            rationale,
+            next_query,
+            confidence,
+        } => match confidence {
+            Some(c) => ailoy::to_value!({
+                "verdict": "retry",
+                "rationale": rationale.as_str(),
+                "next_query": next_query.as_str(),
+                "confidence": *c as f64,
+            }),
+            None => ailoy::to_value!({
+                "verdict": "retry",
+                "rationale": rationale.as_str(),
+                "next_query": next_query.as_str(),
+            }),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,5 +473,29 @@ mod tests {
         attach_default_tools(&mut provider);
         // 1 (initial bash) + 3 (default tools) = 4
         assert_eq!(provider.tools.iter().count(), 4);
+    }
+
+    /// `verify_tool_factory` should produce a [`ToolFactory`] whose name
+    /// is `"verify"` and whose schema requires the `draft_answer` field.
+    /// Doesn't run the closure (that needs an LLM); just inspects the
+    /// resolved [`Tool`] descriptor.
+    #[test]
+    fn verify_tool_factory_describes_a_verify_tool() {
+        let factory = verify_tool_factory(AgentProvider::new(), "test/model".to_string());
+        assert_eq!(factory.get_name(), "verify");
+
+        // Resolve to a Tool against an empty spec to inspect the desc.
+        let spec = ailoy::agent::AgentSpec::new("test/model");
+        let tool = factory.make(&spec);
+        let desc = tool.get_desc();
+        assert_eq!(desc.name, "verify");
+
+        let required = desc
+            .parameters
+            .pointer("/required")
+            .and_then(|v| v.as_array())
+            .expect("schema should declare required[]");
+        let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(required_names.contains(&"draft_answer"));
     }
 }

--- a/reflect-agent/src/lib.rs
+++ b/reflect-agent/src/lib.rs
@@ -3,8 +3,16 @@
 
 mod agent;
 mod provider;
+mod reflect;
 mod verify;
 
-pub use agent::{DEFAULT_MODEL, build_agent, run_with_verify};
+pub use agent::{
+    DEFAULT_MODEL, ForcedReflectOutcome, HybridReflectOutcome, build_agent, build_agent_with_mode,
+    run_with_forced_reflect, run_with_hybrid, run_with_verify,
+};
 pub use provider::register_provider_from_env;
+pub use reflect::{
+    DEFAULT_REFLECT_MODEL, HYBRID_LOW_CONFIDENCE_THRESHOLD, RETRY_BUDGET, ReflectMode,
+    ReflectVerdict, reflect_call,
+};
 pub use verify::{BashFailureReason, Issue, VerifyConfig, VerifyReport, verify_run};

--- a/reflect-agent/src/lib.rs
+++ b/reflect-agent/src/lib.rs
@@ -1,5 +1,6 @@
 //! `reflect-agent` — single lead agent built via `ailoy::agent::AgentBuilder`,
-//! with a deterministic post-hoc verify pass over each turn's history slice.
+//! with a deterministic post-hoc verify pass and an optional LLM-driven
+//! reflect gate that escalates low-confidence stops to a stronger model.
 
 mod agent;
 mod provider;
@@ -7,12 +8,12 @@ mod reflect;
 mod verify;
 
 pub use agent::{
-    DEFAULT_MODEL, ForcedReflectOutcome, HybridReflectOutcome, build_agent, build_agent_with_mode,
-    run_with_forced_reflect, run_with_hybrid, run_with_verify,
+    DEFAULT_MODEL, ForcedReflectOutcome, build_agent, build_agent_with_mode,
+    run_with_forced_reflect, run_with_verify,
 };
 pub use provider::register_provider_from_env;
 pub use reflect::{
-    DEFAULT_REFLECT_MODEL, HYBRID_LOW_CONFIDENCE_THRESHOLD, RETRY_BUDGET, ReflectMode,
-    ReflectVerdict, reflect_call,
+    DEFAULT_ESCALATE_MODEL, DEFAULT_REFLECT_MODEL, LOW_CONFIDENCE_THRESHOLD, ReflectMode,
+    ReflectVerdict, RETRY_BUDGET, reflect_call,
 };
 pub use verify::{BashFailureReason, Issue, VerifyConfig, VerifyReport, verify_run};

--- a/reflect-agent/src/main.rs
+++ b/reflect-agent/src/main.rs
@@ -8,11 +8,10 @@
 //! # Override model
 //! cargo run -p reflect-agent -- --model openai/gpt-4o-mini
 //!
-//! # Choose reflect mode (off | self | forced)
-//! cargo run -p reflect-agent -- --reflect-mode self  --query "..."
+//! # Choose reflect mode (off | forced)
 //! cargo run -p reflect-agent -- --reflect-mode forced --query "..."
 //!
-//! # Show both verify and reflect outputs (regardless of mode)
+//! # Show both verify and reflect outputs in forced mode
 //! cargo run -p reflect-agent -- --reflect-mode forced --verbose --query "..."
 //! ```
 
@@ -23,8 +22,8 @@ use ailoy::{
 use anyhow::Result;
 use clap::Parser;
 use reflect_agent::{
-    DEFAULT_MODEL, DEFAULT_REFLECT_MODEL, ReflectMode, VerifyConfig, VerifyReport,
-    build_agent_with_mode, register_provider_from_env, run_with_forced_reflect, run_with_hybrid,
+    DEFAULT_ESCALATE_MODEL, DEFAULT_MODEL, DEFAULT_REFLECT_MODEL, ReflectMode, VerifyConfig,
+    VerifyReport, build_agent_with_mode, register_provider_from_env, run_with_forced_reflect,
     run_with_verify,
 };
 use rustyline::{DefaultEditor, error::ReadlineError};
@@ -32,7 +31,7 @@ use rustyline::{DefaultEditor, error::ReadlineError};
 #[derive(Parser)]
 #[command(
     name = "reflect-agent",
-    about = "Single lead agent with bash + python + web_search tools, plus optional verify/reflect gates"
+    about = "Single lead agent with bash + python + web_search tools and a post-hoc verify gate"
 )]
 struct Cli {
     /// Language model id, e.g. `openai/gpt-4o-mini`,
@@ -44,17 +43,22 @@ struct Cli {
     #[arg(long)]
     query: Option<String>,
 
-    /// Reflect strategy: `off` (default), `self` (verify tool + system
-    /// prompt), or `forced` (wrapper-driven retry budget = 1).
+    /// Reflect strategy: `off` (default) or `forced` (Haiku reflect after
+    /// each turn, with low-confidence Stops escalating to a stronger model).
     #[arg(long, default_value = "off")]
     reflect_mode: String,
 
-    /// Model used for the reflect call in `self` and `forced` modes.
+    /// First-pass reflect model used in `forced` mode.
     #[arg(long, default_value = DEFAULT_REFLECT_MODEL)]
     reflect_model: String,
 
+    /// Stronger model invoked when the first-pass verdict's confidence
+    /// falls below the escalation threshold.
+    #[arg(long, default_value = DEFAULT_ESCALATE_MODEL)]
+    escalate_model: String,
+
     /// Always emit the verify report to stderr, even when reflect mode is
-    /// `self` or `forced`. Useful for comparing what each layer flags.
+    /// `forced`. Useful for comparing what each layer flags.
     #[arg(long)]
     verbose: bool,
 }
@@ -78,7 +82,15 @@ async fn main() -> Result<()> {
     let mut agent = build_agent_with_mode(&cli.model, mode).await?;
 
     if let Some(q) = cli.query {
-        run_query(&mut agent, &q, mode, &cli.reflect_model, cli.verbose).await?;
+        run_query(
+            &mut agent,
+            &q,
+            mode,
+            &cli.reflect_model,
+            &cli.escalate_model,
+            cli.verbose,
+        )
+        .await?;
         return Ok(());
     }
 
@@ -105,7 +117,16 @@ async fn main() -> Result<()> {
         if line == "/exit" {
             break;
         }
-        if let Err(e) = run_query(&mut agent, &line, mode, &cli.reflect_model, cli.verbose).await {
+        if let Err(e) = run_query(
+            &mut agent,
+            &line,
+            mode,
+            &cli.reflect_model,
+            &cli.escalate_model,
+            cli.verbose,
+        )
+        .await
+        {
             eprintln!("ERROR: {e}");
         }
     }
@@ -116,64 +137,50 @@ async fn main() -> Result<()> {
 
 /// Stream one user turn through the chosen reflect mode and print:
 ///
-/// - assistant text + tool-call markers on stdout (every mode);
+/// - assistant text + tool-call markers on stdout;
 /// - verify report on stderr — always in `off`, only with `--verbose` in
-///   the LLM-driven modes;
-/// - reflect verdicts on stderr — only when `forced` mode actually emits
-///   them (`self` mode's verdicts surface as tool results in the stdout
-///   stream, so they don't need a separate channel).
+///   `forced`;
+/// - reflect verdicts on stderr in `forced` (with the escalation count
+///   when at least one fired).
 async fn run_query(
     agent: &mut Agent,
     input: &str,
     mode: ReflectMode,
     reflect_model: &str,
+    escalate_model: &str,
     verbose: bool,
 ) -> Result<()> {
     let query = Message::new(Role::User).with_contents([Part::text(input)]);
     let verify_config = VerifyConfig::default();
 
     match mode {
-        ReflectMode::Off | ReflectMode::Self_ => {
-            // Both modes use the same outer driver. The difference is at
-            // build_agent_with_mode time (Self_ added the verify tool +
-            // system prompt). At run time we just stream and verify.
+        ReflectMode::Off => {
             let (outputs, report) = run_with_verify(agent, query, &verify_config).await?;
             print_assistant_stream(&outputs);
-            // Off: always show the verify report. Self_: only with --verbose.
-            let show_verify = matches!(mode, ReflectMode::Off) || verbose;
-            if show_verify {
-                print_verify_report(&report);
-            }
+            print_verify_report(&report);
         }
         ReflectMode::Forced => {
             let provider: AgentProvider = default_provider().await.clone();
-            let outcome =
-                run_with_forced_reflect(agent, query, &verify_config, &provider, reflect_model)
-                    .await?;
+            let outcome = run_with_forced_reflect(
+                agent,
+                query,
+                &verify_config,
+                &provider,
+                reflect_model,
+                escalate_model,
+            )
+            .await?;
             print_assistant_stream(&outcome.outputs);
-            // Reflect verdicts always print in forced mode (that's the point).
             print_reflect_verdicts(&outcome.reflect_verdicts, outcome.retry_count);
-            // Verify report only with --verbose to keep the comparison clean.
+            if outcome.escalations > 0 {
+                eprintln!(
+                    "       (escalated {} low-confidence stop(s) to {})",
+                    outcome.escalations, escalate_model
+                );
+            }
             if verbose {
                 print_verify_report(&outcome.verify_report);
             }
-        }
-        ReflectMode::Hybrid => {
-            let provider: AgentProvider = default_provider().await.clone();
-            let outcome =
-                run_with_hybrid(agent, query, &verify_config, &provider, reflect_model).await?;
-            print_assistant_stream(&outcome.outputs);
-            // Hybrid is the comparison mode, so its outputs always include
-            // both verdicts *and* the verifier's per-turn findings — that's
-            // the entire point of using this mode.
-            print_reflect_verdicts(&outcome.reflect_verdicts, outcome.retry_count);
-            if outcome.low_confidence_promotions > 0 {
-                eprintln!(
-                    "       (promoted {} low-confidence stop(s) into retries)",
-                    outcome.low_confidence_promotions
-                );
-            }
-            print_verify_report(&outcome.verify_report);
         }
     }
 

--- a/reflect-agent/src/main.rs
+++ b/reflect-agent/src/main.rs
@@ -2,28 +2,37 @@
 //! # Interactive REPL with default model
 //! cargo run -p reflect-agent
 //!
-//! # Single query (non-interactive), useful for scripts and tests
+//! # Single query (non-interactive), useful for smoke tests / scripts
 //! cargo run -p reflect-agent -- --query "What is 2 + 2?"
 //!
 //! # Override model
 //! cargo run -p reflect-agent -- --model openai/gpt-4o-mini
+//!
+//! # Choose reflect mode (off | self | forced)
+//! cargo run -p reflect-agent -- --reflect-mode self  --query "..."
+//! cargo run -p reflect-agent -- --reflect-mode forced --query "..."
+//!
+//! # Show both verify and reflect outputs (regardless of mode)
+//! cargo run -p reflect-agent -- --reflect-mode forced --verbose --query "..."
 //! ```
 
 use ailoy::{
-    agent::default_provider_mut,
+    agent::{Agent, AgentProvider, default_provider, default_provider_mut},
     message::{Message, Part, Role},
 };
 use anyhow::Result;
 use clap::Parser;
 use reflect_agent::{
-    DEFAULT_MODEL, VerifyConfig, build_agent, register_provider_from_env, run_with_verify,
+    DEFAULT_MODEL, DEFAULT_REFLECT_MODEL, ReflectMode, VerifyConfig, VerifyReport,
+    build_agent_with_mode, register_provider_from_env, run_with_forced_reflect, run_with_hybrid,
+    run_with_verify,
 };
 use rustyline::{DefaultEditor, error::ReadlineError};
 
 #[derive(Parser)]
 #[command(
     name = "reflect-agent",
-    about = "Single lead agent with bash + python + web_search tools and a post-hoc verify gate"
+    about = "Single lead agent with bash + python + web_search tools, plus optional verify/reflect gates"
 )]
 struct Cli {
     /// Language model id, e.g. `openai/gpt-4o-mini`,
@@ -31,10 +40,23 @@ struct Cli {
     #[arg(long, default_value = DEFAULT_MODEL)]
     model: String,
 
-    /// Run a single query non-interactively and exit. Useful for smoke tests
-    /// and scripted workflows.
+    /// Run a single query non-interactively and exit.
     #[arg(long)]
     query: Option<String>,
+
+    /// Reflect strategy: `off` (default), `self` (verify tool + system
+    /// prompt), or `forced` (wrapper-driven retry budget = 1).
+    #[arg(long, default_value = "off")]
+    reflect_mode: String,
+
+    /// Model used for the reflect call in `self` and `forced` modes.
+    #[arg(long, default_value = DEFAULT_REFLECT_MODEL)]
+    reflect_model: String,
+
+    /// Always emit the verify report to stderr, even when reflect mode is
+    /// `self` or `forced`. Useful for comparing what each layer flags.
+    #[arg(long)]
+    verbose: bool,
 }
 
 #[tokio::main]
@@ -49,19 +71,23 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+    let mode = ReflectMode::parse(&cli.reflect_mode)?;
 
-    // Populate ailoy's process-global provider once at boot.
     register_provider_from_env(&mut *default_provider_mut().await);
 
-    let mut agent = build_agent(&cli.model).await?;
+    let mut agent = build_agent_with_mode(&cli.model, mode).await?;
 
     if let Some(q) = cli.query {
-        run_query(&mut agent, &q).await?;
+        run_query(&mut agent, &q, mode, &cli.reflect_model, cli.verbose).await?;
         return Ok(());
     }
 
     println!();
-    println!("  reflect-agent  |  model: {}", cli.model);
+    println!(
+        "  reflect-agent  |  model: {}  |  reflect: {}",
+        cli.model,
+        mode.as_str()
+    );
     println!("  Commands: /exit");
     println!("  {}", "─".repeat(60));
 
@@ -79,7 +105,7 @@ async fn main() -> Result<()> {
         if line == "/exit" {
             break;
         }
-        if let Err(e) = run_query(&mut agent, &line).await {
+        if let Err(e) = run_query(&mut agent, &line, mode, &cli.reflect_model, cli.verbose).await {
             eprintln!("ERROR: {e}");
         }
     }
@@ -88,15 +114,74 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Stream one user turn, print assistant text + tool-call markers, and
-/// emit the verify report to stderr only when at least one issue was
-/// flagged (otherwise stderr stays clean).
-async fn run_query(agent: &mut ailoy::agent::Agent, input: &str) -> Result<()> {
+/// Stream one user turn through the chosen reflect mode and print:
+///
+/// - assistant text + tool-call markers on stdout (every mode);
+/// - verify report on stderr — always in `off`, only with `--verbose` in
+///   the LLM-driven modes;
+/// - reflect verdicts on stderr — only when `forced` mode actually emits
+///   them (`self` mode's verdicts surface as tool results in the stdout
+///   stream, so they don't need a separate channel).
+async fn run_query(
+    agent: &mut Agent,
+    input: &str,
+    mode: ReflectMode,
+    reflect_model: &str,
+    verbose: bool,
+) -> Result<()> {
     let query = Message::new(Role::User).with_contents([Part::text(input)]);
-    let config = VerifyConfig::default();
-    let (outputs, report) = run_with_verify(agent, query, &config).await?;
+    let verify_config = VerifyConfig::default();
 
-    for output in &outputs {
+    match mode {
+        ReflectMode::Off | ReflectMode::Self_ => {
+            // Both modes use the same outer driver. The difference is at
+            // build_agent_with_mode time (Self_ added the verify tool +
+            // system prompt). At run time we just stream and verify.
+            let (outputs, report) = run_with_verify(agent, query, &verify_config).await?;
+            print_assistant_stream(&outputs);
+            // Off: always show the verify report. Self_: only with --verbose.
+            let show_verify = matches!(mode, ReflectMode::Off) || verbose;
+            if show_verify {
+                print_verify_report(&report);
+            }
+        }
+        ReflectMode::Forced => {
+            let provider: AgentProvider = default_provider().await.clone();
+            let outcome =
+                run_with_forced_reflect(agent, query, &verify_config, &provider, reflect_model)
+                    .await?;
+            print_assistant_stream(&outcome.outputs);
+            // Reflect verdicts always print in forced mode (that's the point).
+            print_reflect_verdicts(&outcome.reflect_verdicts, outcome.retry_count);
+            // Verify report only with --verbose to keep the comparison clean.
+            if verbose {
+                print_verify_report(&outcome.verify_report);
+            }
+        }
+        ReflectMode::Hybrid => {
+            let provider: AgentProvider = default_provider().await.clone();
+            let outcome =
+                run_with_hybrid(agent, query, &verify_config, &provider, reflect_model).await?;
+            print_assistant_stream(&outcome.outputs);
+            // Hybrid is the comparison mode, so its outputs always include
+            // both verdicts *and* the verifier's per-turn findings — that's
+            // the entire point of using this mode.
+            print_reflect_verdicts(&outcome.reflect_verdicts, outcome.retry_count);
+            if outcome.low_confidence_promotions > 0 {
+                eprintln!(
+                    "       (promoted {} low-confidence stop(s) into retries)",
+                    outcome.low_confidence_promotions
+                );
+            }
+            print_verify_report(&outcome.verify_report);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_assistant_stream(outputs: &[ailoy::message::MessageOutput]) {
+    for output in outputs {
         let msg = &output.message;
         if msg.role != Role::Assistant {
             continue;
@@ -117,10 +202,38 @@ async fn run_query(agent: &mut ailoy::agent::Agent, input: &str) -> Result<()> {
         }
     }
     println!();
+}
 
-    if !report.is_empty() {
-        eprintln!("\n─── verify gate findings ───");
-        eprint!("{}", report.format());
+fn print_verify_report(report: &VerifyReport) {
+    if report.is_empty() {
+        return;
     }
-    Ok(())
+    eprintln!("\n─── verify gate findings ───");
+    eprint!("{}", report.format());
+}
+
+fn print_reflect_verdicts(verdicts: &[reflect_agent::ReflectVerdict], retry_count: usize) {
+    if verdicts.is_empty() {
+        return;
+    }
+    eprintln!("\n─── reflect gate verdicts (retries: {}) ───", retry_count);
+    for (i, v) in verdicts.iter().enumerate() {
+        let conf = match v.confidence() {
+            Some(c) => format!(" (conf={c:.2})"),
+            None => String::new(),
+        };
+        match v {
+            reflect_agent::ReflectVerdict::Stop { rationale, .. } => {
+                eprintln!("- [{i}] stop{conf}: {rationale}");
+            }
+            reflect_agent::ReflectVerdict::Retry {
+                rationale,
+                next_query,
+                ..
+            } => {
+                eprintln!("- [{i}] retry{conf}: {rationale}");
+                eprintln!("       next_query: {next_query}");
+            }
+        }
+    }
 }

--- a/reflect-agent/src/reflect.rs
+++ b/reflect-agent/src/reflect.rs
@@ -1,0 +1,490 @@
+//! LLM-driven reflect gate (Phase 2 of the reflect-agent design).
+//!
+//! Two modes are exposed:
+//!
+//! - **`Self_`** — the agent's `bash` / `python_repl` / `web_search` tool set
+//!   gains a fourth tool, `verify`, and the system prompt instructs the LLM
+//!   to call it before emitting the final answer. The LLM decides when to
+//!   invoke the verify pass; if it doesn't, the gate is bypassed.
+//!
+//! - **`Forced`** — `Agent::run` is wrapped on the outside. After the agent
+//!   finishes a turn, the wrapper unconditionally runs a separate LLM call
+//!   on the draft answer and gets a [`ReflectVerdict`] back. On `Retry`,
+//!   the wrapper re-invokes the agent with `next_query`. The retry budget
+//!   is fixed at one re-attempt per user turn.
+//!
+//! Both modes share [`reflect_call`] — the JSON-shaped LLM critique that
+//! emits a `stop` / `retry` verdict — and [`ReflectVerdict`] parsing.
+
+use ailoy::{
+    agent::AgentProvider,
+    lang_model::LangModel,
+    message::{Message, Part, Role},
+};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// Default LLM used by the reflect call. Cheap enough that one extra call
+/// per turn is acceptable; same model family as the main agent so that the
+/// global provider already covers it.
+pub const DEFAULT_REFLECT_MODEL: &str = "anthropic/claude-haiku-4-5-20251001";
+
+/// Maximum number of `Retry` verdicts honoured per user turn. The second
+/// `Retry` is silently coerced to `Stop`. Mirrors the budget the rest of
+/// the verify-gate work uses.
+pub const RETRY_BUDGET: usize = 1;
+
+/// Which reflect strategy to apply to a turn.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ReflectMode {
+    /// No LLM-driven reflect. The deterministic [`crate::verify_run`] pass
+    /// from PR #53 still runs; this mode is what the CLI defaults to.
+    #[default]
+    Off,
+    /// `verify` tool registered on the agent + system prompt instructs the
+    /// LLM to call it before final emission. LLM-self-discipline driven.
+    Self_,
+    /// Wrapper around `Agent::run` that unconditionally runs [`reflect_call`]
+    /// on the draft answer after the turn finishes. Strict but blind to
+    /// what the deterministic verify pass already noticed.
+    Forced,
+    /// Forced behaviour plus the deterministic verifier's findings get
+    /// passed into the reflect call as hints, and a low-confidence `Stop`
+    /// (below [`HYBRID_LOW_CONFIDENCE_THRESHOLD`]) is treated as a
+    /// retry within the standard budget. The two layers (deterministic
+    /// verify + LLM reflect) work together rather than in parallel.
+    Hybrid,
+}
+
+impl ReflectMode {
+    /// Lower-case CLI label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReflectMode::Off => "off",
+            ReflectMode::Self_ => "self",
+            ReflectMode::Forced => "forced",
+            ReflectMode::Hybrid => "hybrid",
+        }
+    }
+
+    /// Parse the `--reflect-mode` CLI value.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "off" => Ok(ReflectMode::Off),
+            "self" => Ok(ReflectMode::Self_),
+            "forced" => Ok(ReflectMode::Forced),
+            "hybrid" => Ok(ReflectMode::Hybrid),
+            other => anyhow::bail!(
+                "unknown reflect mode: {other:?} (expected off|self|forced|hybrid)"
+            ),
+        }
+    }
+}
+
+/// Outcome of one reflect call. `Stop` means the draft can be returned to
+/// the user; `Retry` carries a re-posed query for the agent to run again.
+///
+/// `confidence` is an `Option<f32>` in `[0.0, 1.0]`. The verifier LLM is
+/// asked to emit it but is allowed to omit it — older verdicts produced
+/// before the field was introduced still parse cleanly. Hybrid mode reads
+/// it to decide whether a `Stop` verdict is strong enough to honour;
+/// other modes treat low-confidence stops the same as high-confidence
+/// ones.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ReflectVerdict {
+    Stop {
+        rationale: String,
+        confidence: Option<f32>,
+    },
+    Retry {
+        rationale: String,
+        next_query: String,
+        confidence: Option<f32>,
+    },
+}
+
+impl ReflectVerdict {
+    pub fn is_retry(&self) -> bool {
+        matches!(self, ReflectVerdict::Retry { .. })
+    }
+
+    pub fn rationale(&self) -> &str {
+        match self {
+            ReflectVerdict::Stop { rationale, .. } => rationale,
+            ReflectVerdict::Retry { rationale, .. } => rationale,
+        }
+    }
+
+    pub fn confidence(&self) -> Option<f32> {
+        match self {
+            ReflectVerdict::Stop { confidence, .. } => *confidence,
+            ReflectVerdict::Retry { confidence, .. } => *confidence,
+        }
+    }
+}
+
+/// Threshold under which Hybrid mode treats a `Stop` verdict as "not
+/// confident enough" and forces a retry (within the standard retry
+/// budget). Picked at 0.7 to match the loose convention in Codex's
+/// `review_prompt.md` evaluator: low-confidence assessments shouldn't
+/// be allowed to silently end the turn. Other modes ignore this.
+pub const HYBRID_LOW_CONFIDENCE_THRESHOLD: f32 = 0.7;
+
+/// Wire-format expected from the reflect LLM. We keep the parsing tolerant —
+/// trailing prose, mixed casing, missing `next_query` on a `Stop`
+/// verdict, and missing/out-of-range `confidence` are all accepted. A
+/// malformed payload coerces to `Stop` so the gate fails open rather
+/// than erroring out the whole turn.
+#[derive(Debug, Serialize, Deserialize)]
+struct WireVerdict {
+    verdict: String,
+    #[serde(default)]
+    rationale: String,
+    #[serde(default)]
+    next_query: String,
+    /// Optional. Verifier's self-rated confidence in `[0.0, 1.0]`. Out-of
+    /// -range values are rejected at parse time and become `None`.
+    #[serde(default)]
+    confidence: Option<f32>,
+}
+
+const REFLECT_SYSTEM_PROMPT: &str = "\
+You are a verification assistant. Read the draft answer below and decide \
+whether it can be sent to the user as-is.
+
+Output a single JSON object with these fields:
+  - verdict:    \"stop\" or \"retry\"
+  - rationale:  one short sentence explaining the choice
+  - next_query: only when verdict is \"retry\"; a re-posed task that fixes the issue
+  - confidence: a number in [0.0, 1.0] expressing how sure you are of the verdict
+
+Choose \"stop\" when the draft answers the user's question correctly and is \
+self-consistent with the cited evidence. Choose \"retry\" when the draft \
+contains errors, leaves the user's question unanswered, or cites sources \
+that do not exist in the trajectory. Use a confidence below 0.7 only when \
+you genuinely cannot tell whether the draft is right. Output JSON only — \
+no prose around it.";
+
+/// Run one reflect call. The LLM sees the draft answer plus, optionally,
+/// a list of deterministic-verifier hints — typically the rendered
+/// findings from a [`crate::VerifyReport`] when called from Hybrid mode.
+/// Pass an empty slice in modes (Self / Forced) that don't have a verify
+/// pass paired with the call.
+pub async fn reflect_call(
+    provider: &AgentProvider,
+    model_id: &str,
+    draft_answer: &str,
+    verify_hints: &[String],
+) -> Result<ReflectVerdict> {
+    let model: LangModel = provider.models.make_runtime(model_id)?;
+    let user_text = if verify_hints.is_empty() {
+        format!("Draft answer to verify:\n\n{}", draft_answer)
+    } else {
+        let mut hints = String::new();
+        for h in verify_hints {
+            hints.push_str("- ");
+            hints.push_str(h);
+            hints.push('\n');
+        }
+        format!(
+            "A deterministic pre-checker has already flagged the following \
+             potential issues with this turn — weigh them when judging the \
+             draft, but remember they can be false positives (e.g. when the \
+             user explicitly asked for a failing command). Use them as \
+             inputs, not verdicts.\n\nVerifier flags:\n{}\nDraft answer to \
+             verify:\n\n{}",
+            hints.trim_end(),
+            draft_answer
+        )
+    };
+    let messages = vec![
+        Message::new(Role::System).with_contents([Part::text(REFLECT_SYSTEM_PROMPT)]),
+        Message::new(Role::User).with_contents([Part::text(user_text)]),
+    ];
+    let output = model.run(&messages, &[]).await?;
+    let raw = collect_assistant_text(&output.message);
+    Ok(parse_verdict(&raw))
+}
+
+fn collect_assistant_text(msg: &Message) -> String {
+    let mut out = String::new();
+    for part in &msg.contents {
+        if let Some(t) = part.as_text() {
+            out.push_str(t);
+        }
+    }
+    out
+}
+
+/// Pull the first `{...}` block out of the raw LLM response and parse it.
+/// On any failure we fall back to `Stop` with a synthetic rationale —
+/// keeping the gate fail-open is preferable to erroring an entire user
+/// turn just because the verifier produced loose JSON.
+fn parse_verdict(raw: &str) -> ReflectVerdict {
+    let trimmed = raw.trim();
+    let json_slice = match (trimmed.find('{'), trimmed.rfind('}')) {
+        (Some(l), Some(r)) if l < r => &trimmed[l..=r],
+        _ => return fallback_stop("verifier produced no JSON"),
+    };
+    let wire: WireVerdict = match serde_json::from_str(json_slice) {
+        Ok(v) => v,
+        Err(_) => return fallback_stop("verifier produced malformed JSON"),
+    };
+    let confidence = sanitize_confidence(wire.confidence);
+    match wire.verdict.trim().to_ascii_lowercase().as_str() {
+        "stop" => ReflectVerdict::Stop {
+            rationale: trim_or_default(&wire.rationale, "ok"),
+            confidence,
+        },
+        "retry" => {
+            let next_query = wire.next_query.trim();
+            if next_query.is_empty() {
+                // No actionable retry — coerce to Stop with a rationale that
+                // names the missing field, so the caller sees what happened.
+                return ReflectVerdict::Stop {
+                    rationale: format!(
+                        "verifier asked for retry without next_query; coerced to stop ({})",
+                        trim_or_default(&wire.rationale, "no rationale")
+                    ),
+                    confidence,
+                };
+            }
+            ReflectVerdict::Retry {
+                rationale: trim_or_default(&wire.rationale, "needs another attempt"),
+                next_query: next_query.to_string(),
+                confidence,
+            }
+        }
+        other => ReflectVerdict::Stop {
+            rationale: format!("unknown verdict {other:?}; coerced to stop"),
+            confidence,
+        },
+    }
+}
+
+/// Drop NaN, infinities, and out-of-range values; clamp anything else
+/// inside [0.0, 1.0] to itself. Tolerant on purpose so a verifier emitting
+/// `1.05` or `-0.1` is read as "no usable confidence" rather than poison.
+fn sanitize_confidence(c: Option<f32>) -> Option<f32> {
+    let v = c?;
+    if v.is_finite() && (0.0..=1.0).contains(&v) {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+fn fallback_stop(reason: &str) -> ReflectVerdict {
+    // Fail-open verdicts have no claim to high confidence — leave it as
+    // None so Hybrid mode doesn't silently honour a synthetic stop.
+    ReflectVerdict::Stop {
+        rationale: reason.to_string(),
+        confidence: None,
+    }
+}
+
+fn trim_or_default(s: &str, default_: &str) -> String {
+    let t = s.trim();
+    if t.is_empty() {
+        default_.to_string()
+    } else {
+        t.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ReflectMode parsing ───────────────────────────────────────────────
+
+    #[test]
+    fn mode_round_trip() {
+        for m in [ReflectMode::Off, ReflectMode::Self_, ReflectMode::Forced] {
+            assert_eq!(ReflectMode::parse(m.as_str()).unwrap(), m);
+        }
+    }
+
+    #[test]
+    fn mode_parse_rejects_unknown() {
+        assert!(ReflectMode::parse("nope").is_err());
+        assert!(ReflectMode::parse("").is_err());
+    }
+
+    #[test]
+    fn mode_default_is_off() {
+        assert_eq!(ReflectMode::default(), ReflectMode::Off);
+    }
+
+    // ── verdict parsing — happy paths ─────────────────────────────────────
+
+    #[test]
+    fn stop_verdict_is_parsed() {
+        let v = parse_verdict(r#"{"verdict": "stop", "rationale": "looks good"}"#);
+        assert_eq!(
+            v,
+            ReflectVerdict::Stop {
+                rationale: "looks good".into(),
+                confidence: None,
+            }
+        );
+        assert!(!v.is_retry());
+        assert_eq!(v.confidence(), None);
+    }
+
+    #[test]
+    fn retry_verdict_is_parsed() {
+        let v = parse_verdict(
+            r#"{"verdict": "retry", "rationale": "missing source", "next_query": "look up X"}"#,
+        );
+        assert_eq!(
+            v,
+            ReflectVerdict::Retry {
+                rationale: "missing source".into(),
+                next_query: "look up X".into(),
+                confidence: None,
+            }
+        );
+        assert!(v.is_retry());
+    }
+
+    #[test]
+    fn verdict_extracts_json_from_surrounding_prose() {
+        let v = parse_verdict(
+            "Sure, here's my verdict: {\"verdict\": \"stop\", \"rationale\": \"clean\"} done.",
+        );
+        assert!(matches!(v, ReflectVerdict::Stop { .. }));
+        assert_eq!(v.rationale(), "clean");
+    }
+
+    #[test]
+    fn verdict_is_case_insensitive() {
+        let v = parse_verdict(r#"{"verdict": "STOP", "rationale": "ok"}"#);
+        assert!(matches!(v, ReflectVerdict::Stop { .. }));
+    }
+
+    // ── verdict parsing — fail-open coercions ─────────────────────────────
+
+    #[test]
+    fn malformed_json_coerces_to_stop() {
+        let v = parse_verdict("not json at all");
+        assert!(matches!(v, ReflectVerdict::Stop { .. }));
+        assert!(v.rationale().contains("no JSON"));
+    }
+
+    #[test]
+    fn invalid_json_inside_braces_coerces_to_stop() {
+        let v = parse_verdict("{verdict: stop, no quotes}");
+        assert!(matches!(v, ReflectVerdict::Stop { .. }));
+        assert!(v.rationale().contains("malformed JSON"));
+    }
+
+    #[test]
+    fn unknown_verdict_value_coerces_to_stop() {
+        let v = parse_verdict(r#"{"verdict": "maybe", "rationale": "?"}"#);
+        assert!(matches!(v, ReflectVerdict::Stop { .. }));
+        assert!(v.rationale().contains("unknown verdict"));
+    }
+
+    #[test]
+    fn retry_without_next_query_coerces_to_stop() {
+        // No actionable retry — gate fails open rather than looping forever.
+        let v = parse_verdict(r#"{"verdict": "retry", "rationale": "needs more"}"#);
+        assert!(matches!(v, ReflectVerdict::Stop { .. }));
+        assert!(v.rationale().contains("without next_query"));
+    }
+
+    #[test]
+    fn empty_rationale_gets_default() {
+        let v = parse_verdict(r#"{"verdict": "stop", "rationale": ""}"#);
+        assert_eq!(v.rationale(), "ok");
+    }
+
+    #[test]
+    fn missing_rationale_gets_default() {
+        // serde default = empty string; trim_or_default fills it in.
+        let v = parse_verdict(r#"{"verdict": "stop"}"#);
+        assert_eq!(v.rationale(), "ok");
+    }
+
+    // ── confidence parsing ────────────────────────────────────────────────
+
+    #[test]
+    fn confidence_is_parsed_when_in_range() {
+        let v = parse_verdict(r#"{"verdict": "stop", "rationale": "ok", "confidence": 0.83}"#);
+        assert_eq!(v.confidence(), Some(0.83));
+    }
+
+    #[test]
+    fn confidence_passes_through_on_retry() {
+        let v = parse_verdict(
+            r#"{"verdict": "retry", "rationale": "needs work", "next_query": "redo it", "confidence": 0.42}"#,
+        );
+        assert_eq!(v.confidence(), Some(0.42));
+        assert!(v.is_retry());
+    }
+
+    #[test]
+    fn confidence_missing_yields_none() {
+        let v = parse_verdict(r#"{"verdict": "stop", "rationale": "ok"}"#);
+        assert_eq!(v.confidence(), None);
+    }
+
+    #[test]
+    fn confidence_above_one_is_dropped() {
+        let v = parse_verdict(r#"{"verdict": "stop", "rationale": "ok", "confidence": 1.5}"#);
+        assert_eq!(v.confidence(), None);
+    }
+
+    #[test]
+    fn confidence_negative_is_dropped() {
+        let v = parse_verdict(r#"{"verdict": "stop", "rationale": "ok", "confidence": -0.1}"#);
+        assert_eq!(v.confidence(), None);
+    }
+
+    #[test]
+    fn confidence_at_boundaries_is_kept() {
+        assert_eq!(
+            parse_verdict(r#"{"verdict": "stop", "rationale": "ok", "confidence": 0.0}"#)
+                .confidence(),
+            Some(0.0)
+        );
+        assert_eq!(
+            parse_verdict(r#"{"verdict": "stop", "rationale": "ok", "confidence": 1.0}"#)
+                .confidence(),
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn fallback_stop_has_no_confidence() {
+        // Fail-open paths must not claim a confidence — Hybrid mode would
+        // otherwise treat synthetic verdicts as decisively as real ones.
+        let v = parse_verdict("not json at all");
+        assert_eq!(v.confidence(), None);
+    }
+
+    // ── budget + threshold constants — referenced by run_with_*_reflect ───
+
+    #[test]
+    fn retry_budget_is_one() {
+        // Pinned at 1 to avoid surprise looping. If this number ever needs
+        // to change, do it deliberately.
+        assert_eq!(RETRY_BUDGET, 1);
+    }
+
+    #[test]
+    fn hybrid_threshold_is_seven_tenths() {
+        // Hybrid mode's "low confidence → retry" threshold. Loose convention
+        // from Codex's review_prompt.md evaluator. Change deliberately.
+        assert!((HYBRID_LOW_CONFIDENCE_THRESHOLD - 0.7).abs() < f32::EPSILON);
+    }
+
+    // ── ReflectMode coverage ──────────────────────────────────────────────
+
+    #[test]
+    fn hybrid_mode_round_trips() {
+        assert_eq!(ReflectMode::parse("hybrid").unwrap(), ReflectMode::Hybrid);
+        assert_eq!(ReflectMode::Hybrid.as_str(), "hybrid");
+    }
+}

--- a/reflect-agent/src/reflect.rs
+++ b/reflect-agent/src/reflect.rs
@@ -1,20 +1,16 @@
-//! LLM-driven reflect gate (Phase 2 of the reflect-agent design).
+//! LLM-driven reflect gate.
 //!
-//! Two modes are exposed:
+//! One mode is exposed: **`Forced`** — `Agent::run` is wrapped on the
+//! outside, and after each turn a Haiku reflect call examines the draft.
+//! When the draft's reported confidence falls below
+//! [`LOW_CONFIDENCE_THRESHOLD`], a stronger model (Sonnet by default)
+//! re-examines the same draft and the stronger verdict is final.
+//! Sonnet's `stop` is honoured; a Sonnet `retry` verdict is ignored
+//! because in our calibration data the retry path never recovered the
+//! answer.
 //!
-//! - **`Self_`** — the agent's `bash` / `python_repl` / `web_search` tool set
-//!   gains a fourth tool, `verify`, and the system prompt instructs the LLM
-//!   to call it before emitting the final answer. The LLM decides when to
-//!   invoke the verify pass; if it doesn't, the gate is bypassed.
-//!
-//! - **`Forced`** — `Agent::run` is wrapped on the outside. After the agent
-//!   finishes a turn, the wrapper unconditionally runs a separate LLM call
-//!   on the draft answer and gets a [`ReflectVerdict`] back. On `Retry`,
-//!   the wrapper re-invokes the agent with `next_query`. The retry budget
-//!   is fixed at one re-attempt per user turn.
-//!
-//! Both modes share [`reflect_call`] — the JSON-shaped LLM critique that
-//! emits a `stop` / `retry` verdict — and [`ReflectVerdict`] parsing.
+//! [`reflect_call`] performs the JSON-shaped LLM critique and
+//! [`ReflectVerdict`] is the parsed result.
 
 use ailoy::{
     agent::AgentProvider,
@@ -24,15 +20,27 @@ use ailoy::{
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-/// Default LLM used by the reflect call. Cheap enough that one extra call
-/// per turn is acceptable; same model family as the main agent so that the
-/// global provider already covers it.
+/// Default LLM used by the first-pass reflect call. Same family as the
+/// main agent so the global provider already covers it.
 pub const DEFAULT_REFLECT_MODEL: &str = "anthropic/claude-haiku-4-5-20251001";
 
-/// Maximum number of `Retry` verdicts honoured per user turn. The second
-/// `Retry` is silently coerced to `Stop`. Mirrors the budget the rest of
-/// the verify-gate work uses.
+/// Default stronger model used when the first-pass verdict's confidence
+/// falls below [`LOW_CONFIDENCE_THRESHOLD`]. Mirrors Trust-or-Escalate
+/// (ICLR 2025 Oral, Pacchiardi et al.): low-confidence cases route to a
+/// stronger judge.
+pub const DEFAULT_ESCALATE_MODEL: &str = "anthropic/claude-sonnet-4-6";
+
+/// Maximum number of `Retry` verdicts honoured per user turn from the
+/// first-pass reflect model. Set to 1 to mirror the budget used elsewhere
+/// in the verify-gate work. The escalation model's `Retry` verdict is
+/// always ignored — only its `Stop` verdicts are acted on.
 pub const RETRY_BUDGET: usize = 1;
+
+/// Threshold below which a low-confidence `Stop` triggers escalation to
+/// the stronger model. The choice of 0.7 follows the convention in the
+/// OpenAI agentic-governance cookbook and LangGraph's `GroundingConfig`
+/// default; it is not calibrated against this project's workload.
+pub const LOW_CONFIDENCE_THRESHOLD: f32 = 0.7;
 
 /// Which reflect strategy to apply to a turn.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -41,19 +49,15 @@ pub enum ReflectMode {
     /// from PR #53 still runs; this mode is what the CLI defaults to.
     #[default]
     Off,
-    /// `verify` tool registered on the agent + system prompt instructs the
-    /// LLM to call it before final emission. LLM-self-discipline driven.
-    Self_,
-    /// Wrapper around `Agent::run` that unconditionally runs [`reflect_call`]
-    /// on the draft answer after the turn finishes. Strict but blind to
-    /// what the deterministic verify pass already noticed.
+    /// Wrapper around `Agent::run` that runs [`reflect_call`] with Haiku
+    /// after the turn finishes. When the verdict is a low-confidence
+    /// `Stop` (confidence below [`LOW_CONFIDENCE_THRESHOLD`]), the
+    /// wrapper escalates to a stronger reflect model (Sonnet by default)
+    /// for a second look. The stronger model's `Stop` verdict is final.
+    /// A stronger-model `Retry` verdict is ignored — the calibration
+    /// data for this PR shows same-model retry never recovered the
+    /// answer in those cases.
     Forced,
-    /// Forced behaviour plus the deterministic verifier's findings get
-    /// passed into the reflect call as hints, and a low-confidence `Stop`
-    /// (below [`HYBRID_LOW_CONFIDENCE_THRESHOLD`]) is treated as a
-    /// retry within the standard budget. The two layers (deterministic
-    /// verify + LLM reflect) work together rather than in parallel.
-    Hybrid,
 }
 
 impl ReflectMode {
@@ -61,9 +65,7 @@ impl ReflectMode {
     pub fn as_str(self) -> &'static str {
         match self {
             ReflectMode::Off => "off",
-            ReflectMode::Self_ => "self",
             ReflectMode::Forced => "forced",
-            ReflectMode::Hybrid => "hybrid",
         }
     }
 
@@ -71,12 +73,8 @@ impl ReflectMode {
     pub fn parse(s: &str) -> Result<Self> {
         match s {
             "off" => Ok(ReflectMode::Off),
-            "self" => Ok(ReflectMode::Self_),
             "forced" => Ok(ReflectMode::Forced),
-            "hybrid" => Ok(ReflectMode::Hybrid),
-            other => anyhow::bail!(
-                "unknown reflect mode: {other:?} (expected off|self|forced|hybrid)"
-            ),
+            other => anyhow::bail!("unknown reflect mode: {other:?} (expected off|forced)"),
         }
     }
 }
@@ -85,11 +83,10 @@ impl ReflectMode {
 /// the user; `Retry` carries a re-posed query for the agent to run again.
 ///
 /// `confidence` is an `Option<f32>` in `[0.0, 1.0]`. The verifier LLM is
-/// asked to emit it but is allowed to omit it — older verdicts produced
-/// before the field was introduced still parse cleanly. Hybrid mode reads
-/// it to decide whether a `Stop` verdict is strong enough to honour;
-/// other modes treat low-confidence stops the same as high-confidence
-/// ones.
+/// asked to emit it but is allowed to omit it. Forced mode reads it to
+/// decide whether a `Stop` verdict is strong enough to honour or
+/// requires escalation to the stronger model; otherwise high- and
+/// low-confidence stops are treated the same.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ReflectVerdict {
     Stop {
@@ -122,13 +119,6 @@ impl ReflectVerdict {
         }
     }
 }
-
-/// Threshold under which Hybrid mode treats a `Stop` verdict as "not
-/// confident enough" and forces a retry (within the standard retry
-/// budget). Picked at 0.7 to match the loose convention in Codex's
-/// `review_prompt.md` evaluator: low-confidence assessments shouldn't
-/// be allowed to silently end the turn. Other modes ignore this.
-pub const HYBRID_LOW_CONFIDENCE_THRESHOLD: f32 = 0.7;
 
 /// Wire-format expected from the reflect LLM. We keep the parsing tolerant —
 /// trailing prose, mixed casing, missing `next_query` on a `Stop`
@@ -165,11 +155,11 @@ that do not exist in the trajectory. Use a confidence below 0.7 only when \
 you genuinely cannot tell whether the draft is right. Output JSON only — \
 no prose around it.";
 
-/// Run one reflect call. The LLM sees the draft answer plus, optionally,
-/// a list of deterministic-verifier hints — typically the rendered
-/// findings from a [`crate::VerifyReport`] when called from Hybrid mode.
-/// Pass an empty slice in modes (Self / Forced) that don't have a verify
-/// pass paired with the call.
+/// Run one reflect call. The LLM sees the draft answer plus an optional
+/// list of deterministic-verifier hints — typically the rendered
+/// findings from a [`crate::VerifyReport`]. Forced mode passes an empty
+/// slice; the parameter is kept on the public surface so callers that
+/// want to layer hints on top can opt in.
 pub async fn reflect_call(
     provider: &AgentProvider,
     model_id: &str,
@@ -276,7 +266,7 @@ fn sanitize_confidence(c: Option<f32>) -> Option<f32> {
 
 fn fallback_stop(reason: &str) -> ReflectVerdict {
     // Fail-open verdicts have no claim to high confidence — leave it as
-    // None so Hybrid mode doesn't silently honour a synthetic stop.
+    // None so the escalation gate doesn't silently honour a synthetic stop.
     ReflectVerdict::Stop {
         rationale: reason.to_string(),
         confidence: None,
@@ -300,7 +290,7 @@ mod tests {
 
     #[test]
     fn mode_round_trip() {
-        for m in [ReflectMode::Off, ReflectMode::Self_, ReflectMode::Forced] {
+        for m in [ReflectMode::Off, ReflectMode::Forced] {
             assert_eq!(ReflectMode::parse(m.as_str()).unwrap(), m);
         }
     }
@@ -458,13 +448,13 @@ mod tests {
 
     #[test]
     fn fallback_stop_has_no_confidence() {
-        // Fail-open paths must not claim a confidence — Hybrid mode would
-        // otherwise treat synthetic verdicts as decisively as real ones.
+        // Fail-open paths must not claim a confidence — the escalation gate
+        // would otherwise treat synthetic verdicts as decisively as real ones.
         let v = parse_verdict("not json at all");
         assert_eq!(v.confidence(), None);
     }
 
-    // ── budget + threshold constants — referenced by run_with_*_reflect ───
+    // ── budget + threshold constants — referenced by run_with_forced_reflect ─
 
     #[test]
     fn retry_budget_is_one() {
@@ -474,17 +464,10 @@ mod tests {
     }
 
     #[test]
-    fn hybrid_threshold_is_seven_tenths() {
-        // Hybrid mode's "low confidence → retry" threshold. Loose convention
-        // from Codex's review_prompt.md evaluator. Change deliberately.
-        assert!((HYBRID_LOW_CONFIDENCE_THRESHOLD - 0.7).abs() < f32::EPSILON);
-    }
-
-    // ── ReflectMode coverage ──────────────────────────────────────────────
-
-    #[test]
-    fn hybrid_mode_round_trips() {
-        assert_eq!(ReflectMode::parse("hybrid").unwrap(), ReflectMode::Hybrid);
-        assert_eq!(ReflectMode::Hybrid.as_str(), "hybrid");
+    fn low_confidence_threshold_is_seven_tenths() {
+        // The escalation threshold. 0.7 follows the convention in OpenAI's
+        // agentic-governance cookbook and LangGraph's GroundingConfig
+        // default. Change deliberately.
+        assert!((LOW_CONFIDENCE_THRESHOLD - 0.7).abs() < f32::EPSILON);
     }
 }

--- a/reflect-agent/tests/reflect_modes.rs
+++ b/reflect-agent/tests/reflect_modes.rs
@@ -1,0 +1,252 @@
+//! End-to-end comparison of `ReflectMode::{Off, Self_, Forced}` on the
+//! demo task (unstructured experiment log → structured `(timestamp, metric,
+//! value)` parse).
+//!
+//! All three tests are `#[ignore]`d because they require a live LLM API
+//! key (`ANTHROPIC_API_KEY` preferred, `OPENAI_API_KEY` accepted). They
+//! make no LLM-dependent assertions — the agent's exact output varies
+//! run-to-run — but they do verify that each mode's pipeline runs to
+//! completion and that the verify report / reflect verdicts surface in
+//! the expected shape.
+//!
+//! Run all three:
+//!
+//! ```sh
+//! ANTHROPIC_API_KEY=... cargo test -p reflect-agent --test reflect_modes \
+//!     -- --ignored --nocapture
+//! ```
+
+use ailoy::{
+    agent::{AgentProvider, default_provider, default_provider_mut},
+    message::{Message, Part, Role},
+};
+use reflect_agent::{
+    DEFAULT_REFLECT_MODEL, ReflectMode, VerifyConfig, build_agent_with_mode,
+    register_provider_from_env, run_with_forced_reflect, run_with_hybrid, run_with_verify,
+};
+
+const LOG_FIXTURE: &str = "\
+2024-01-15T10:30:00 cpu=42
+2024-01-15T10:31:00 cpu=51
+2024-01-15T10:32:00 cpu=47
+";
+
+const PROMPT_TEMPLATE: &str = "\
+Below is an experiment log. Parse it into a list of \
+(timestamp, metric, value) tuples using bash and python_repl. \
+Print the parsed list — don't try to make a plot. Cite each row's \
+timestamp from the log verbatim.
+
+Log:
+{log}";
+
+/// Pick a model whose provider is registered. Anthropic is preferred for
+/// stable tool-call behaviour; OpenAI is the fallback so this still runs
+/// against an `OPENAI_API_KEY`-only environment.
+fn pick_model() -> Option<&'static str> {
+    if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+        Some("anthropic/claude-haiku-4-5-20251001")
+    } else if std::env::var("OPENAI_API_KEY").is_ok() {
+        Some("openai/gpt-4o-mini")
+    } else {
+        None
+    }
+}
+
+fn build_query() -> Message {
+    Message::new(Role::User).with_contents([Part::text(
+        PROMPT_TEMPLATE.replace("{log}", LOG_FIXTURE),
+    )])
+}
+
+async fn boot() -> Option<&'static str> {
+    dotenvy::dotenv().ok();
+    let model = pick_model()?;
+    register_provider_from_env(&mut *default_provider_mut().await);
+    Some(model)
+}
+
+/// Off mode reproduces PR #53's behaviour: no LLM-driven reflect, just
+/// the deterministic verify pass at turn-end. We confirm the agent
+/// produced an assistant message and the verify report rendered without
+/// panicking — content-level assertions stay hands-off because LLM
+/// behaviour drifts.
+#[tokio::test]
+#[ignore = "requires an LLM API key (ANTHROPIC_API_KEY or OPENAI_API_KEY)"]
+async fn off_mode_runs_through_verify_only() {
+    let Some(model) = boot().await else {
+        eprintln!("no API key registered; skipping");
+        return;
+    };
+
+    let mut agent = build_agent_with_mode(model, ReflectMode::Off)
+        .await
+        .expect("build agent");
+    let (outputs, report) = run_with_verify(&mut agent, build_query(), &VerifyConfig::default())
+        .await
+        .expect("run_with_verify");
+
+    assert!(
+        outputs.iter().any(|o| o.message.role == Role::Assistant),
+        "no assistant output produced"
+    );
+    eprintln!("[off] verify report:\n{}", report.format());
+}
+
+/// Self mode adds the `verify` tool + a system-prompt instruction telling
+/// the LLM to call it before emitting the final answer. We don't assert
+/// the LLM actually called it — that's self-discipline driven and
+/// notoriously flaky — but we do confirm the agent ran end-to-end with
+/// the augmented tool set.
+#[tokio::test]
+#[ignore = "requires an LLM API key (ANTHROPIC_API_KEY or OPENAI_API_KEY)"]
+async fn self_mode_runs_through_with_verify_tool() {
+    let Some(model) = boot().await else {
+        eprintln!("no API key registered; skipping");
+        return;
+    };
+
+    let mut agent = build_agent_with_mode(model, ReflectMode::Self_)
+        .await
+        .expect("build agent");
+    let (outputs, report) = run_with_verify(&mut agent, build_query(), &VerifyConfig::default())
+        .await
+        .expect("run_with_verify");
+
+    assert!(
+        outputs.iter().any(|o| o.message.role == Role::Assistant),
+        "no assistant output produced"
+    );
+    let verify_tool_calls = outputs
+        .iter()
+        .filter_map(|o| o.message.tool_calls.as_ref())
+        .flatten()
+        .filter(|p| {
+            p.as_function()
+                .map(|(_, name, _)| name == "verify")
+                .unwrap_or(false)
+        })
+        .count();
+    eprintln!(
+        "[self] verify tool calls observed: {verify_tool_calls}; verify report:\n{}",
+        report.format()
+    );
+}
+
+/// Forced mode wraps the agent: after the turn finishes we unconditionally
+/// run a reflect call on the draft answer and follow its verdict. We
+/// confirm the wrapper produced at least one verdict and respected the
+/// retry budget (≤ 1).
+#[tokio::test]
+#[ignore = "requires an LLM API key (ANTHROPIC_API_KEY or OPENAI_API_KEY)"]
+async fn forced_mode_runs_through_with_reflect_verdicts() {
+    let Some(model) = boot().await else {
+        eprintln!("no API key registered; skipping");
+        return;
+    };
+
+    let provider: AgentProvider = default_provider().await.clone();
+    let mut agent = build_agent_with_mode(model, ReflectMode::Forced)
+        .await
+        .expect("build agent");
+    let outcome = run_with_forced_reflect(
+        &mut agent,
+        build_query(),
+        &VerifyConfig::default(),
+        &provider,
+        DEFAULT_REFLECT_MODEL,
+    )
+    .await
+    .expect("run_with_forced_reflect");
+
+    assert!(
+        outcome
+            .outputs
+            .iter()
+            .any(|o| o.message.role == Role::Assistant),
+        "no assistant output produced"
+    );
+    assert!(
+        !outcome.reflect_verdicts.is_empty(),
+        "forced mode should emit at least one reflect verdict"
+    );
+    assert!(
+        outcome.retry_count <= 1,
+        "retry budget exceeded: {}",
+        outcome.retry_count
+    );
+    eprintln!(
+        "[forced] retries: {}; verdicts: {} ({:?}); verify report:\n{}",
+        outcome.retry_count,
+        outcome.reflect_verdicts.len(),
+        outcome
+            .reflect_verdicts
+            .iter()
+            .map(|v| if v.is_retry() { "retry" } else { "stop" })
+            .collect::<Vec<_>>(),
+        outcome.verify_report.format()
+    );
+}
+
+/// Hybrid mode runs the deterministic verifier per turn, hands its
+/// findings into the reflect call, and may promote a low-confidence
+/// `Stop` into a retry. We verify shape: at least one verdict, a per-turn
+/// report for each agent turn, and the retry budget is respected. Content
+/// is left to manual inspection — LLM behaviour is non-deterministic.
+#[tokio::test]
+#[ignore = "requires an LLM API key (ANTHROPIC_API_KEY or OPENAI_API_KEY)"]
+async fn hybrid_mode_runs_through_with_per_turn_verify() {
+    let Some(model) = boot().await else {
+        eprintln!("no API key registered; skipping");
+        return;
+    };
+
+    let provider: AgentProvider = default_provider().await.clone();
+    let mut agent = build_agent_with_mode(model, ReflectMode::Hybrid)
+        .await
+        .expect("build agent");
+    let outcome = run_with_hybrid(
+        &mut agent,
+        build_query(),
+        &VerifyConfig::default(),
+        &provider,
+        DEFAULT_REFLECT_MODEL,
+    )
+    .await
+    .expect("run_with_hybrid");
+
+    assert!(
+        outcome
+            .outputs
+            .iter()
+            .any(|o| o.message.role == Role::Assistant),
+        "no assistant output produced"
+    );
+    assert!(
+        !outcome.reflect_verdicts.is_empty(),
+        "hybrid mode should emit at least one reflect verdict"
+    );
+    // One verify report per agent turn (initial + each retry).
+    assert_eq!(
+        outcome.per_turn_verify_reports.len(),
+        outcome.retry_count + 1,
+        "per-turn report count must equal retry_count + 1"
+    );
+    assert!(
+        outcome.retry_count <= 1,
+        "retry budget exceeded: {}",
+        outcome.retry_count
+    );
+    eprintln!(
+        "[hybrid] retries: {} (low-confidence promotions: {}); verdicts: {} ({:?}); final verify report:\n{}",
+        outcome.retry_count,
+        outcome.low_confidence_promotions,
+        outcome.reflect_verdicts.len(),
+        outcome
+            .reflect_verdicts
+            .iter()
+            .map(|v| if v.is_retry() { "retry" } else { "stop" })
+            .collect::<Vec<_>>(),
+        outcome.verify_report.format()
+    );
+}

--- a/reflect-agent/tests/reflect_modes.rs
+++ b/reflect-agent/tests/reflect_modes.rs
@@ -1,15 +1,15 @@
-//! End-to-end comparison of `ReflectMode::{Off, Self_, Forced}` on the
-//! demo task (unstructured experiment log → structured `(timestamp, metric,
+//! End-to-end shape tests for `ReflectMode::{Off, Forced}` on the demo
+//! task (unstructured experiment log → structured `(timestamp, metric,
 //! value)` parse).
 //!
-//! All three tests are `#[ignore]`d because they require a live LLM API
-//! key (`ANTHROPIC_API_KEY` preferred, `OPENAI_API_KEY` accepted). They
-//! make no LLM-dependent assertions — the agent's exact output varies
+//! Both tests are `#[ignore]`d because they require a live LLM API key
+//! (`ANTHROPIC_API_KEY` preferred, `OPENAI_API_KEY` accepted). They make
+//! no LLM-dependent assertions — the agent's exact output varies
 //! run-to-run — but they do verify that each mode's pipeline runs to
 //! completion and that the verify report / reflect verdicts surface in
 //! the expected shape.
 //!
-//! Run all three:
+//! Run them:
 //!
 //! ```sh
 //! ANTHROPIC_API_KEY=... cargo test -p reflect-agent --test reflect_modes \
@@ -21,8 +21,8 @@ use ailoy::{
     message::{Message, Part, Role},
 };
 use reflect_agent::{
-    DEFAULT_REFLECT_MODEL, ReflectMode, VerifyConfig, build_agent_with_mode,
-    register_provider_from_env, run_with_forced_reflect, run_with_hybrid, run_with_verify,
+    DEFAULT_ESCALATE_MODEL, DEFAULT_REFLECT_MODEL, ReflectMode, VerifyConfig,
+    build_agent_with_mode, register_provider_from_env, run_with_forced_reflect, run_with_verify,
 };
 
 const LOG_FIXTURE: &str = "\
@@ -93,50 +93,12 @@ async fn off_mode_runs_through_verify_only() {
     eprintln!("[off] verify report:\n{}", report.format());
 }
 
-/// Self mode adds the `verify` tool + a system-prompt instruction telling
-/// the LLM to call it before emitting the final answer. We don't assert
-/// the LLM actually called it — that's self-discipline driven and
-/// notoriously flaky — but we do confirm the agent ran end-to-end with
-/// the augmented tool set.
-#[tokio::test]
-#[ignore = "requires an LLM API key (ANTHROPIC_API_KEY or OPENAI_API_KEY)"]
-async fn self_mode_runs_through_with_verify_tool() {
-    let Some(model) = boot().await else {
-        eprintln!("no API key registered; skipping");
-        return;
-    };
-
-    let mut agent = build_agent_with_mode(model, ReflectMode::Self_)
-        .await
-        .expect("build agent");
-    let (outputs, report) = run_with_verify(&mut agent, build_query(), &VerifyConfig::default())
-        .await
-        .expect("run_with_verify");
-
-    assert!(
-        outputs.iter().any(|o| o.message.role == Role::Assistant),
-        "no assistant output produced"
-    );
-    let verify_tool_calls = outputs
-        .iter()
-        .filter_map(|o| o.message.tool_calls.as_ref())
-        .flatten()
-        .filter(|p| {
-            p.as_function()
-                .map(|(_, name, _)| name == "verify")
-                .unwrap_or(false)
-        })
-        .count();
-    eprintln!(
-        "[self] verify tool calls observed: {verify_tool_calls}; verify report:\n{}",
-        report.format()
-    );
-}
-
-/// Forced mode wraps the agent: after the turn finishes we unconditionally
-/// run a reflect call on the draft answer and follow its verdict. We
-/// confirm the wrapper produced at least one verdict and respected the
-/// retry budget (≤ 1).
+/// Forced mode wraps the agent: after each turn we run a Haiku reflect
+/// call on the draft answer and follow its verdict, escalating to the
+/// stronger model when the first-pass confidence is low. We confirm the
+/// wrapper produced at least one verdict and respected the retry budget
+/// (≤ 1) and that the escalation count is consistent with the verdict
+/// chain length.
 #[tokio::test]
 #[ignore = "requires an LLM API key (ANTHROPIC_API_KEY or OPENAI_API_KEY)"]
 async fn forced_mode_runs_through_with_reflect_verdicts() {
@@ -155,6 +117,7 @@ async fn forced_mode_runs_through_with_reflect_verdicts() {
         &VerifyConfig::default(),
         &provider,
         DEFAULT_REFLECT_MODEL,
+        DEFAULT_ESCALATE_MODEL,
     )
     .await
     .expect("run_with_forced_reflect");
@@ -175,72 +138,16 @@ async fn forced_mode_runs_through_with_reflect_verdicts() {
         "retry budget exceeded: {}",
         outcome.retry_count
     );
-    eprintln!(
-        "[forced] retries: {}; verdicts: {} ({:?}); verify report:\n{}",
-        outcome.retry_count,
-        outcome.reflect_verdicts.len(),
-        outcome
-            .reflect_verdicts
-            .iter()
-            .map(|v| if v.is_retry() { "retry" } else { "stop" })
-            .collect::<Vec<_>>(),
-        outcome.verify_report.format()
-    );
-}
-
-/// Hybrid mode runs the deterministic verifier per turn, hands its
-/// findings into the reflect call, and may promote a low-confidence
-/// `Stop` into a retry. We verify shape: at least one verdict, a per-turn
-/// report for each agent turn, and the retry budget is respected. Content
-/// is left to manual inspection — LLM behaviour is non-deterministic.
-#[tokio::test]
-#[ignore = "requires an LLM API key (ANTHROPIC_API_KEY or OPENAI_API_KEY)"]
-async fn hybrid_mode_runs_through_with_per_turn_verify() {
-    let Some(model) = boot().await else {
-        eprintln!("no API key registered; skipping");
-        return;
-    };
-
-    let provider: AgentProvider = default_provider().await.clone();
-    let mut agent = build_agent_with_mode(model, ReflectMode::Hybrid)
-        .await
-        .expect("build agent");
-    let outcome = run_with_hybrid(
-        &mut agent,
-        build_query(),
-        &VerifyConfig::default(),
-        &provider,
-        DEFAULT_REFLECT_MODEL,
-    )
-    .await
-    .expect("run_with_hybrid");
-
+    // The verdict chain holds one first-pass verdict per turn plus one
+    // additional verdict per escalation. Lower bound: turns ≤ verdicts.
     assert!(
-        outcome
-            .outputs
-            .iter()
-            .any(|o| o.message.role == Role::Assistant),
-        "no assistant output produced"
-    );
-    assert!(
-        !outcome.reflect_verdicts.is_empty(),
-        "hybrid mode should emit at least one reflect verdict"
-    );
-    // One verify report per agent turn (initial + each retry).
-    assert_eq!(
-        outcome.per_turn_verify_reports.len(),
-        outcome.retry_count + 1,
-        "per-turn report count must equal retry_count + 1"
-    );
-    assert!(
-        outcome.retry_count <= 1,
-        "retry budget exceeded: {}",
-        outcome.retry_count
+        outcome.reflect_verdicts.len() >= outcome.retry_count + 1,
+        "verdict chain shorter than expected"
     );
     eprintln!(
-        "[hybrid] retries: {} (low-confidence promotions: {}); verdicts: {} ({:?}); final verify report:\n{}",
+        "[forced] retries: {} escalations: {}; verdicts: {} ({:?}); verify report:\n{}",
         outcome.retry_count,
-        outcome.low_confidence_promotions,
+        outcome.escalations,
         outcome.reflect_verdicts.len(),
         outcome
             .reflect_verdicts


### PR DESCRIPTION
## Summary

This PR layers an LLM-driven reflect gate on top of the deterministic verify layer in #53. After running the calibration experiment summarised below, the design simplifies to two modes:

- `off` (default) — only the deterministic verifier from #53 runs at turn-end.
- `forced` — after every turn a Haiku reflect call examines the draft. When the first-pass verdict is a `Stop` whose self-reported confidence is below 0.7, the wrapper escalates to a stronger reflect model (Sonnet 4.6 by default) and uses the stronger model's verdict as final.

Earlier revisions of this PR shipped four modes (`off`, `self`, `forced`, `hybrid`); the calibration data described below removed the case for keeping `self` and `hybrid`, so they were dropped in 3ca3d37.

## Stacked on PR #53

Base = `feat/verify-gate`. Once #53 merges, GitHub will retarget this PR's base to `feat/reflect-agent`, then to `fix/ailoy-bump-391`, then to `refactoring-applied` as the upstream stack lands. Nothing on this branch needs to move.

## Background — the paper this is built on

Pacchiardi et al., "Trust or Escalate: LLM Judges with Provable Guarantees for Human Agreement" (ICLR 2025 Oral) — https://arxiv.org/abs/2407.18370 — argues that an LLM judge is useful when (a) it emits a verdict together with a verbalised confidence, (b) low-confidence cases route to a stronger model, and (c) the threshold is calibrated against held-out data. The verdict + confidence schema this PR uses is the same dual-signal shape Codex's `review_prompt.md` evaluator enforces; the threshold value (0.7) matches the OpenAI agentic-governance cookbook's `confidence_threshold` default for tunable LLM-based guardrails and LangGraph's `GroundingConfig` default for ReAct reliability.

## What each mode does

| Mode | Source of verdict | Action on low-confidence Stop | Retries |
|---|---|---|---|
| `off` (default) | n/a — only the deterministic verifier from #53 runs at turn-end | n/a | none |
| `forced` | Haiku reflect call after every turn | escalate to a stronger model (default Sonnet 4.6); accept its `Stop`, ignore its `Retry` | first-pass `Retry` honoured up to `RETRY_BUDGET = 1` |

The escalation model's `Retry` verdict is intentionally ignored: in the calibration data, every same-model retry that fired left the answer unchanged or made it worse. Only the stronger model's `Stop` (i.e. confirmation of the original draft) is acted on; same-model self-retry is not on the public surface.

## Calibration experiment

Held off-tree under `reflect-agent/research/` (untracked working material): a paired-trial study on a 13-task hard suite (off-by-one traps, subtle constraints, format gotchas, multi-step traps), n=10 trials per task per mode = 390 trials, agent + first-pass reflect = `claude-haiku-4-5-20251001`, escalation = `claude-sonnet-4-6`.

| Mode | Accuracy | 95% CI (Wilson) | vs. forced |
|---|---:|---:|---:|
| forced (Haiku-only reflect, no escalation) | 46.2% (60/130) | [37.8, 54.7] | baseline |
| hybrid (forced + verify-finding hints + same-model retry on low conf) | 46.2% (60/130) | [37.8, 54.7] | 0/130 paired (McNemar p = 1.0) |
| escalate (forced + Sonnet on low confidence) | 81.5% (106/130) | [74.0, 87.3] | +46/130 paired, 0 regressions (McNemar p < 0.0001) |

`hybrid` and `forced` produced an identical answer on every single (task, trial) pair — the dual mechanisms hybrid added (verify-finding hint injection + low-confidence promotion to retry) had zero detectable effect at this sample size. A separate paired ablation against escalate (n=5 = 65 trials) confirmed the verify-finding hint contributes ≤ 1 trial out of 65 (McNemar p = 1.0), so the escalation path doesn't need the hint either; Sonnet's raw strength on the same draft carries the gain.

The full report — methodology, calibration plot, threshold sweep, qualitative case examples, conclusion — is preserved as `reflect-agent/research/calibration-report.html` (also archived locally outside the repo). It is not part of this commit's diff but is the source of the four design decisions in this PR:

1. drop `Self_` (self-discipline triggered verify tool) — peer-reviewed work on agentic instruction following (e.g. AgentIF) shows ≤ 30% full-compliance even with explicit "MUST" prompts; without measurement the mode is too unpredictable to keep.
2. drop `Hybrid` — null effect in our data.
3. keep escalation but drop the verify-finding hints into the reflect call — the n=65 paired ablation found no marginal effect.
4. ignore the escalation model's `Retry` verdict — when it fired in our data, the resulting same-model retry never recovered the answer.

## Public surface (after this PR)

- `ReflectMode = Off | Forced` (was `Off | Self_ | Forced | Hybrid`)
- `run_with_forced_reflect(agent, query, verify_config, provider, reflect_model, escalate_model)` — `escalate_model` is the new parameter
- `ForcedReflectOutcome { outputs, verify_report, reflect_verdicts, retry_count, escalations }` — `escalations` is new (count of times the stronger model was invoked); `low_confidence_promotions` is gone
- `LOW_CONFIDENCE_THRESHOLD: f32 = 0.7` — replaces `HYBRID_LOW_CONFIDENCE_THRESHOLD`
- `DEFAULT_ESCALATE_MODEL: &str = "anthropic/claude-sonnet-4-6"` — new
- `DEFAULT_REFLECT_MODEL`, `RETRY_BUDGET`, `reflect_call`, `ReflectVerdict` — unchanged
- gone: `ReflectMode::Self_`, `ReflectMode::Hybrid`, `run_with_hybrid`, `HybridReflectOutcome`, `HYBRID_LOW_CONFIDENCE_THRESHOLD`, `render_verify_hints`, the `verify` tool factory, the self-mode system prompt

## CLI

```
reflect-agent [OPTIONS]

  --model <MODEL>            agent model           [default: anthropic/claude-haiku-4-5-20251001]
  --query <QUERY>            single-shot, exit
  --reflect-mode <MODE>      off | forced          [default: off]
  --reflect-model <MODEL>    first-pass reflect    [default: anthropic/claude-haiku-4-5-20251001]
  --escalate-model <MODEL>   stronger reflect      [default: anthropic/claude-sonnet-4-6]
  --verbose                  show verify report in forced mode
```

CLI breaking change: `--reflect-mode self` and `--reflect-mode hybrid` no longer parse. The two replaced flows have been measured against the surviving one and the data does not justify them; downstream invocations that hard-coded those values will need to switch to `forced` (or `off`).

## Reflect-call system prompt

Unchanged from the previous revision — both Haiku and Sonnet reflect calls receive the same prompt:

> You are a verification assistant. Read the draft answer below and decide whether it can be sent to the user as-is.
>
> Output a single JSON object with these fields:
>   - verdict:    "stop" or "retry"
>   - rationale:  one short sentence explaining the choice
>   - next_query: only when verdict is "retry"; a re-posed task that fixes the issue
>   - confidence: a number in [0.0, 1.0] expressing how sure you are of the verdict
>
> Choose "stop" when the draft answers the user's question correctly and is self-consistent with the cited evidence. Choose "retry" when the draft contains errors, leaves the user's question unanswered, or cites sources that do not exist in the trajectory. Use a confidence below 0.7 only when you genuinely cannot tell whether the draft is right. Output JSON only — no prose around it.

## Verdict format

```json
{ "verdict": "stop" | "retry",
  "rationale": "...",
  "next_query": "...",   // only when retry
  "confidence": 0.92 }    // optional, [0.0, 1.0]
```

`parse_verdict` is fail-open: missing fields, surrounding prose, mixed casing, retry-without-next_query, and out-of-range confidence all coerce sensibly (mostly to a synthetic `Stop`) so a malformed verifier response never aborts a real user turn.

## Verification

```
cargo check --workspace --tests --all-features         # clean
cargo test  -p reflect-agent --lib                      # passes
cargo test  -p reflect-agent --test demo_task           # 2 passed; 1 ignored
cargo test  -p reflect-agent --test reflect_modes       # 2 ignored (need API key)
cargo test  -p speedwagon  --lib --all-features         # no regression
```

## Test plan

- [x] `cargo check --workspace --tests --all-features` is clean
- [x] `cargo test -p reflect-agent --lib` passes
- [x] `cargo test -p reflect-agent --test demo_task` 2/0/1 (one ignored, needs API key)
- [x] `cargo test -p reflect-agent --test reflect_modes` compiles two `#[ignore]`d e2e tests (one per mode)
- [x] No regression on `speedwagon`: 71/0/2 still green
- [x] Manual smoke: `--reflect-mode forced` on a Haiku-easy query (`What is 17 * 23?`) — Haiku reflect returns Stop@0.99, no escalation
- [x] Manual smoke: `--reflect-mode forced` on a Haiku-uncertain query (Fibonacci F(15)) — Haiku Stop@0.5, escalates to Sonnet, Sonnet Stop@0.85, draft accepted
