### PR TITLE
feat(session): integrate multi-step outputs with a stitcher LLM

### DIFF
--- a/agent-k/src/bin/session.rs
+++ b/agent-k/src/bin/session.rs
@@ -2,8 +2,11 @@
 //!
 //! Reads a user request from argv (or stdin if none given), asks a small router
 //! agent for a Plan (a sequence of (agent, input) steps), then dispatches each
-//! step in order. Step outputs are appended verbatim to stdout (streaming for
-//! minerva). Dependent steps see prior step outputs in their prompt.
+//! step in order. Single-step plans stream the sub-agent output directly to
+//! stdout (existing UX). Multi-step plans buffer each sub-agent's output and
+//! then call a small stitcher LLM (gpt-5.4-mini) to integrate the outputs into
+//! one final answer that is printed at the end. Dependent steps see prior step
+//! outputs in their prompt either way.
 //!
 //! echo "주간 보고 메일 초안 써줘" | cargo run -p agent-k --bin session
 //! cargo run -p agent-k --bin session -- "세계 날씨를 확인할 수 있는 간단한 HTML 페이지 만들어주세요"
@@ -12,10 +15,14 @@ use std::io::{self, BufRead, IsTerminal, Read, Write};
 
 use agent_k::agents::{get_gpt_minerva_agent, run_gpt_router_agent, Plan};
 use ailoy::{
-    agent::Agent,
+    agent::{Agent, AgentBuilder},
     message::{Message, Part, Role},
 };
 use futures::StreamExt;
+
+const STITCH_MODEL: &str = "openai/gpt-5.4-mini";
+
+const STITCH_INSTRUCTION: &str = "You are given a user's request and the outputs of one or more sub-agents that handled different slices of it. Produce ONE concise final answer that integrates the sub-agent outputs naturally. Do not add information the sub-agents did not provide. Do not show sub-agent names, step markers, or meta-language. Write in the user's original language. If the sub-agents disagree or one failed, note it briefly. Keep the answer focused on what the user asked.";
 
 enum InputSource {
     Stdin,
@@ -121,7 +128,9 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(e) => Err(e),
             },
