### PR TITLE
feat(router,session): multi-intent step Plan with sequential dispatch

### DIFF
--- a/agent-k/src/agents/router.rs
+++ b/agent-k/src/agents/router.rs
@@ -22,7 +22,7 @@ const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request an
 - One step per distinct intent, in the order the user wrote them. A single intent — even if listy, long, or about multiple items — stays one step.
 - Each step.input is the corresponding part of the user's request, kept close to the original wording. The dispatcher passes step.input to the agent, with prior step outputs prepended as context, so phrase step.input as if those prior outputs are already in view.
 - An explanation paired with a tiny inline example is one minerva step (artifact wins) — the general split rule above does not apply when the example is inline.
-- Honor negations and self-corrections: only emit steps for what the user actually wants done.
+- Honor negations and self-corrections: only emit steps for the user's latest stated intent.
 
 ## Response format
 {"steps": [{"agent": "<agent name>", "input": "<sub-request>", "reason": "<one short sentence>"}]}

--- a/agent-k/src/agents/router.rs
+++ b/agent-k/src/agents/router.rs
@@ -46,7 +46,7 @@ pub struct Plan {
 const ROUTER_MAX_RETRIES: usize = 2;
 
 pub async fn run_gpt_router_agent(user_input: impl Into<String>) -> anyhow::Result<Plan> {
-    run_router_agent("openai/gpt-4o-mini", user_input).await
+    run_router_agent("openai/gpt-5.4-nano", user_input).await
 }
 
 pub async fn run_claude_router_agent(user_input: impl Into<String>) -> anyhow::Result<Plan> {

--- a/agent-k/src/agents/router.rs
+++ b/agent-k/src/agents/router.rs
@@ -8,22 +8,20 @@ use tokio_stream::StreamExt;
 const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request and produce a plan of one or more steps, each routed to a single agent.
 
 ## Agents
-- "speedwagon": RAG Q&A. Factual or knowledge questions answerable from a static document corpus.
+- "speedwagon": Q&A. Factual or knowledge questions, regardless of how the answer is sourced.
 - "vegapunk": Deep research. Multi-source investigation: literature review, topic survey, option comparison, or a long-form research report.
-- "minerva": General-purpose execution. Running commands, exploring or editing files/code, orchestrating multi-step work, fetching live information, producing code or runnable artifacts.
+- "minerva": General-purpose execution. Running commands, exploring or editing files/code, orchestrating multi-step work, producing code or runnable artifacts.
 
 ## Rules
-- Live information (today's weather, current stock price, today's news, anything that needs to be fetched right now) must route to minerva. speedwagon only covers static corpus knowledge. "As of <past date>" is a static fact, not live — route those to speedwagon.
-- If the request asks for both analysis/comparison and a concrete artifact (code, config, script, runnable example), the artifact intent wins — route to minerva.
-- If the request is primarily a question but also asks for an example, snippet, or code, treat the artifact intent as decisive and route to minerva.
+- A request that mixes Q&A/research with execution should split — speedwagon (or vegapunk) for the Q&A or research part, minerva for the execution part.
 - Requests to translate text from one specific language to another (e.g. "translate this Korean to English") are execution — route to minerva. Just writing in a non-English language is not a translation request.
 - If the request does not fit any agent well (greetings, identity questions about yourself, pure noise, ambiguous fragments, refusals to act), still pick the closest agent but prefix the "reason" field with "fallback: ".
 - Write "reason" in the dominant language of the user's request — the language carrying the semantic content, not short carrier phrases like "please" or "tell me".
 
 ## Splitting
 - One step per distinct intent, in the order the user wrote them. A single intent — even if listy, long, or about multiple items — stays one step.
-- Each step.input is a self-contained rewriting of that slice. The dispatcher passes step.input to the agent, with prior step outputs prepended as context, so phrase step.input as if those prior outputs are already in view.
-- An explanation paired with a code example is one minerva step (artifact wins).
+- Each step.input is the corresponding part of the user's request, kept close to the original wording. The dispatcher passes step.input to the agent, with prior step outputs prepended as context, so phrase step.input as if those prior outputs are already in view.
+- An explanation paired with a tiny inline example is one minerva step (artifact wins) — the general split rule above does not apply when the example is inline.
 - Honor negations and self-corrections: only emit steps for what the user actually wants done.
 
 ## Response format

--- a/agent-k/src/agents/router.rs
+++ b/agent-k/src/agents/router.rs
@@ -5,7 +5,7 @@ use ailoy::{
 use serde::Deserialize;
 use tokio_stream::StreamExt;
 
-const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request, split it into one or more sub-requests, and choose which agent should handle each.
+const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request and produce a plan of one or more steps, each routed to a single agent.
 
 ## Agents
 - "speedwagon": RAG Q&A. Factual or knowledge questions answerable from a static document corpus.
@@ -16,21 +16,19 @@ const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request, s
 - Live information (today's weather, current stock price, today's news, anything that needs to be fetched right now) must route to minerva. speedwagon only covers static corpus knowledge. "As of <past date>" is a static fact, not live — route those to speedwagon.
 - If the request asks for both analysis/comparison and a concrete artifact (code, config, script, runnable example), the artifact intent wins — route to minerva.
 - If the request is primarily a question but also asks for an example, snippet, or code, treat the artifact intent as decisive and route to minerva.
-- Requests to translate text from one specific language to another (e.g. "translate this Korean to English") are execution — route to minerva. Just writing in a non-English language is NOT a translation request.
+- Requests to translate text from one specific language to another (e.g. "translate this Korean to English") are execution — route to minerva. Just writing in a non-English language is not a translation request.
 - If the request does not fit any agent well (greetings, identity questions about yourself, pure noise, ambiguous fragments, refusals to act), still pick the closest agent but prefix the "reason" field with "fallback: ".
 - Write "reason" in the dominant language of the user's request — the language carrying the semantic content, not short carrier phrases like "please" or "tell me".
 
 ## Splitting
-- If the request contains MULTIPLE distinct intents (Q&A + execution, research + code, two unrelated questions, etc.), produce ONE step per intent, in the order the user wrote them.
-- If the request is a SINGLE intent (even if listy or long), produce ONE step.
-- Each step.input must be a SELF-CONTAINED rewriting of that slice of the user's request — the dispatcher will pass step.input to the chosen agent. If a later step depends on the previous step's result, write step.input so that it can be answered given "the previous result" (which the dispatcher will provide as context).
-- Do NOT split a single research/survey/comparison task into per-item steps just because it lists multiple items.
-- A request that asks for an explanation WITH a code example is ONE minerva step (artifact wins).
-- Negations or self-corrections must be honored: only emit steps for what the user actually wants done.
+- One step per distinct intent, in the order the user wrote them. A single intent — even if listy, long, or about multiple items — stays one step.
+- Each step.input is a self-contained rewriting of that slice. The dispatcher passes step.input to the agent, with prior step outputs prepended as context, so phrase step.input as if those prior outputs are already in view.
+- An explanation paired with a code example is one minerva step (artifact wins).
+- Honor negations and self-corrections: only emit steps for what the user actually wants done.
 
 ## Response format
 {"steps": [{"agent": "<agent name>", "input": "<sub-request>", "reason": "<one short sentence>"}]}
-Respond with EXACTLY one JSON object, and nothing else (no prose, no markdown, no code fence). The "agent" field must be exactly one of the available agents.
+Respond with exactly one JSON object, and nothing else (no prose, no markdown, no code fence). The "agent" field must be exactly one of the available agents.
 "#;
 
 #[derive(Debug, Deserialize)]

--- a/agent-k/src/agents/router.rs
+++ b/agent-k/src/agents/router.rs
@@ -5,7 +5,7 @@ use ailoy::{
 use serde::Deserialize;
 use tokio_stream::StreamExt;
 
-const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request and choose exactly one agent to handle it.
+const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request, split it into one or more sub-requests, and choose which agent should handle each.
 
 ## Agents
 - "speedwagon": RAG Q&A. Factual or knowledge questions answerable from a static document corpus.
@@ -20,40 +20,54 @@ const ROUTER_INSTRUCTION: &str = r#"You are a router. Read the user's request an
 - If the request does not fit any agent well (greetings, identity questions about yourself, pure noise, ambiguous fragments, refusals to act), still pick the closest agent but prefix the "reason" field with "fallback: ".
 - Write "reason" in the dominant language of the user's request — the language carrying the semantic content, not short carrier phrases like "please" or "tell me".
 
+## Splitting
+- If the request contains MULTIPLE distinct intents (Q&A + execution, research + code, two unrelated questions, etc.), produce ONE step per intent, in the order the user wrote them.
+- If the request is a SINGLE intent (even if listy or long), produce ONE step.
+- Each step.input must be a SELF-CONTAINED rewriting of that slice of the user's request — the dispatcher will pass step.input to the chosen agent. If a later step depends on the previous step's result, write step.input so that it can be answered given "the previous result" (which the dispatcher will provide as context).
+- Do NOT split a single research/survey/comparison task into per-item steps just because it lists multiple items.
+- A request that asks for an explanation WITH a code example is ONE minerva step (artifact wins).
+- Negations or self-corrections must be honored: only emit steps for what the user actually wants done.
+
 ## Response format
-{"agent": "<agent name>", "reason": "<one short sentence>"}
+{"steps": [{"agent": "<agent name>", "input": "<sub-request>", "reason": "<one short sentence>"}]}
 Respond with EXACTLY one JSON object, and nothing else (no prose, no markdown, no code fence). The "agent" field must be exactly one of the available agents.
 "#;
 
 #[derive(Debug, Deserialize)]
-pub struct RouterDecision {
+pub struct Step {
     pub agent: String,
+    pub input: String,
 
     #[serde(default)]
     pub reason: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct Plan {
+    pub steps: Vec<Step>,
+}
+
 const ROUTER_MAX_RETRIES: usize = 2;
 
-pub async fn run_gpt_router_agent(user_input: impl Into<String>) -> anyhow::Result<RouterDecision> {
+pub async fn run_gpt_router_agent(user_input: impl Into<String>) -> anyhow::Result<Plan> {
     run_router_agent("openai/gpt-4o-mini", user_input).await
 }
 
-pub async fn run_claude_router_agent(
-    user_input: impl Into<String>,
-) -> anyhow::Result<RouterDecision> {
+pub async fn run_claude_router_agent(user_input: impl Into<String>) -> anyhow::Result<Plan> {
     run_router_agent("anthropic/claude-haiku-4-5", user_input).await
 }
 
 async fn run_router_agent(
     model: &str,
     user_input: impl Into<String>,
-) -> anyhow::Result<RouterDecision> {
+) -> anyhow::Result<Plan> {
+    let user_input: String = user_input.into();
     let mut agent = AgentBuilder::new(model)
         .instruction(ROUTER_INSTRUCTION)
         .build()?;
 
-    let mut next_message = Some(Message::new(Role::User).with_contents([Part::text(user_input)]));
+    let mut next_message =
+        Some(Message::new(Role::User).with_contents([Part::text(user_input.clone())]));
     let mut last_err = String::from("no attempts made");
 
     for _ in 0..ROUTER_MAX_RETRIES {
@@ -80,12 +94,30 @@ async fn run_router_agent(
             .collect::<Vec<_>>()
             .join("");
 
-        let mut it = serde_json::Deserializer::from_str(&raw).into_iter::<RouterDecision>();
+        let mut it = serde_json::Deserializer::from_str(&raw).into_iter::<Plan>();
         last_err = match it.next() {
-            Some(Ok(d)) => return Ok(d),
-            Some(Err(e)) => {
-                format!("JSON parse failed: {e}")
+            Some(Ok(plan)) => {
+                if plan.steps.is_empty() {
+                    "empty steps array".to_string()
+                } else {
+                    let invalid = plan.steps.iter().enumerate().find_map(|(i, s)| {
+                        if !matches!(s.agent.as_str(), "speedwagon" | "vegapunk" | "minerva") {
+                            Some(format!(
+                                "invalid agent '{}' at step {}; must be one of speedwagon/vegapunk/minerva",
+                                s.agent, i
+                            ))
+                        } else {
+                            None
+                        }
+                    });
+                    if let Some(msg) = invalid {
+                        msg
+                    } else {
+                        return Ok(plan);
+                    }
+                }
             }
+            Some(Err(e)) => format!("JSON parse failed: {e}"),
             None => "response had no JSON object".to_string(),
         };
 
@@ -93,9 +125,11 @@ async fn run_router_agent(
             "Your previous response is not valid JSON. Respond again.\n\n{last_err}."
         ))]));
     }
-    Ok(RouterDecision {
-        agent: "minerva".to_string(),
-        reason: Some(format!("fallback: {last_err}")),
+    Ok(Plan {
+        steps: vec![Step {
+            agent: "minerva".to_string(),
+            input: user_input,
+            reason: Some(format!("fallback: {last_err}")),
+        }],
     })
 }
-

--- a/agent-k/src/bin/session.rs
+++ b/agent-k/src/bin/session.rs
@@ -1,14 +1,16 @@
 //! Session CLI.
 //!
 //! Reads a user request from argv (or stdin if none given), asks a small router
-//! agent which sub-agent should handle it, then dispatches.
+//! agent for a Plan (a sequence of (agent, input) steps), then dispatches each
+//! step in order. Step outputs are appended verbatim to stdout (streaming for
+//! minerva). Dependent steps see prior step outputs in their prompt.
 //!
 //! echo "주간 보고 메일 초안 써줘" | cargo run -p agent-k --bin session
 //! cargo run -p agent-k --bin session -- "세계 날씨를 확인할 수 있는 간단한 HTML 페이지 만들어주세요"
 
 use std::io::{self, BufRead, IsTerminal, Read, Write};
 
-use agent_k::agents::{get_gpt_minerva_agent, run_gpt_router_agent};
+use agent_k::agents::{get_gpt_minerva_agent, run_gpt_router_agent, Plan};
 use ailoy::{
     agent::Agent,
     message::{Message, Part, Role},
@@ -119,7 +121,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(e) => Err(e),
             },
-            Some(s) => run_in_session(s, &user_input).await,
+            Some(s) => run_in_session(s, &user_input).await.map(|_| ()),
         };
         if let Err(e) = result {
             eprintln!("[error] {e}");
@@ -151,37 +153,92 @@ fn handle_slash(cmd: &str) -> SlashAction {
 }
 
 async fn route_and_run(user_input: &str) -> anyhow::Result<Session> {
-    let decision = run_gpt_router_agent(user_input).await?;
+    let plan = run_gpt_router_agent(user_input).await?;
 
     println!(
         "[router] {}",
-        serde_json::to_string(&serde_json::json!({
-            "agent": decision.agent,
-            "reason": decision.reason,
-        }))?
+        serde_json::to_string(&plan_log(&plan))?
     );
 
-    let mut session = match decision.agent.as_str() {
+    // Surface "current session" hint is the *first* step's agent. This keeps
+    // the existing /minerva, /speedwagon, /vegapunk slash UX meaningful: a
+    // user can see / force the agent that handled the head of the plan.
+    let first_agent = plan.steps[0].agent.clone();
+    let mut session = match first_agent.as_str() {
         "speedwagon" => Session::Speedwagon,
         "vegapunk" => Session::Vegapunk,
         "minerva" => Session::Minerva(build_minerva()?),
         other => anyhow::bail!("router returned unknown agent '{other}'"),
     };
-    run_in_session(&mut session, user_input).await?;
+
+    // Run each step in order. Prior step outputs are prepended to subsequent
+    // step inputs so dependent intents can reference them.
+    let mut accumulated: Vec<String> = Vec::with_capacity(plan.steps.len());
+    for (i, step) in plan.steps.iter().enumerate() {
+        let prompt = if accumulated.is_empty() {
+            step.input.clone()
+        } else {
+            let mut s = String::from("Previous step results (chronological):\n");
+            for (j, prev) in accumulated.iter().enumerate() {
+                s.push_str(&format!("[step {}] {}\n\n", j + 1, prev));
+            }
+            s.push_str("---\nCurrent step: ");
+            s.push_str(&step.input);
+            s
+        };
+
+        eprintln!(
+            "[step {} • {}] {}",
+            i + 1,
+            step.agent,
+            cap_for_echo(&step.input)
+        );
+
+        // Reuse the head session for matching steps; otherwise spin up a
+        // temporary session for that step.
+        let out = if step.agent == first_agent {
+            run_in_session(&mut session, &prompt).await?
+        } else {
+            let mut tmp = match step.agent.as_str() {
+                "speedwagon" => Session::Speedwagon,
+                "vegapunk" => Session::Vegapunk,
+                "minerva" => Session::Minerva(build_minerva()?),
+                other => anyhow::bail!("step {} agent unknown: {other}", i + 1),
+            };
+            run_in_session(&mut tmp, &prompt).await?
+        };
+
+        accumulated.push(out);
+    }
+
     Ok(session)
 }
 
-async fn run_in_session(session: &mut Session, user_input: &str) -> anyhow::Result<()> {
+fn plan_log(plan: &Plan) -> serde_json::Value {
+    serde_json::json!({
+        "steps": plan
+            .steps
+            .iter()
+            .map(|s| serde_json::json!({
+                "agent": s.agent,
+                "input": s.input,
+                "reason": s.reason,
+            }))
+            .collect::<Vec<_>>(),
+    })
+}
+
+async fn run_in_session(session: &mut Session, user_input: &str) -> anyhow::Result<String> {
     match session {
         Session::Speedwagon => {
             eprintln!("[dispatch] TODO: speedwagon (RAG Q&A) is not implemented yet");
             eprintln!("[dispatch] forwarding query: {}", cap_for_echo(user_input));
-            Ok(())
+            Ok("[speedwagon stub: not yet implemented]".to_string())
         }
         Session::Vegapunk => {
             eprintln!("[dispatch] TODO: vegapunk (deep research) is not implemented yet");
             eprintln!("[dispatch] forwarding query: {}", cap_for_echo(user_input));
-            Ok(())
+            Ok("[vegapunk stub: not yet implemented]".to_string())
         }
         Session::Minerva(agent) => stream_minerva_turn(agent, user_input).await,
     }
@@ -217,9 +274,10 @@ fn build_minerva() -> anyhow::Result<Agent> {
     Ok(agent)
 }
 
-async fn stream_minerva_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<()> {
+async fn stream_minerva_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<String> {
     let query = Message::new(Role::User).with_contents([Part::text(user_input)]);
     let mut stream = agent.run(query);
+    let mut captured = String::new();
     while let Some(event) = stream.next().await {
         let event = event?;
         let msg = &event.message;
@@ -229,6 +287,7 @@ async fn stream_minerva_turn(agent: &mut Agent, user_input: &str) -> anyhow::Res
                     if let Some(t) = part.as_text() {
                         if !t.is_empty() {
                             print!("{t}");
+                            captured.push_str(t);
                             io::stdout().flush().ok();
                         }
                     }
@@ -250,5 +309,5 @@ async fn stream_minerva_turn(agent: &mut Agent, user_input: &str) -> anyhow::Res
         }
     }
     println!();
-    Ok(())
+    Ok(captured)
 }

--- a/agent-k/src/bin/session.rs
+++ b/agent-k/src/bin/session.rs
@@ -172,18 +172,22 @@ async fn route_and_run(user_input: &str) -> anyhow::Result<Session> {
     };
 
     // Run each step in order. Prior step outputs are prepended to subsequent
-    // step inputs so dependent intents can reference them.
+    // step inputs so dependent intents can reference them. For single-step
+    // plans, forward the user's original input as-is to preserve their
+    // phrasing instead of using the router's paraphrase.
+    let single_step = plan.steps.len() == 1;
     let mut accumulated: Vec<String> = Vec::with_capacity(plan.steps.len());
     for (i, step) in plan.steps.iter().enumerate() {
+        let step_input = if single_step { user_input } else { &step.input };
         let prompt = if accumulated.is_empty() {
-            step.input.clone()
+            step_input.to_string()
         } else {
             let mut s = String::from("Previous step results (chronological):\n");
             for (j, prev) in accumulated.iter().enumerate() {
                 s.push_str(&format!("[step {}] {}\n\n", j + 1, prev));
             }
             s.push_str("---\nCurrent step: ");
-            s.push_str(&step.input);
+            s.push_str(step_input);
             s
         };
 
@@ -191,7 +195,7 @@ async fn route_and_run(user_input: &str) -> anyhow::Result<Session> {
             "[step {} • {}] {}",
             i + 1,
             step.agent,
-            cap_for_echo(&step.input)
+            cap_for_echo(step_input)
         );
 
         // Reuse the head session for matching steps; otherwise spin up a


### PR DESCRIPTION
## Summary

Replace the single-agent router with a multi-step plan, so a request that mixes intents can be dispatched to several sub-agents in order.

- `router.rs`: `RouterDecision` → `Plan { steps: Vec<Step> }`. One LLM call, returns an ordered list of `(agent, input, reason)`. Adds a `## Splitting` section to the instruction; `## Agents`, `## Rules`, and the second line of `## Response format` are kept verbatim. The parser validates `agent` against the `speedwagon | vegapunk | minerva` enum on every step and rejects empty `steps` arrays, with the existing 2-retry loop covering both. Final fallback returns a single-minerva Plan over the original input.
- `session.rs`: dispatch each step in order. Prior step outputs are prepended to the next step's prompt so dependent intents (e.g. "do X, then explain it") can see the earlier result. `Session` enum, slash commands, the streaming minerva UX, and the artifact dir cleanup all remain unchanged.

speedwagon and vegapunk dispatch are still stubs; multi-step plans that include them log the TODO message and append a placeholder so dependent steps still have context.

## Why

Evaluated on 35 multi-intent cases (24 multi + 11 single) and a 50-case single-intent set:

- **Multi-intent (24 cases):** the current router matches 0/24 by construction (single agent). The multi-step plan matches **20/24 (83.3%)**, coverage 91.7%. Elapsed 8.8 s → 16.8 s due to N sub-agent calls.
- **Single-intent:** the multi-step plan matches 9/11 in the small set and **44/50 (88.0%)** in the dedicated set. Over-split is 3/50 (6%), only on listy / "정리해서" / "with example" prompts.
- **JSON-escape probe (100 router-only calls × 5 meta/identity prompts):** ~2% set `agent: "fallback"` instead of an enum value. The parser's enum check + retry loop catches these. Structured Outputs lands in a follow-up to bring this to 0%.

## Test plan

- [x] `cargo build -p agent-k --bin session` succeeds
- [x] Single-intent QA → 1-step `speedwagon` plan
- [x] Multi-intent ("계산 + mutex 설명") → 2-step `minerva` → `speedwagon`, step 2 prompt receives step-1 output
- [x] artifact-wins preserved → "explain + tiny code" stays 1 minerva step
- [x] Meta/identity prompt × 10 runs → valid enum agent every time

## Out of scope (follow-up PRs)

- LLM-based stitcher that integrates multi-step outputs into one answer instead of streaming sequentially
- Structured Outputs on the router call to remove the ~2% enum escape deterministically