-            Some(s) => run_in_session(s, &user_input).await.map(|_| ()),
+            Some(s) => run_in_session(s, &user_input, /*streaming=*/ true)
+                .await
+                .map(|_| ()),
         };
         if let Err(e) = result {
             eprintln!("[error] {e}");
@@ -155,10 +164,7 @@ fn handle_slash(cmd: &str) -> SlashAction {
 async fn route_and_run(user_input: &str) -> anyhow::Result<Session> {
     let plan = run_gpt_router_agent(user_input).await?;
 
-    println!(
-        "[router] {}",
-        serde_json::to_string(&plan_log(&plan))?
-    );
+    println!("[router] {}", serde_json::to_string(&plan_log(&plan))?);
 
     // Surface "current session" hint is the *first* step's agent. This keeps
     // the existing /minerva, /speedwagon, /vegapunk slash UX meaningful: a
@@ -171,12 +177,19 @@ async fn route_and_run(user_input: &str) -> anyhow::Result<Session> {
         other => anyhow::bail!("router returned unknown agent '{other}'"),
     };
 
+    // Single-step plans keep the existing streaming UX. Multi-step plans
+    // buffer each sub-agent's output (no stdout streaming during dispatch),
+    // then call the stitcher once at the end and print the integrated answer.
+    let multi_step = plan.steps.len() > 1;
+    let streaming = !multi_step;
+
     // Run each step in order. Prior step outputs are prepended to subsequent
     // step inputs so dependent intents can reference them. For single-step
     // plans, forward the user's original input as-is to preserve their
     // phrasing instead of using the router's paraphrase.
     let single_step = plan.steps.len() == 1;
     let mut accumulated: Vec<String> = Vec::with_capacity(plan.steps.len());
+    let mut agents: Vec<String> = Vec::with_capacity(plan.steps.len());
     for (i, step) in plan.steps.iter().enumerate() {
         let step_input = if single_step { user_input } else { &step.input };
         let prompt = if accumulated.is_empty() {
@@ -201,7 +214,7 @@ async fn route_and_run(user_input: &str) -> anyhow::Result<Session> {
         // Reuse the head session for matching steps; otherwise spin up a
         // temporary session for that step.
         let out = if step.agent == first_agent {
-            run_in_session(&mut session, &prompt).await?
+            run_in_session(&mut session, &prompt, streaming).await?
         } else {
             let mut tmp = match step.agent.as_str() {
                 "speedwagon" => Session::Speedwagon,
@@ -209,10 +222,30 @@ async fn route_and_run(user_input: &str) -> anyhow::Result<Session> {
                 "minerva" => Session::Minerva(build_minerva()?),
                 other => anyhow::bail!("step {} agent unknown: {other}", i + 1),
             };
-            run_in_session(&mut tmp, &prompt).await?
+            run_in_session(&mut tmp, &prompt, streaming).await?
         };
 
         accumulated.push(out);
+        agents.push(step.agent.clone());
+    }
+
+    // Multi-step: stitch sub-agent outputs into one final answer and print it.
+    // Single-step: nothing more to do — the output was already streamed.
+    if multi_step {
+        eprintln!("[stitch] integrating {} step outputs", accumulated.len());
+        match stitch_with_llm(user_input, &agents, &accumulated).await {
+            Ok(final_text) => {
+                println!("{final_text}");
+            }
+            Err(e) => {
+                // Stitch failure: fall back to raw concat so the user still
+                // sees something useful, plus a note about the stitch error.
+                eprintln!("[stitch] failed: {e}; falling back to raw concat");
+                for (i, t) in accumulated.iter().enumerate() {
+                    println!("[step {} • {}]\n{}\n", i + 1, agents[i], t);
+                }
+            }
+        }
     }
 
     Ok(session)
@@ -232,7 +265,56 @@ fn plan_log(plan: &Plan) -> serde_json::Value {
     })
 }
 
-async fn run_in_session(session: &mut Session, user_input: &str) -> anyhow::Result<String> {
+/// LLM-based stitcher. For zero or one step we return verbatim — no extra LLM
+/// call. For multiple steps we hand the user's request + all sub-agent outputs
+/// to a small summarizer model (gpt-5.4-mini) and return its integrated answer.
+async fn stitch_with_llm(
+    user_input: &str,
+    agents: &[String],
+    outputs: &[String],
+) -> anyhow::Result<String> {
+    debug_assert_eq!(agents.len(), outputs.len());
+    match outputs.len() {
+        0 => return Ok(String::new()),
+        1 => return Ok(outputs[0].clone()),
+        _ => {}
+    }
+    let mut payload = String::from("User request:\n");
+    payload.push_str(user_input);
+    payload.push_str("\n\nSub-agent outputs (in order):\n");
+    for (i, (a, o)) in agents.iter().zip(outputs.iter()).enumerate() {
+        payload.push_str(&format!("\n[output {} — handled by {}]\n{}\n", i + 1, a, o));
+    }
+
+    let mut agent = AgentBuilder::new(STITCH_MODEL)
+        .instruction(STITCH_INSTRUCTION)
+        .build()?;
+    let query = Message::new(Role::User).with_contents([Part::text(payload)]);
+    let mut stream = agent.run(query);
+    let mut last = String::new();
+    while let Some(event) = stream.next().await {
+        let event = event?;
+        if event.message.role == Role::Assistant {
+            let text: String = event
+                .message
+                .contents
+                .iter()
+                .filter_map(|p| p.as_text())
+                .collect::<Vec<_>>()
+                .join("");
+            if !text.is_empty() {
+                last = text;
+            }
+        }
+    }
+    Ok(last)
+}
+
+async fn run_in_session(
+    session: &mut Session,
+    user_input: &str,
+    streaming: bool,
+) -> anyhow::Result<String> {
     match session {
         Session::Speedwagon => {
             eprintln!("[dispatch] TODO: speedwagon (RAG Q&A) is not implemented yet");
@@ -244,7 +326,7 @@ async fn run_in_session(session: &mut Session, user_input: &str) -> anyhow::Resu
             eprintln!("[dispatch] forwarding query: {}", cap_for_echo(user_input));
             Ok("[vegapunk stub: not yet implemented]".to_string())
         }
-        Session::Minerva(agent) => stream_minerva_turn(agent, user_input).await,
+        Session::Minerva(agent) => stream_minerva_turn(agent, user_input, streaming).await,
     }
 }
 
@@ -278,7 +360,11 @@ fn build_minerva() -> anyhow::Result<Agent> {
     Ok(agent)
 }
 
-async fn stream_minerva_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<String> {
+async fn stream_minerva_turn(
+    agent: &mut Agent,
+    user_input: &str,
+    streaming: bool,
+) -> anyhow::Result<String> {
     let query = Message::new(Role::User).with_contents([Part::text(user_input)]);
     let mut stream = agent.run(query);
     let mut captured = String::new();
@@ -290,9 +376,11 @@ async fn stream_minerva_turn(agent: &mut Agent, user_input: &str) -> anyhow::Res
                 for part in &msg.contents {
                     if let Some(t) = part.as_text() {
                         if !t.is_empty() {
-                            print!("{t}");
+                            if streaming {
+                                print!("{t}");
+                                io::stdout().flush().ok();
+                            }
                             captured.push_str(t);
-                            io::stdout().flush().ok();
                         }
                     }
                 }
@@ -312,6 +400,8 @@ async fn stream_minerva_turn(agent: &mut Agent, user_input: &str) -> anyhow::Res
             _ => {}
         }
     }
-    println!();
+    if streaming {
+        println!();
+    }
     Ok(captured)
 }


### PR DESCRIPTION
## Summary

Stacks on top of #73. For multi-step plans only, integrate the per-step sub-agent outputs into one final answer using a small stitcher LLM (`gpt-5.4-mini`) before printing. Single-step plans keep the existing streaming UX and skip the stitcher entirely.

- For multi-step plans, sub-agent output is buffered (no stdout streaming during dispatch), then handed to the stitcher with the user's original request. The stitcher returns one concise answer in the user's language, which is printed at the end.
- Single-step plans stream as before — no extra LLM call, no behavior change for the common case.
- Stitch failure falls back to the prior `[step N • agent]` concat so the user still sees something useful.
- The helper is a private function inside `session.rs`. When backend-v2 adopts the same flow it can move into a library module.

## Why

The raw `[step N • agent] ...` concat is noisy when several sub-agents handle different slices of a request — the user has to mentally stitch the pieces back together. The stitcher turns N raw outputs into one answer with no step markers or meta-language.

Measured against the multi-step subset of the 35-case multi-intent set:
- Multi-step coverage: 91.7% → 90.0% (within noise; routing-time metrics unchanged because the stitcher runs after dispatch).
- Elapsed: 14.4 s → 14.9 s on average (~+3%). Stitch adds ~1.4 s on multi-step cases and 0 s on single-step (call is skipped).
- On the 50-case single-intent set, only 2/50 cases routed multi-step at all, so the stitcher fires rarely.

Qualitatively, multi-step answers no longer leak step headers and read as one coherent reply. Spot-checks (3 examples):
- "HTTP 418 + README line count" → one paragraph covering both, no `[step 1 ...]` headers.
- 4-intent plan (definition + comparison table + save + tree) → 745 chars stitched vs 2098 chars raw concat, with the comparison table preserved.
- "Compare LLM eval harnesses, separately compare Rust GPU libs" → 1566 chars stitched vs 7089 chars raw concat, both sections preserved with a closing one-line takeaway.

## Test plan

- [x] `cargo build -p agent-k --bin session` succeeds
- [x] Single-intent ("Python 한 줄 합산 코드") → 1-step `minerva`, streamed verbatim, no `[stitch]` log
- [x] Multi-intent ("1234 * 567 계산 + mutex 설명") → 2-step `minerva` → `speedwagon`, sub-agent outputs not streamed, `[stitch] integrating 2 step outputs` log, then one integrated answer
- [x] Stitch failure path reachable via the inline fallback (raw `[step N • agent]` concat)

## Out of scope (follow-up PRs)

- Wiring stitch into `backend-v2` so the FE can render either the integrated answer or per-step events.
- Structured Outputs on the router call to remove the ~2% enum escape deterministically.