### PR TITLE
feat(files): batch move/copy via PATCH /dirents, unified rename

### DIFF
--- a/app/src/api/backend-types.ts
+++ b/app/src/api/backend-types.ts
@@ -52,13 +52,19 @@ export interface BackendDirent {
   modified_at?: string | null;
 }
 
-export interface BackendUploadedFile { path: string; bytes: number; }
 export interface BackendFailedFile { path: string; error: string; }
-export interface BackendUploadResponse {
+
+/// Unified result shape for upload / move / copy batch operations.
+export interface BackendDirentBatchResult {
   project_id: string;
-  succeeded: BackendUploadedFile[];
+  succeeded: BackendDirent[];
   failed: BackendFailedFile[];
 }
+
+/// Tagged union for PATCH /dirents batch operations.
+export type BackendDirentBatchOp =
+  | { op: 'move'; sources: string[]; destination: string; new_name: string | null }
+  | { op: 'copy'; sources: string[]; destination: string };
 
 export type AiloyPart =
   | { type: 'text'; text: string }

--- a/app/src/api/dirents.ts
+++ b/app/src/api/dirents.ts
@@ -1,9 +1,13 @@
 import { ApiError, getBaseUrl, getToken, request } from './client';
-import type { BackendDirent, BackendUploadResponse } from './backend-types';
+import type {
+  BackendDirent,
+  BackendDirentBatchOp,
+  BackendDirentBatchResult,
+} from './backend-types';
 import { toFileAsset } from './transformers';
 import type { FileAsset } from '@/domain/types';
 
-export type UploadResult = BackendUploadResponse;
+export type DirentBatchResult = BackendDirentBatchResult;
 
 function encodePath(path: string): string {
   return path.split('/').map(encodeURIComponent).join('/');
@@ -25,7 +29,7 @@ export async function listDirentsRaw(projectId: string, recursive = true): Promi
   return res.entries;
 }
 
-export async function uploadFile(projectId: string, file: File, targetPath: string): Promise<UploadResult> {
+export async function uploadFile(projectId: string, file: File, targetPath: string): Promise<DirentBatchResult> {
   return uploadFiles(projectId, [{ file, targetPath }]);
 }
 
@@ -35,13 +39,13 @@ export async function uploadFile(projectId: string, file: File, targetPath: stri
 export async function uploadFiles(
   projectId: string,
   items: Array<{ file: File; targetPath: string }>,
-): Promise<UploadResult> {
+): Promise<DirentBatchResult> {
   const form = new FormData();
   for (const { file, targetPath } of items) {
     const renamed = new File([file], targetPath, { type: file.type });
     form.append('file', renamed);
   }
-  return request<UploadResult>(`/projects/${projectId}/dirents`, {
+  return request<DirentBatchResult>(`/projects/${projectId}/dirents`, {
     method: 'POST',
     body: form,
     isForm: true,
@@ -54,6 +58,38 @@ export async function createFolder(projectId: string, folderPath: string): Promi
   const form = new FormData();
   form.append('file', placeholder);
   await request(`/projects/${projectId}/dirents`, { method: 'POST', body: form, isForm: true });
+}
+
+// Collection-level batch op (move/copy). Rename is just a single-source move
+// with new_name set.
+export async function moveDirents(
+  projectId: string,
+  sources: string[],
+  destination: string,
+  newName?: string,
+): Promise<DirentBatchResult> {
+  const body: BackendDirentBatchOp = {
+    op: 'move',
+    sources,
+    destination,
+    new_name: newName ?? null,
+  };
+  return request<DirentBatchResult>(`/projects/${projectId}/dirents`, {
+    method: 'PATCH',
+    body,
+  });
+}
+
+export async function copyDirents(
+  projectId: string,
+  sources: string[],
+  destination: string,
+): Promise<DirentBatchResult> {
+  const body: BackendDirentBatchOp = { op: 'copy', sources, destination };
+  return request<DirentBatchResult>(`/projects/${projectId}/dirents`, {
+    method: 'PATCH',
+    body,
+  });
 }
 
 export async function deleteDirent(projectId: string, path: string): Promise<void> {

--- a/app/src/components/FolderPickerDialog.tsx
+++ b/app/src/components/FolderPickerDialog.tsx
@@ -1,0 +1,198 @@
+// Tree picker dialog for choosing a destination folder for move/copy ops.
+// Mirrors the NewFolderDialog visual pattern but renders a recursive folder
+// tree built from the project's dirents instead of a text input.
+//
+// destination convention: "" (empty string) = project root.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Icon } from './Icon';
+import { buildFolderTree, nameOf, type FolderNode } from '@/domain/files';
+import type { BackendDirent } from '@/api/backend-types';
+
+interface FolderPickerDialogProps {
+  title: string;
+  confirmLabel: string;
+  entries: BackendDirent[];
+  sources: BackendDirent[];
+  pending: boolean;
+  onConfirm: (destination: string) => void;
+  onClose: () => void;
+}
+
+function PickerNode({
+  node,
+  depth,
+  expanded,
+  selected,
+  disabledPaths,
+  onToggle,
+  onSelect,
+}: {
+  node: FolderNode;
+  depth: number;
+  expanded: Set<string>;
+  selected: string | null;
+  disabledPaths: Set<string>;
+  onToggle: (path: string) => void;
+  onSelect: (path: string) => void;
+}) {
+  const hasChildren = node.children.length > 0;
+  const isOpen = expanded.has(node.path);
+  const isSelected = selected === node.path;
+
+  // Disabled if this node is a source folder or any of its descendants.
+  let isDisabled = false;
+  for (const dp of disabledPaths) {
+    if (node.path === dp || node.path.startsWith(dp + '/')) {
+      isDisabled = true;
+      break;
+    }
+  }
+
+  return (
+    <>
+      <div
+        className={`cw-tree-row${isSelected ? ' is-selected' : ''}${isDisabled ? ' is-disabled' : ''}`}
+        style={{ paddingLeft: 8 + depth * 14 }}
+      >
+        <button
+          type="button"
+          className="cw-tree-chevron"
+          aria-label={isOpen ? '접기' : '펼치기'}
+          onClick={(e) => { e.stopPropagation(); onToggle(node.path); }}
+          style={{ visibility: hasChildren ? 'visible' : 'hidden' }}
+        >
+          <Icon name={isOpen ? 'chevron' : 'chevron-right'} size={12} />
+        </button>
+        <button
+          type="button"
+          className="cw-tree-label"
+          onClick={() => { if (!isDisabled) onSelect(node.path); }}
+          disabled={isDisabled}
+        >
+          <Icon name={isOpen ? 'folder-open' : 'folder'} size={14} />
+          <span>{node.name}</span>
+        </button>
+      </div>
+      {isOpen && node.children.map((child) => (
+        <PickerNode
+          key={child.path}
+          node={child}
+          depth={depth + 1}
+          expanded={expanded}
+          selected={selected}
+          disabledPaths={disabledPaths}
+          onToggle={onToggle}
+          onSelect={onSelect}
+        />
+      ))}
+    </>
+  );
+}
+
+export function FolderPickerDialog({
+  title, confirmLabel, entries, sources, pending, onConfirm, onClose,
+}: FolderPickerDialogProps) {
+  const tree = useMemo(() => buildFolderTree(entries), [entries]);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [selected, setSelected] = useState<string | null>('');
+
+  // Source folders block themselves and their descendants as destinations.
+  const disabledPaths = useMemo(() => {
+    const s = new Set<string>();
+    sources.forEach((src) => {
+      if (src.kind === 'dir') s.add(src.path);
+    });
+    return s;
+  }, [sources]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !pending) onClose();
+      if (e.key === 'Enter' && selected !== null && !pending) {
+        e.preventDefault();
+        onConfirm(selected);
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, onConfirm, pending, selected]);
+
+  const downOnBackdropRef = useRef(false);
+
+  function toggleExpand(path: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  const subtitle = sources.length === 1
+    ? `"${nameOf(sources[0]!)}"을(를) 이동할 폴더를 선택하세요.`
+    : `${sources.length}개 항목을 이동할 폴더를 선택하세요.`;
+
+  return (
+    <div
+      className="cw-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={(e) => { downOnBackdropRef.current = e.target === e.currentTarget; }}
+      onClick={(e) => {
+        const wasDown = downOnBackdropRef.current;
+        downOnBackdropRef.current = false;
+        if (wasDown && e.target === e.currentTarget && !pending) onClose();
+      }}
+    >
+      <div className="cw-dialog">
+        <button type="button" className="cw-close" onClick={onClose} disabled={pending} aria-label="close">
+          <Icon name="x" />
+        </button>
+        <h2 style={{ margin: '0 0 6px', fontSize: 18, letterSpacing: '-0.015em' }}>{title}</h2>
+        <p style={{ color: 'var(--cw-ink-3)', margin: '0 0 12px', fontSize: 13, lineHeight: 1.55 }}>
+          {subtitle}
+        </p>
+        <div className="cw-folder-picker-tree">
+          <div
+            className={`cw-tree-row${selected === '' ? ' is-selected' : ''}`}
+            style={{ paddingLeft: 8 }}
+          >
+            <span className="cw-tree-chevron" style={{ visibility: 'hidden' }}>
+              <Icon name="chevron-right" size={12} />
+            </span>
+            <button type="button" className="cw-tree-label" onClick={() => setSelected('')}>
+              <Icon name="folder" size={14} />
+              <span>프로젝트 루트</span>
+            </button>
+          </div>
+          {tree.map((node) => (
+            <PickerNode
+              key={node.path}
+              node={node}
+              depth={1}
+              expanded={expanded}
+              selected={selected}
+              disabledPaths={disabledPaths}
+              onToggle={toggleExpand}
+              onSelect={setSelected}
+            />
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 18 }}>
+          <button type="button" className="cw-btn-secondary" onClick={onClose} disabled={pending}>
+            취소
+          </button>
+          <button
+            type="button"
+            className="cw-btn-primary"
+            disabled={pending || selected === null}
+            onClick={() => { if (selected !== null) onConfirm(selected); }}
+          >
+            {pending ? '진행 중…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/RenameDialog.tsx
+++ b/app/src/components/RenameDialog.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react';
+import { Icon } from './Icon';
+import type { BackendDirent } from '@/api/backend-types';
+import { nameOf } from '@/domain/files';
+
+interface RenameDialogProps {
+  entry: BackendDirent;
+  existingNames: string[];
+  pending: boolean;
+  onConfirm: (newFullName: string) => void;
+  onClose: () => void;
+}
+
+function extOf(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? name.slice(dot) : '';
+}
+
+function validate(raw: string, originalName: string, existing: string[]): string | null {
+  const name = raw.trim();
+  if (name.length === 0) return null;
+  if (/[/\\]/.test(name)) return '이름에 / 또는 \\ 문자는 사용할 수 없습니다.';
+  if (/^\.+$/.test(name)) return '. 만으로 이루어진 이름은 사용할 수 없습니다.';
+  if (name === originalName) return '현재 이름과 동일합니다.';
+  if (existing.some((e) => e.toLowerCase() === name.toLowerCase())) {
+    return `"${name}" 이름이 이미 있습니다.`;
+  }
+  return null;
+}
+
+type Step = 'input' | 'confirm-ext';
+
+export function RenameDialog({ entry, existingNames, pending, onConfirm, onClose }: RenameDialogProps) {
+  const originalName = nameOf(entry);
+  const originalExt = entry.kind === 'file' ? extOf(originalName) : '';
+
+  const [value, setValue] = useState(originalName);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [step, setStep] = useState<Step>('input');
+
+  const trimmed = value.trim();
+  const submitDisabled = trimmed.length === 0 || pending;
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && !pending) {
+        if (step === 'confirm-ext') { setStep('input'); }
+        else { onClose(); }
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, pending, step]);
+
+  function handleChange(v: string) {
+    setValue(v);
+    if (submitError) setSubmitError(null);
+  }
+
+  function submit() {
+    if (submitDisabled) return;
+    const err = validate(value, originalName, existingNames.filter((n) => n !== originalName));
+    if (err) { setSubmitError(err); return; }
+
+    // Warn only for files with changed extension.
+    const newExt = entry.kind === 'file' ? extOf(trimmed) : '';
+    if (entry.kind === 'file' && newExt.toLowerCase() !== originalExt.toLowerCase()) {
+      setStep('confirm-ext');
+      return;
+    }
+    onConfirm(trimmed);
+  }
+
+  const downOnBackdropRef = useRef(false);
+
+  return (
+    <div
+      className="cw-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={(e) => { downOnBackdropRef.current = e.target === e.currentTarget; }}
+      onClick={(e) => {
+        const wasDown = downOnBackdropRef.current;
+        downOnBackdropRef.current = false;
+        if (wasDown && e.target === e.currentTarget && !pending) onClose();
+      }}
+    >
+      <form className="cw-dialog" onSubmit={(e) => { e.preventDefault(); submit(); }}>
+        <button type="button" className="cw-close" onClick={onClose} disabled={pending} aria-label="close">
+          <Icon name="x" />
+        </button>
+
+        <h2 style={{ margin: '0 0 6px', fontSize: 18, letterSpacing: '-0.015em' }}>이름 변경</h2>
+        <p style={{ color: 'var(--cw-ink-3)', margin: '0 0 16px', fontSize: 13, lineHeight: 1.55 }}>
+          현재 이름: <strong style={{ color: 'var(--cw-ink-2)' }}>{originalName}</strong>
+        </p>
+
+        {step === 'input' ? (
+          <>
+            <label className="cw-field">
+              <span>새 이름</span>
+              <input
+                autoFocus
+                value={value}
+                onChange={(e) => handleChange(e.target.value)}
+                disabled={pending}
+                aria-invalid={submitError !== null}
+                aria-describedby={submitError ? 'cw-rename-error' : undefined}
+              />
+            </label>
+            {submitError && (
+              <div id="cw-rename-error" className="cw-dialog-warn" role="alert">
+                <Icon name="x" size={12} /> {submitError}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 18 }}>
+              <button type="button" className="cw-btn-secondary" onClick={onClose} disabled={pending}>취소</button>
+              <button type="submit" className="cw-btn-primary" disabled={submitDisabled}>
+                {pending ? '변경 중…' : '변경'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="cw-dialog-warn" role="alert" style={{ marginBottom: 16 }}>
+              <Icon name="x" size={12} />
+              {' '}확장자가 <strong>{originalExt || '(없음)'}</strong>에서{' '}
+              <strong>{extOf(trimmed) || '(없음)'}</strong>으로 바뀝니다.
+              파일이 제대로 열리지 않을 수 있습니다.
+            </div>
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+              <button type="button" className="cw-btn-secondary" onClick={() => setStep('input')} disabled={pending}>
+                돌아가기
+              </button>
+              <button
+                type="button"
+                className="cw-btn-primary"
+                disabled={pending}
+                onClick={() => onConfirm(trimmed)}
+              >
+                {pending ? '변경 중…' : '확장자 포함하여 변경'}
+              </button>
+            </div>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/app/src/routes/_app.projects.$projectId.files.tsx
+++ b/app/src/routes/_app.projects.$projectId.files.tsx
@@ -15,17 +15,21 @@ import { createPortal } from 'react-dom';
 import { createFileRoute } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  copyDirents,
   createFolder,
   deleteDirent,
   downloadFile,
   listDirentsRaw,
+  moveDirents,
   uploadFiles,
-  type UploadResult,
+  type DirentBatchResult,
 } from '@/api/dirents';
 import { getProject } from '@/api/projects';
 import { Icon } from '@/components/Icon';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { FolderPickerDialog } from '@/components/FolderPickerDialog';
 import { NewFolderDialog } from '@/components/NewFolderDialog';
+import { RenameDialog } from '@/components/RenameDialog';
 import { EmptyState, IconPocket } from '@/components/uiPrimitives';
 import { useToastStore } from '@/components/Toast';
 import { ApiError } from '@/api/client';
@@ -131,7 +135,7 @@ function FilesPage() {
     currentPath.length > 0 ? `${currentPath.join('/')}/${file.name}` : file.name;
 
   const uploadMutation = useMutation({
-    mutationFn: async (files: File[]): Promise<UploadResult> => {
+    mutationFn: async (files: File[]): Promise<DirentBatchResult> => {
       const items = files.map((file) => ({ file, targetPath: targetPathFor(file) }));
       return uploadFiles(projectId, items);
     },
@@ -186,6 +190,14 @@ function FilesPage() {
   });
 
   const [pendingDelete, setPendingDelete] = useState<BackendDirent[] | null>(null);
+  const [pendingRename, setPendingRename] = useState<BackendDirent | null>(null);
+  const [pendingMove, setPendingMove] = useState<BackendDirent[] | null>(null);
+  const [pendingCopy, setPendingCopy] = useState<BackendDirent[] | null>(null);
+  const [openMenuPath, setOpenMenuPath] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
+  // Disambiguates "rename via dialog" from generic moves so we can show the
+  // right toast copy ("이름이 변경되었습니다" vs "이동되었습니다").
+  const renamingRef = useRef(false);
 
   const bulkDeleteMutation = useMutation({
     mutationFn: async (targets: BackendDirent[]) => {
@@ -282,6 +294,57 @@ function FilesPage() {
     files.forEach((f) => downloadMutation.mutate(f));
   }, [selectedEntries, downloadMutation, showToast]);
 
+  // Single unified mutation for both rename (1-item move with new_name) and
+  // bulk move. The `renamingRef` flag tells the success/error handler whether
+  // to show "이름이 변경되었습니다" or "이동되었습니다" copy.
+  const moveMutation = useMutation({
+    mutationFn: ({ sources, destination, newName }: { sources: string[]; destination: string; newName?: string }) =>
+      moveDirents(projectId, sources, destination, newName),
+    onSuccess: async (res) => {
+      await queryClient.invalidateQueries({ queryKey: ['dirents', projectId] });
+      const ok = res.succeeded.length;
+      const ko = res.failed.length;
+      const wasRename = renamingRef.current;
+      renamingRef.current = false;
+      if (wasRename) {
+        if (ko === 0) showToast('이름이 변경되었습니다');
+        else showToast('이름 변경 실패', res.failed.map((f) => f.error));
+      } else {
+        if (ko === 0) showToast(ok === 1 ? '이동되었습니다' : `${ok}개 이동되었습니다`);
+        else showToast(`${ok}개 이동, ${ko}개 실패`, res.failed.map((f) => `${f.path} — ${f.error}`));
+      }
+      setPendingRename(null);
+      setPendingMove(null);
+      setSelectedPaths(new Set());
+      anchorRef.current = null;
+    },
+    onError: (err) => {
+      const msg = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'move failed';
+      const wasRename = renamingRef.current;
+      renamingRef.current = false;
+      showToast(`${wasRename ? '이름 변경' : '이동'} 실패: ${msg}`);
+    },
+  });
+
+  const copyMutation = useMutation({
+    mutationFn: ({ sources, destination }: { sources: string[]; destination: string }) =>
+      copyDirents(projectId, sources, destination),
+    onSuccess: async (res) => {
+      await queryClient.invalidateQueries({ queryKey: ['dirents', projectId] });
+      const ok = res.succeeded.length;
+      const ko = res.failed.length;
+      if (ko === 0) showToast(ok === 1 ? '복사되었습니다' : `${ok}개 복사되었습니다`);
+      else showToast(`${ok}개 복사, ${ko}개 실패`, res.failed.map((f) => `${f.path} — ${f.error}`));
+      setPendingCopy(null);
+      setSelectedPaths(new Set());
+      anchorRef.current = null;
+    },
+    onError: (err) => {
+      const msg = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'copy failed';
+      showToast(`복사 실패: ${msg}`);
+    },
+  });
+
   // ── Outside click clears selection ───────────────────────────────
   // If the user clicks anywhere that isn't a file-pane interaction, the
   // floating bulk toolbar, or an open dialog, treat it as "dismiss".
@@ -298,14 +361,33 @@ function FilesPage() {
     return () => document.removeEventListener('mousedown', onDocMouseDown);
   }, [selectedPaths.size, clearSelection]);
 
+  // ── Outside click closes ⋯ dropdown ──────────────────────────────
+  useEffect(() => {
+    if (!openMenuPath) return;
+    function onDocClick(e: MouseEvent) {
+      const t = e.target as HTMLElement | null;
+      if (t?.closest('.cw-file-menu-wrap')) return;
+      setOpenMenuPath(null);
+    }
+    document.addEventListener('click', onDocClick, true);
+    return () => document.removeEventListener('click', onDocClick, true);
+  }, [openMenuPath]);
+
   // ── Keyboard shortcuts (window-level) ────────────────────────────
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       const target = e.target as HTMLElement | null;
       const inField = !!target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
 
-      if (e.key === 'Escape') { if (!inField) clearSelection(); return; }
+      if (e.key === 'Escape') { if (!inField) { setOpenMenuPath(null); clearSelection(); } return; }
       if (inField) return;
+
+      if (e.key === 'F2' && selectedPaths.size === 1 && !pendingRename) {
+        e.preventDefault();
+        const entry = entries.find((en) => selectedPaths.has(en.path));
+        if (entry) setPendingRename(entry);
+        return;
+      }
 
       if ((e.key === 'Delete' || e.key === 'Backspace') && selectedPaths.size > 0) {
         e.preventDefault();
@@ -446,6 +528,58 @@ function FilesPage() {
     };
   }, [dragRect]);
 
+  // ── Intra-app drag (move/copy) ───────────────────────────────────
+  // Global safety net: any drag that ends (dropped on a non-target or aborted
+  // with Esc) clears the highlighted folder so it doesn't get stuck visually.
+  useEffect(() => {
+    function onEnd() { setDropTarget(null); }
+    window.addEventListener('dragend', onEnd);
+    return () => window.removeEventListener('dragend', onEnd);
+  }, []);
+
+  // dataTransfer custom MIME distinguishes intra-app drag from external file
+  // upload. Alt/Ctrl/Cmd held during drop → copy; otherwise → move.
+  const handleDragStart = useCallback((e: React.DragEvent, entry: BackendDirent) => {
+    // mousedown started a potential rubber-band; HTML5 drag superseded it.
+    dragOriginRef.current = null;
+    setDragRect(null);
+    e.dataTransfer.effectAllowed = 'copyMove';
+    const dragPaths = selectedPaths.has(entry.path)
+      ? Array.from(selectedPaths)
+      : [entry.path];
+    e.dataTransfer.setData('application/x-cowork-dirent-paths', JSON.stringify(dragPaths));
+    e.dataTransfer.setData('text/plain', dragPaths.join('\n'));
+
+    // The browser's default drag image renders the entire row/card at the
+    // cursor, obscuring the drop area. Replace with a compact pill that just
+    // shows the item count (or filename for a single item).
+    const ghost = document.createElement('div');
+    ghost.className = 'cw-drag-ghost';
+    ghost.textContent = dragPaths.length === 1
+      ? nameOf(entry)
+      : `${dragPaths.length}개 항목`;
+    document.body.appendChild(ghost);
+    e.dataTransfer.setDragImage(ghost, 14, 14);
+    // Browser captures the bitmap synchronously; safe to remove next frame.
+    requestAnimationFrame(() => ghost.remove());
+  }, [selectedPaths]);
+
+  // Returns true if this event was an intra-app drop (handled), false otherwise.
+  const handleDropOnFolder = useCallback((destination: string, e: React.DragEvent): boolean => {
+    const raw = e.dataTransfer.getData('application/x-cowork-dirent-paths');
+    if (!raw) return false;
+    let sources: string[];
+    try { sources = JSON.parse(raw); } catch { return false; }
+    if (sources.some((s) => destination === s || destination.startsWith(s + '/'))) {
+      showToast('자기 자신 또는 하위 폴더로는 이동할 수 없습니다');
+      return true;
+    }
+    const isCopy = e.altKey || e.ctrlKey || e.metaKey;
+    if (isCopy) copyMutation.mutate({ sources, destination });
+    else moveMutation.mutate({ sources, destination });
+    return true;
+  }, [showToast, copyMutation, moveMutation]);
+
   // ── Confirm dialog copy ──────────────────────────────────────────
   const deleteCopy = useMemo(() => describeBulkDelete(pendingDelete, entries), [pendingDelete, entries]);
   const currentPathKey = currentPath.join('/');
@@ -478,8 +612,28 @@ function FilesPage() {
         <aside className="cw-sidebar-tree">
           <button
             type="button"
-            className={`cw-tree-row cw-tree-root${currentPath.length === 0 ? ' is-active' : ''}`}
+            className={`cw-tree-row cw-tree-root${currentPath.length === 0 ? ' is-active' : ''}${dropTarget === '' ? ' is-drop-target' : ''}`}
             onClick={() => setCurrentPath([])}
+            onDragEnter={(e) => {
+              if (!e.dataTransfer.types.includes('application/x-cowork-dirent-paths')) return;
+              e.preventDefault();
+              setDropTarget('');
+            }}
+            onDragOver={(e) => {
+              if (!e.dataTransfer.types.includes('application/x-cowork-dirent-paths')) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = e.altKey || e.ctrlKey || e.metaKey ? 'copy' : 'move';
+              setDropTarget('');
+            }}
+            onDragLeave={(e) => {
+              const to = e.relatedTarget as Node | null;
+              if (!to || !e.currentTarget.contains(to)) setDropTarget(null);
+            }}
+            onDrop={(e) => {
+              if (!handleDropOnFolder('', e)) return;
+              e.preventDefault();
+              setDropTarget(null);
+            }}
           >
             <Icon name="folder" size={14} />
             <span>{project.data?.name ?? 'Project'}</span>
@@ -492,8 +646,11 @@ function FilesPage() {
               currentPathKey={currentPathKey}
               expanded={expanded}
               entries={entries}
+              dropTarget={dropTarget}
               onSelect={(segments) => setCurrentPath(segments)}
               onToggle={toggleExpand}
+              onDropOnFolder={handleDropOnFolder}
+              setDropTarget={setDropTarget}
             />
           ))}
         </aside>
@@ -505,6 +662,17 @@ function FilesPage() {
                 <span className="cw-bulk-count">{selectedPaths.size}개 선택됨</span>
                 <button type="button" className="cw-btn-secondary" onClick={bulkDownload}>
                   <Icon name="download" size={13} /> Download
+                </button>
+                {selectedPaths.size === 1 && (
+                  <button type="button" className="cw-btn-secondary" onClick={() => setPendingRename(selectedEntries[0]!)}>
+                    <Icon name="writing" size={13} /> Rename
+                  </button>
+                )}
+                <button type="button" className="cw-btn-secondary" onClick={() => setPendingMove(selectedEntries)}>
+                  <Icon name="chevron-right" size={13} /> 이동
+                </button>
+                <button type="button" className="cw-btn-secondary" onClick={() => setPendingCopy(selectedEntries)}>
+                  <Icon name="file" size={13} /> 복사
                 </button>
                 <button type="button" className="cw-btn-secondary cw-btn-destructive" onClick={requestBulkDelete}>
                   <Icon name="trash" size={13} /> Delete
@@ -545,9 +713,16 @@ function FilesPage() {
             className={`cw-file-body cw-view-${viewMode}${isDraggingOver ? ' is-over' : ''}`}
             onClick={(e) => { if (e.target === e.currentTarget) clearSelection(); }}
             onMouseDown={onBodyMouseDown}
-            onDragEnter={(e) => { e.preventDefault(); dragDepthRef.current += 1; setIsDraggingOver(true); }}
+            onDragEnter={(e) => {
+              // Internal drag (move/copy) doesn't paint the upload over-state.
+              if (e.dataTransfer.types.includes('application/x-cowork-dirent-paths')) return;
+              e.preventDefault();
+              dragDepthRef.current += 1;
+              setIsDraggingOver(true);
+            }}
             onDragOver={(e) => { e.preventDefault(); }}
             onDragLeave={(e) => {
+              if (e.dataTransfer.types.includes('application/x-cowork-dirent-paths')) return;
               e.preventDefault();
               dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
               if (dragDepthRef.current === 0) setIsDraggingOver(false);
@@ -556,6 +731,9 @@ function FilesPage() {
               e.preventDefault();
               dragDepthRef.current = 0;
               setIsDraggingOver(false);
+              // Intra-app drop on the file body is treated as cancel — only
+              // sidebar tree folders are valid intra-app destinations.
+              if (e.dataTransfer.types.includes('application/x-cowork-dirent-paths')) return;
               onDropFiles(e.dataTransfer.files);
             }}
           >
@@ -579,9 +757,16 @@ function FilesPage() {
                     entries={entries}
                     selected={selectedPaths.has(entry.path)}
                     showPath={view.isSearch}
+                    menuOpen={openMenuPath === entry.path}
                     onSelect={handleSelect}
                     onOpen={openEntry}
+                    onDownload={(e) => downloadMutation.mutate(e)}
                     onDelete={(e) => setPendingDelete([e])}
+                    onRename={(e) => setPendingRename(e)}
+                    onMove={(e) => setPendingMove([e])}
+                    onCopy={(e) => setPendingCopy([e])}
+                    onMenuToggle={setOpenMenuPath}
+                    onDragStart={handleDragStart}
                   />
                 ))}
               </div>
@@ -595,9 +780,16 @@ function FilesPage() {
                     entries={entries}
                     selected={selectedPaths.has(entry.path)}
                     showPath={view.isSearch}
+                    menuOpen={openMenuPath === entry.path}
                     onSelect={handleSelect}
                     onOpen={openEntry}
+                    onDownload={(e) => downloadMutation.mutate(e)}
                     onDelete={(e) => setPendingDelete([e])}
+                    onRename={(e) => setPendingRename(e)}
+                    onMove={(e) => setPendingMove([e])}
+                    onCopy={(e) => setPendingCopy([e])}
+                    onMenuToggle={setOpenMenuPath}
+                    onDragStart={handleDragStart}
                   />
                 ))}
               </div>
@@ -634,6 +826,50 @@ function FilesPage() {
           onClose={() => { if (!bulkDeleteMutation.isPending) setPendingDelete(null); }}
         />
       )}
+
+      {pendingRename && (
+        <RenameDialog
+          entry={pendingRename}
+          existingNames={view.folders.concat(view.files).map(nameOf)}
+          pending={moveMutation.isPending}
+          onConfirm={(newName) => {
+            const parent = pendingRename.path.split('/').slice(0, -1).join('/');
+            renamingRef.current = true;
+            moveMutation.mutate({ sources: [pendingRename.path], destination: parent, newName });
+          }}
+          onClose={() => { if (!moveMutation.isPending) setPendingRename(null); }}
+        />
+      )}
+
+      {pendingMove && (
+        <FolderPickerDialog
+          title="이동"
+          confirmLabel="이동"
+          entries={entries}
+          sources={pendingMove}
+          pending={moveMutation.isPending}
+          onConfirm={(destination) => moveMutation.mutate({
+            sources: pendingMove.map((e) => e.path),
+            destination,
+          })}
+          onClose={() => { if (!moveMutation.isPending) setPendingMove(null); }}
+        />
+      )}
+
+      {pendingCopy && (
+        <FolderPickerDialog
+          title="복사"
+          confirmLabel="복사"
+          entries={entries}
+          sources={pendingCopy}
+          pending={copyMutation.isPending}
+          onConfirm={(destination) => copyMutation.mutate({
+            sources: pendingCopy.map((e) => e.path),
+            destination,
+          })}
+          onClose={() => { if (!copyMutation.isPending) setPendingCopy(null); }}
+        />
+      )}
     </section>
   );
 }
@@ -646,25 +882,62 @@ function TreeBranch({
   currentPathKey,
   expanded,
   entries,
+  dropTarget,
   onSelect,
   onToggle,
+  onDropOnFolder,
+  setDropTarget,
 }: {
   node: FolderNode;
   depth: number;
   currentPathKey: string;
   expanded: Set<string>;
   entries: BackendDirent[];
+  dropTarget: string | null;
   onSelect: (segments: string[]) => void;
   onToggle: (path: string) => void;
+  onDropOnFolder: (destination: string, e: React.DragEvent) => boolean;
+  setDropTarget: (path: string | null) => void;
 }) {
   const isActive = currentPathKey === node.path;
   const hasChildren = node.children.length > 0;
   const isOpen = expanded.has(node.path);
   const count = countDescendants(entries, node.segments);
+  const isDropTarget = dropTarget === node.path;
 
   return (
     <>
-      <div className={`cw-tree-row${isActive ? ' is-active' : ''}`} style={{ paddingLeft: 8 + depth * 14 }}>
+      <div
+        className={`cw-tree-row${isActive ? ' is-active' : ''}${isDropTarget ? ' is-drop-target' : ''}`}
+        style={{ paddingLeft: 8 + depth * 14 }}
+        onDragEnter={(e) => {
+          if (!e.dataTransfer.types.includes('application/x-cowork-dirent-paths')) return;
+          e.preventDefault();
+          e.stopPropagation();
+          setDropTarget(node.path);
+        }}
+        onDragOver={(e) => {
+          if (!e.dataTransfer.types.includes('application/x-cowork-dirent-paths')) return;
+          e.preventDefault();
+          e.stopPropagation();
+          e.dataTransfer.dropEffect = e.altKey || e.ctrlKey || e.metaKey ? 'copy' : 'move';
+          // Re-affirm dropTarget continuously; helps after children flicker.
+          setDropTarget(node.path);
+        }}
+        onDragLeave={(e) => {
+          // dragleave fires when crossing into a child too; only clear if
+          // the cursor moved outside this row entirely. The global dragend
+          // listener catches the case where the drag aborts elsewhere.
+          const to = e.relatedTarget as Node | null;
+          if (!to || !e.currentTarget.contains(to)) setDropTarget(null);
+        }}
+        onDrop={(e) => {
+          if (!onDropOnFolder(node.path, e)) return;
+          e.preventDefault();
+          e.stopPropagation();
+          setDropTarget(null);
+        }}
+      >
         <button
           type="button"
           className="cw-tree-chevron"
@@ -688,8 +961,11 @@ function TreeBranch({
           currentPathKey={currentPathKey}
           expanded={expanded}
           entries={entries}
+          dropTarget={dropTarget}
           onSelect={onSelect}
           onToggle={onToggle}
+          onDropOnFolder={onDropOnFolder}
+          setDropTarget={setDropTarget}
         />
       ))}
     </>
@@ -704,9 +980,16 @@ interface RowProps {
   entries: BackendDirent[];
   selected: boolean;
   showPath: boolean;
+  menuOpen: boolean;
   onSelect: (e: BackendDirent, ev: React.MouseEvent | React.KeyboardEvent) => void;
   onOpen: (e: BackendDirent) => void;
+  onDownload: (e: BackendDirent) => void;
   onDelete: (e: BackendDirent) => void;
+  onRename: (e: BackendDirent) => void;
+  onMove: (e: BackendDirent) => void;
+  onCopy: (e: BackendDirent) => void;
+  onMenuToggle: (path: string | null) => void;
+  onDragStart: (ev: React.DragEvent, e: BackendDirent) => void;
 }
 
 function iconClass(entry: BackendDirent): string {
@@ -723,7 +1006,70 @@ function folderSubtitle(entry: BackendDirent, entries: BackendDirent[]): string 
   return n === 0 ? '빈 폴더' : `${n}개 항목`;
 }
 
-function ListRow({ entry, index, entries, selected, showPath, onSelect, onOpen, onDelete }: RowProps) {
+function RowMenu({
+  entry, menuOpen, onMenuToggle, onDownload, onRename, onMove, onCopy, onDelete,
+}: {
+  entry: BackendDirent;
+  menuOpen: boolean;
+  onMenuToggle: (path: string | null) => void;
+  onDownload: () => void;
+  onRename: () => void;
+  onMove: () => void;
+  onCopy: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="cw-file-menu-wrap">
+      <button
+        type="button"
+        className="cw-file-more"
+        aria-label="더보기"
+        aria-expanded={menuOpen}
+        onClick={(e) => { e.stopPropagation(); onMenuToggle(menuOpen ? null : entry.path); }}
+      >
+        <Icon name="more" size={14} />
+      </button>
+      {menuOpen && (
+        <ul
+          className="cw-file-dropdown"
+          role="menu"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {entry.kind === 'file' && (
+            <li role="menuitem">
+              <button type="button" onClick={() => { onMenuToggle(null); onDownload(); }}>
+                <Icon name="download" size={13} /> Download
+              </button>
+            </li>
+          )}
+          <li role="menuitem">
+            <button type="button" onClick={() => { onMenuToggle(null); onRename(); }}>
+              <Icon name="writing" size={13} /> Rename
+            </button>
+          </li>
+          <li role="menuitem">
+            <button type="button" onClick={() => { onMenuToggle(null); onMove(); }}>
+              <Icon name="chevron-right" size={13} /> 이동…
+            </button>
+          </li>
+          <li role="menuitem">
+            <button type="button" onClick={() => { onMenuToggle(null); onCopy(); }}>
+              <Icon name="file" size={13} /> 복사…
+            </button>
+          </li>
+          <li role="separator" aria-hidden="true" className="cw-file-dropdown-sep" />
+          <li role="menuitem">
+            <button type="button" className="cw-file-dropdown-destructive" onClick={() => { onMenuToggle(null); onDelete(); }}>
+              <Icon name="trash" size={13} /> Delete
+            </button>
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ListRow({ entry, index, entries, selected, showPath, menuOpen, onSelect, onOpen, onDownload, onDelete, onRename, onMove, onCopy, onMenuToggle, onDragStart }: RowProps) {
   const isDir = entry.kind === 'dir';
   return (
     <div
@@ -733,6 +1079,8 @@ function ListRow({ entry, index, entries, selected, showPath, onSelect, onOpen, 
       aria-selected={selected}
       data-row-index={index}
       data-row-path={entry.path}
+      draggable
+      onDragStart={(e) => onDragStart(e, entry)}
       onClick={(e) => { e.stopPropagation(); onSelect(entry, e); }}
       onDoubleClick={(e) => { e.stopPropagation(); onOpen(entry); }}
       onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); onOpen(entry); } }}
@@ -749,19 +1097,21 @@ function ListRow({ entry, index, entries, selected, showPath, onSelect, onOpen, 
             : `${entry.modified_at ? new Date(entry.modified_at).toLocaleDateString() : '—'} · ${formatBytes(entry.bytes ?? 0)}`}
         </span>
       </span>
-      <button
-        type="button"
-        className="cw-file-more"
-        aria-label={isDir ? '폴더 삭제' : '파일 삭제'}
-        onClick={(e) => { e.stopPropagation(); onDelete(entry); }}
-      >
-        <Icon name="trash" size={14} />
-      </button>
+      <RowMenu
+        entry={entry}
+        menuOpen={menuOpen}
+        onMenuToggle={onMenuToggle}
+        onDownload={() => onDownload(entry)}
+        onRename={() => onRename(entry)}
+        onMove={() => onMove(entry)}
+        onCopy={() => onCopy(entry)}
+        onDelete={() => onDelete(entry)}
+      />
     </div>
   );
 }
 
-function GridCard({ entry, index, entries, selected, showPath, onSelect, onOpen, onDelete }: RowProps) {
+function GridCard({ entry, index, entries, selected, showPath, menuOpen, onSelect, onOpen, onDownload, onDelete, onRename, onMove, onCopy, onMenuToggle, onDragStart }: RowProps) {
   const isDir = entry.kind === 'dir';
   return (
     <div
@@ -771,6 +1121,8 @@ function GridCard({ entry, index, entries, selected, showPath, onSelect, onOpen,
       aria-selected={selected}
       data-row-index={index}
       data-row-path={entry.path}
+      draggable
+      onDragStart={(e) => onDragStart(e, entry)}
       onClick={(e) => { e.stopPropagation(); onSelect(entry, e); }}
       onDoubleClick={(e) => { e.stopPropagation(); onOpen(entry); }}
       onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); onOpen(entry); } }}
@@ -786,14 +1138,16 @@ function GridCard({ entry, index, entries, selected, showPath, onSelect, onOpen,
             ? folderSubtitle(entry, entries)
             : formatBytes(entry.bytes ?? 0)}
       </div>
-      <button
-        type="button"
-        className="cw-grid-card-more"
-        aria-label={isDir ? '폴더 삭제' : '파일 삭제'}
-        onClick={(e) => { e.stopPropagation(); onDelete(entry); }}
-      >
-        <Icon name="trash" size={13} />
-      </button>
+      <RowMenu
+        entry={entry}
+        menuOpen={menuOpen}
+        onMenuToggle={onMenuToggle}
+        onDownload={() => onDownload(entry)}
+        onRename={() => onRename(entry)}
+        onMove={() => onMove(entry)}
+        onCopy={() => onCopy(entry)}
+        onDelete={() => onDelete(entry)}
+      />
     </div>
   );
 }

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -169,6 +169,42 @@ button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px s
 .cw-sidebar-tree .cw-tree-root { padding: 6px 8px; font-size: 12px; font-weight: 600; color: var(--cw-ink-3); border: 0; background: transparent; width: 100%; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; min-height: 30px; border-radius: var(--cw-radius-sm); margin-bottom: 4px; }
 .cw-sidebar-tree .cw-tree-root:hover { background: var(--cw-paper-3); color: var(--cw-ink); }
 .cw-sidebar-tree .cw-tree-root.is-active { background: var(--cw-paper-3); color: var(--cw-ink); }
+/* Drop target highlight when dragging dirents onto a folder. Scoped to
+   .cw-sidebar-tree so it (a) doesn't bleed into the FolderPickerDialog tree
+   and (b) wins over .cw-sidebar-tree .cw-tree-row.is-active specificity. */
+.cw-sidebar-tree .cw-tree-row.is-drop-target,
+.cw-sidebar-tree .cw-tree-root.is-drop-target {
+  background: var(--cw-accent-soft);
+  outline: 2px solid var(--cw-accent);
+  outline-offset: -2px;
+  color: var(--cw-ink);
+}
+/* Compact pill rendered as the HTML5 drag image — replaces the default,
+   which renders the whole row/card and obscures the drop area. */
+.cw-drag-ghost {
+  position: absolute;
+  top: -1000px;
+  left: -1000px;
+  padding: 6px 12px;
+  background: var(--cw-paper);
+  border: 1px solid var(--cw-accent, var(--cw-paper-4));
+  border-radius: 8px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--cw-ink);
+  box-shadow: 0 4px 12px color-mix(in oklch, var(--cw-ink) 18%, transparent);
+  white-space: nowrap;
+  pointer-events: none;
+}
+/* FolderPickerDialog: reuses .cw-dialog backdrop; only the tree area is custom. */
+.cw-folder-picker-tree { max-height: 280px; overflow: auto; border: 1px solid var(--cw-line); border-radius: 8px; padding: 6px; margin-top: 8px; background: var(--cw-paper-2); }
+.cw-folder-picker-tree .cw-tree-row { display: flex; align-items: center; gap: 4px; min-height: 28px; padding: 0 6px 0 8px; border-radius: var(--cw-radius-sm); color: var(--cw-ink-2); }
+.cw-folder-picker-tree .cw-tree-row.is-selected { background: var(--cw-selected-bg); color: var(--cw-ink); font-weight: 500; }
+.cw-folder-picker-tree .cw-tree-row.is-disabled { opacity: 0.4; }
+.cw-folder-picker-tree .cw-tree-row.is-disabled .cw-tree-label { cursor: not-allowed; }
+.cw-folder-picker-tree .cw-tree-chevron { background: transparent; border: 0; padding: 2px; cursor: pointer; color: var(--cw-ink-3); display: inline-flex; align-items: center; }
+.cw-folder-picker-tree .cw-tree-label { background: transparent; border: 0; padding: 4px 6px; cursor: pointer; flex: 1; text-align: left; display: inline-flex; align-items: center; gap: 6px; color: inherit; font: inherit; }
+.cw-folder-picker-tree .cw-tree-label:hover { color: var(--cw-ink); }
 .cw-sidebar-tree .cw-tree-chevron { width: 18px; height: 22px; display: inline-flex; align-items: center; justify-content: center; border: 0; background: transparent; color: var(--cw-ink-4); cursor: pointer; padding: 0; border-radius: var(--cw-radius-sm); flex: 0 0 auto; }
 .cw-sidebar-tree .cw-tree-chevron:hover { color: var(--cw-ink-2); background: var(--cw-paper-3); }
 .cw-sidebar-tree .cw-tree-label { flex: 1 1 auto; min-width: 0; display: inline-flex; align-items: center; gap: 6px; border: 0; background: transparent; padding: 4px 6px; text-align: left; font-size: 12.5px; color: inherit; cursor: pointer; border-radius: var(--cw-radius-sm); }
@@ -533,8 +569,22 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.cw-file-more { width: 24px; height: 24px; border-radius: 5px; display: inline-flex; align-items: center; justify-content: center; color: var(--cw-ink-4); }
+.cw-file-menu-wrap { position: relative; flex-shrink: 0; }
+.cw-file-more { width: 24px; height: 24px; border-radius: 5px; display: inline-flex; align-items: center; justify-content: center; border: 0; background: transparent; color: var(--cw-ink-4); cursor: pointer; transition: background 120ms, color 120ms; }
 .cw-file-row:hover .cw-file-more { color: var(--cw-ink); }
+.cw-file-more:hover, .cw-file-more[aria-expanded="true"] { background: var(--cw-paper-3); color: var(--cw-ink); }
+.cw-file-dropdown { position: absolute; top: calc(100% + 4px); right: 0; z-index: 120; min-width: 148px; padding: 4px; list-style: none; margin: 0; background: var(--cw-paper); border: 1px solid var(--cw-line); border-radius: 10px; box-shadow: 0 4px 16px color-mix(in oklch, var(--cw-ink) 10%, transparent); }
+.cw-file-dropdown li button { display: flex; align-items: center; gap: 8px; width: 100%; padding: 6px 9px; border: 0; border-radius: 6px; background: transparent; color: var(--cw-ink-2); font-size: 12.5px; cursor: pointer; text-align: left; white-space: nowrap; }
+.cw-file-dropdown li button:hover { background: var(--cw-paper-3); color: var(--cw-ink); }
+.cw-file-dropdown-sep { height: 1px; background: var(--cw-line); margin: 3px 4px; }
+.cw-file-dropdown-destructive { color: var(--cw-cozy-rose) !important; }
+.cw-file-dropdown-destructive:hover { background: color-mix(in oklch, var(--cw-cozy-rose) 10%, var(--cw-paper)) !important; }
+.cw-grid-card .cw-file-menu-wrap { position: absolute; top: 4px; right: 4px; }
+.cw-grid-card .cw-file-more { opacity: 0; transition: opacity 120ms, background 120ms, color 120ms; }
+.cw-grid-card:hover .cw-file-more,
+.cw-grid-card.is-selected .cw-file-more,
+.cw-grid-card:focus-within .cw-file-more,
+.cw-grid-card .cw-file-more[aria-expanded="true"] { opacity: 1; }
 .cw-file-row .cw-pocket { width: 30px; height: 30px; border-radius: 7px; flex: 0 0 auto; }
 .cw-pocket.is-compact { width: 22px; height: 22px; border-radius: 7px; }
 .cw-file-pdf { background: color-mix(in oklch, var(--cw-cozy-rose) 14%, var(--cw-paper)); color: var(--cw-cozy-rose); }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -21,8 +21,7 @@
     "types": ["vite/client", "node"],
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "baseUrl": "."
+    }
   },
   "include": ["src", "tests"]
 }

--- a/backend/src/handlers/dirent.rs
+++ b/backend/src/handlers/dirent.rs
@@ -536,8 +536,16 @@ async fn build_dirent(uploads_root: &Path, host: &Path) -> Result<Dirent, String
         .strip_prefix(uploads_root)
         .map(|p| p.to_string_lossy().replace('\\', "/"))
         .unwrap_or_default();
-    let kind = if meta.is_dir() { DirentKind::Dir } else { DirentKind::File };
-    let bytes = if meta.is_dir() { None } else { Some(meta.len()) };
+    let kind = if meta.is_dir() {
+        DirentKind::Dir
+    } else {
+        DirentKind::File
+    };
+    let bytes = if meta.is_dir() {
+        None
+    } else {
+        Some(meta.len())
+    };
     let modified_at = meta.modified().ok().map(DateTime::<Utc>::from);
     Ok(Dirent {
         path: rel,
@@ -577,10 +585,7 @@ async fn find_available_name(parent: &Path, base_name: &str) -> PathBuf {
         }
     }
     // Fallback (effectively unreachable)
-    parent.join(format!(
-        "{stem} copy {}{ext}",
-        Uuid::new_v4().simple()
-    ))
+    parent.join(format!("{stem} copy {}{ext}", Uuid::new_v4().simple()))
 }
 
 /// Recursive folder copy. Symlinks are skipped to prevent escape.
@@ -650,11 +655,7 @@ async fn move_one(
 }
 
 /// Single copy (folder is recursive; auto " copy" suffix on conflict).
-async fn copy_one(
-    uploads_root: &Path,
-    src_rel: &str,
-    dest_dir: &Path,
-) -> Result<Dirent, String> {
+async fn copy_one(uploads_root: &Path, src_rel: &str, dest_dir: &Path) -> Result<Dirent, String> {
     let (src_host, src_meta) = load_source(uploads_root, src_rel, dest_dir).await?;
 
     let base_name = src_host
@@ -728,7 +729,10 @@ pub async fn batch_op(
             for src in sources {
                 match move_one(&uploads_root, &src, &dest_dir, new_name.as_deref()).await {
                     Ok(d) => succeeded.push(d),
-                    Err(e) => failed.push(FailedFile { path: src, error: e }),
+                    Err(e) => failed.push(FailedFile {
+                        path: src,
+                        error: e,
+                    }),
                 }
             }
             tracing::info!(
@@ -749,7 +753,10 @@ pub async fn batch_op(
             for src in sources {
                 match copy_one(&uploads_root, &src, &dest_dir).await {
                     Ok(d) => succeeded.push(d),
-                    Err(e) => failed.push(FailedFile { path: src, error: e }),
+                    Err(e) => failed.push(FailedFile {
+                        path: src,
+                        error: e,
+                    }),
                 }
             }
             tracing::info!(

--- a/backend/src/handlers/dirent.rs
+++ b/backend/src/handlers/dirent.rs
@@ -14,9 +14,9 @@ use uuid::Uuid;
 
 use crate::{
     auth::AuthUser,
-    error::{ApiResult, AppError},
+    error::{ApiError, ApiResult, AppError},
     model::{
-        Dirent, DirentKind, FailedFile, ListQuery, ListResponse, UploadResponse, UploadedFile,
+        Dirent, DirentBatchOp, DirentBatchResult, DirentKind, FailedFile, ListQuery, ListResponse,
     },
     state::AppState,
 };
@@ -65,7 +65,7 @@ pub async fn upload(
     Extension(auth_user): Extension<AuthUser>,
     AxumPath(project_id): AxumPath<Uuid>,
     NoApi(mut multipart): NoApi<Multipart>,
-) -> ApiResult<Json<UploadResponse>> {
+) -> ApiResult<Json<DirentBatchResult>> {
     let in_project = state
         .repository
         .user_in_project(auth_user.id, project_id)
@@ -86,7 +86,7 @@ pub async fn upload(
         .map_err(|e| AppError::internal(format!("failed to create uploads directory: {e}")))?;
 
     let max_bytes = state.max_upload_bytes;
-    let mut succeeded: Vec<UploadedFile> = Vec::new();
+    let mut succeeded: Vec<Dirent> = Vec::new();
     let mut failed: Vec<FailedFile> = Vec::new();
 
     'files: while let Some(mut field) = multipart
@@ -199,15 +199,22 @@ pub async fn upload(
             continue;
         }
 
-        succeeded.push(UploadedFile {
+        let modified_at = tokio::fs::metadata(&host_path)
+            .await
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .map(DateTime::<Utc>::from);
+        succeeded.push(Dirent {
             path: filename,
-            bytes: byte_count,
+            kind: DirentKind::File,
+            bytes: Some(byte_count),
+            modified_at,
         });
     }
 
     tracing::info!(project = %project_id, count = %succeeded.len(), "dirents uploaded");
 
-    Ok(Json(UploadResponse {
+    Ok(Json(DirentBatchResult {
         project_id,
         succeeded,
         failed,
@@ -438,4 +445,308 @@ pub async fn delete_path(
     tracing::info!(project = %project_id, path = %path_str, "dirent deleted");
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Batch operations (move / copy)
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn validate_filename(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("name must not be empty".into());
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err("name must not contain path separators".into());
+    }
+    if name.contains('\0') {
+        return Err("name must not contain NUL bytes".into());
+    }
+    if name == "." || name == ".." {
+        return Err("name must not be '.' or '..'".into());
+    }
+    Ok(())
+}
+
+/// Empty or "/" destination resolves to the uploads_root itself.
+fn resolve_destination(uploads_root: &Path, dest: &str) -> Result<PathBuf, String> {
+    let trimmed = dest.trim_matches('/');
+    if trimmed.is_empty() {
+        return Ok(uploads_root.to_path_buf());
+    }
+    safe_join(uploads_root, trimmed)
+}
+
+/// Resolve, create, and validate a destination directory for batch ops.
+/// Returns ApiError so the outer handler can short-circuit on malformed input
+/// without polluting `failed` with the same error per source.
+async fn prepare_dest_dir(uploads_root: &Path, destination: &str) -> Result<PathBuf, ApiError> {
+    let dest_dir = resolve_destination(uploads_root, destination).map_err(AppError::bad_request)?;
+    tokio::fs::create_dir_all(&dest_dir)
+        .await
+        .map_err(|e| AppError::internal(format!("create dest: {e}")))?;
+    let dest_meta = tokio::fs::metadata(&dest_dir)
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    if !dest_meta.is_dir() {
+        return Err(AppError::bad_request("destination is not a directory"));
+    }
+    Ok(dest_dir)
+}
+
+/// Load and validate a source path against an already-prepared destination.
+/// Used by both `move_one` and `copy_one` to avoid copy-pasting the safe-join
+/// + symlink rejection + folder-into-itself check.
+async fn load_source(
+    uploads_root: &Path,
+    src_rel: &str,
+    dest_dir: &Path,
+) -> Result<(PathBuf, std::fs::Metadata), String> {
+    let src_host = safe_join(uploads_root, src_rel)?;
+    let src_meta = tokio::fs::symlink_metadata(&src_host).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            "source not found".to_string()
+        } else {
+            e.to_string()
+        }
+    })?;
+    if src_meta.is_symlink() {
+        return Err("source not found".into());
+    }
+    if src_meta.is_dir() && dest_dir.starts_with(&src_host) {
+        return Err("cannot move a folder into itself or its descendants".into());
+    }
+    Ok((src_host, src_meta))
+}
+
+/// Build a Dirent response object from a final on-disk path.
+async fn build_dirent(uploads_root: &Path, host: &Path) -> Result<Dirent, String> {
+    let meta = tokio::fs::metadata(host)
+        .await
+        .map_err(|e| format!("metadata: {e}"))?;
+    let rel = host
+        .strip_prefix(uploads_root)
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_default();
+    let kind = if meta.is_dir() { DirentKind::Dir } else { DirentKind::File };
+    let bytes = if meta.is_dir() { None } else { Some(meta.len()) };
+    let modified_at = meta.modified().ok().map(DateTime::<Utc>::from);
+    Ok(Dirent {
+        path: rel,
+        kind,
+        bytes,
+        modified_at,
+    })
+}
+
+/// "foo.pdf" → "foo copy.pdf" → "foo copy 2.pdf" → …
+/// Dot-files ("foo" prefix is empty) are treated as having no extension.
+fn find_available_name(parent: &Path, base_name: &str) -> PathBuf {
+    let candidate = parent.join(base_name);
+    if !candidate.exists() {
+        return candidate;
+    }
+    let (stem, ext) = if base_name.starts_with('.') {
+        (base_name, "")
+    } else {
+        match base_name.rfind('.') {
+            Some(i) if i > 0 => (&base_name[..i], &base_name[i..]),
+            _ => (base_name, ""),
+        }
+    };
+    let first = parent.join(format!("{stem} copy{ext}"));
+    if !first.exists() {
+        return first;
+    }
+    for n in 2..1000 {
+        let cand = parent.join(format!("{stem} copy {n}{ext}"));
+        if !cand.exists() {
+            return cand;
+        }
+    }
+    // Fallback (effectively unreachable)
+    parent.join(format!(
+        "{stem} copy {}{ext}",
+        Uuid::new_v4().simple()
+    ))
+}
+
+/// Recursive folder copy. Symlinks are skipped to prevent escape.
+///
+/// Safety: callers must pass paths that were already validated via `safe_join`
+/// against `uploads_root` AND confirmed non-symlink. Inside this function, all
+/// further descents are by reading dir entries (no string-derived paths from
+/// untrusted input), and any symlink encountered is skipped, so a malicious
+/// symlink planted inside the source tree cannot escape `dst`'s subtree.
+// nosemgrep: rust.actix.path-traversal.tainted-path
+async fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    tokio::fs::create_dir_all(dst).await?;
+    let mut rd = tokio::fs::read_dir(src).await?;
+    while let Some(entry) = rd.next_entry().await? {
+        let ft = entry.file_type().await?;
+        if ft.is_symlink() {
+            continue;
+        }
+        let entry_path = entry.path();
+        let target = dst.join(entry.file_name());
+        if ft.is_dir() {
+            Box::pin(copy_dir_recursive(&entry_path, &target)).await?;
+        } else {
+            tokio::fs::copy(&entry_path, &target).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Single move (rename = same destination + new_name).
+async fn move_one(
+    uploads_root: &Path,
+    src_rel: &str,
+    dest_dir: &Path,
+    new_name: Option<&str>,
+) -> Result<Dirent, String> {
+    let (src_host, _src_meta) = load_source(uploads_root, src_rel, dest_dir).await?;
+
+    let filename = match new_name {
+        Some(n) => {
+            validate_filename(n)?;
+            n.to_string()
+        }
+        None => src_host
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| "could not determine source filename".to_string())?
+            .to_string(),
+    };
+
+    let new_host = dest_dir.join(&filename);
+
+    if new_host.strip_prefix(uploads_root).is_err() {
+        return Err("destination would escape uploads root".into());
+    }
+
+    if tokio::fs::symlink_metadata(&new_host).await.is_ok() {
+        return Err(format!("\"{filename}\" already exists at destination"));
+    }
+
+    tokio::fs::rename(&src_host, &new_host)
+        .await
+        .map_err(|e| format!("rename failed: {e}"))?;
+
+    build_dirent(uploads_root, &new_host).await
+}
+
+/// Single copy (folder is recursive; auto " copy" suffix on conflict).
+async fn copy_one(
+    uploads_root: &Path,
+    src_rel: &str,
+    dest_dir: &Path,
+) -> Result<Dirent, String> {
+    let (src_host, src_meta) = load_source(uploads_root, src_rel, dest_dir).await?;
+
+    let base_name = src_host
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "could not determine source filename".to_string())?
+        .to_string();
+
+    let new_host = find_available_name(dest_dir, &base_name);
+
+    if new_host.strip_prefix(uploads_root).is_err() {
+        return Err("destination would escape uploads root".into());
+    }
+
+    if src_meta.is_dir() {
+        copy_dir_recursive(&src_host, &new_host)
+            .await
+            .map_err(|e| format!("copy failed: {e}"))?;
+    } else {
+        tokio::fs::copy(&src_host, &new_host)
+            .await
+            .map_err(|e| format!("copy failed: {e}"))?;
+    }
+
+    build_dirent(uploads_root, &new_host).await
+}
+
+/// PATCH /projects/{project_id}/dirents — batch move/copy operations.
+pub async fn batch_op(
+    State(state): State<Arc<AppState>>,
+    Extension(auth_user): Extension<AuthUser>,
+    AxumPath(project_id): AxumPath<Uuid>,
+    Json(body): Json<DirentBatchOp>,
+) -> ApiResult<Json<DirentBatchResult>> {
+    let in_project = state
+        .repository
+        .user_in_project(auth_user.id, project_id)
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    if !in_project {
+        return Err(AppError::forbidden("not a member of this project"));
+    }
+
+    let uploads_root = state
+        .data_root
+        .join("projects")
+        .join(project_id.to_string())
+        .join("uploads");
+
+    let mut succeeded: Vec<Dirent> = Vec::new();
+    let mut failed: Vec<FailedFile> = Vec::new();
+
+    match body {
+        DirentBatchOp::Move {
+            sources,
+            destination,
+            new_name,
+        } => {
+            if sources.is_empty() {
+                return Err(AppError::bad_request("sources must not be empty"));
+            }
+            if new_name.is_some() && sources.len() != 1 {
+                return Err(AppError::bad_request(
+                    "new_name is only valid for a single source",
+                ));
+            }
+            let dest_dir = prepare_dest_dir(&uploads_root, &destination).await?;
+            for src in sources {
+                match move_one(&uploads_root, &src, &dest_dir, new_name.as_deref()).await {
+                    Ok(d) => succeeded.push(d),
+                    Err(e) => failed.push(FailedFile { path: src, error: e }),
+                }
+            }
+            tracing::info!(
+                project = %project_id,
+                count = %succeeded.len(),
+                failed = %failed.len(),
+                "dirents moved"
+            );
+        }
+        DirentBatchOp::Copy {
+            sources,
+            destination,
+        } => {
+            if sources.is_empty() {
+                return Err(AppError::bad_request("sources must not be empty"));
+            }
+            let dest_dir = prepare_dest_dir(&uploads_root, &destination).await?;
+            for src in sources {
+                match copy_one(&uploads_root, &src, &dest_dir).await {
+                    Ok(d) => succeeded.push(d),
+                    Err(e) => failed.push(FailedFile { path: src, error: e }),
+                }
+            }
+            tracing::info!(
+                project = %project_id,
+                count = %succeeded.len(),
+                failed = %failed.len(),
+                "dirents copied"
+            );
+        }
+    }
+
+    Ok(Json(DirentBatchResult {
+        project_id,
+        succeeded,
+        failed,
+    }))
 }

--- a/backend/src/handlers/dirent.rs
+++ b/backend/src/handlers/dirent.rs
@@ -476,21 +476,30 @@ fn resolve_destination(uploads_root: &Path, dest: &str) -> Result<PathBuf, Strin
     safe_join(uploads_root, trimmed)
 }
 
-/// Resolve, create, and validate a destination directory for batch ops.
-/// Returns ApiError so the outer handler can short-circuit on malformed input
-/// without polluting `failed` with the same error per source.
+/// Resolve and validate a destination directory for batch ops.
+///
+/// Does NOT create the directory. Creation is deferred to the first
+/// per-source success (via `ensure_dest_dir` inside `move_one` / `copy_one`)
+/// so that a batch where every source fails (e.g. all source paths missing)
+/// does not leave a stray empty directory on disk.
+///
+/// If the destination path already exists and is not a directory, this
+/// returns a batch-wide 4xx so the outer handler can short-circuit.
 async fn prepare_dest_dir(uploads_root: &Path, destination: &str) -> Result<PathBuf, ApiError> {
     let dest_dir = resolve_destination(uploads_root, destination).map_err(AppError::bad_request)?;
-    tokio::fs::create_dir_all(&dest_dir)
-        .await
-        .map_err(|e| AppError::internal(format!("create dest: {e}")))?;
-    let dest_meta = tokio::fs::metadata(&dest_dir)
-        .await
-        .map_err(|e| AppError::internal(e.to_string()))?;
-    if !dest_meta.is_dir() {
-        return Err(AppError::bad_request("destination is not a directory"));
+    match tokio::fs::metadata(&dest_dir).await {
+        Ok(meta) if !meta.is_dir() => Err(AppError::bad_request("destination is not a directory")),
+        Ok(_) | Err(_) => Ok(dest_dir),
     }
-    Ok(dest_dir)
+}
+
+/// Idempotent best-effort creation of the destination directory.
+/// Called by per-source ops right before the rename/copy, so a fully-failed
+/// batch (e.g. every source missing) never materialises an empty dest dir.
+async fn ensure_dest_dir(dest_dir: &Path) -> Result<(), String> {
+    tokio::fs::create_dir_all(dest_dir)
+        .await
+        .map_err(|e| format!("create dest: {e}"))
 }
 
 /// Load and validate a source path against an already-prepared destination.
@@ -540,9 +549,13 @@ async fn build_dirent(uploads_root: &Path, host: &Path) -> Result<Dirent, String
 
 /// "foo.pdf" → "foo copy.pdf" → "foo copy 2.pdf" → …
 /// Dot-files ("foo" prefix is empty) are treated as having no extension.
-fn find_available_name(parent: &Path, base_name: &str) -> PathBuf {
+///
+/// Async to avoid blocking a Tokio worker on up to ~1000 sync `stat`
+/// calls when `parent` happens to be a directory with a long history
+/// of " copy N" siblings.
+async fn find_available_name(parent: &Path, base_name: &str) -> PathBuf {
     let candidate = parent.join(base_name);
-    if !candidate.exists() {
+    if !tokio::fs::try_exists(&candidate).await.unwrap_or(false) {
         return candidate;
     }
     let (stem, ext) = if base_name.starts_with('.') {
@@ -554,12 +567,12 @@ fn find_available_name(parent: &Path, base_name: &str) -> PathBuf {
         }
     };
     let first = parent.join(format!("{stem} copy{ext}"));
-    if !first.exists() {
+    if !tokio::fs::try_exists(&first).await.unwrap_or(false) {
         return first;
     }
     for n in 2..1000 {
         let cand = parent.join(format!("{stem} copy {n}{ext}"));
-        if !cand.exists() {
+        if !tokio::fs::try_exists(&cand).await.unwrap_or(false) {
             return cand;
         }
     }
@@ -628,6 +641,7 @@ async fn move_one(
         return Err(format!("\"{filename}\" already exists at destination"));
     }
 
+    ensure_dest_dir(dest_dir).await?;
     tokio::fs::rename(&src_host, &new_host)
         .await
         .map_err(|e| format!("rename failed: {e}"))?;
@@ -649,17 +663,20 @@ async fn copy_one(
         .ok_or_else(|| "could not determine source filename".to_string())?
         .to_string();
 
-    let new_host = find_available_name(dest_dir, &base_name);
+    let new_host = find_available_name(dest_dir, &base_name).await;
 
     if new_host.strip_prefix(uploads_root).is_err() {
         return Err("destination would escape uploads root".into());
     }
 
     if src_meta.is_dir() {
+        // `copy_dir_recursive` does its own `create_dir_all(new_host)`, which
+        // also creates `dest_dir` as a side effect — no separate ensure needed.
         copy_dir_recursive(&src_host, &new_host)
             .await
             .map_err(|e| format!("copy failed: {e}"))?;
     } else {
+        ensure_dest_dir(dest_dir).await?;
         tokio::fs::copy(&src_host, &new_host)
             .await
             .map_err(|e| format!("copy failed: {e}"))?;

--- a/backend/src/model/dirent.rs
+++ b/backend/src/model/dirent.rs
@@ -19,21 +19,16 @@ pub struct Dirent {
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
-pub struct UploadedFile {
-    pub path: String,
-    pub bytes: u64,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
 pub struct FailedFile {
     pub path: String,
     pub error: String,
 }
 
+/// Unified batch operation result: upload / move / copy all use this shape.
 #[derive(Debug, Serialize, JsonSchema)]
-pub struct UploadResponse {
+pub struct DirentBatchResult {
     pub project_id: Uuid,
-    pub succeeded: Vec<UploadedFile>,
+    pub succeeded: Vec<Dirent>,
     pub failed: Vec<FailedFile>,
 }
 
@@ -48,4 +43,23 @@ pub struct ListResponse {
 pub struct ListQuery {
     pub prefix: Option<String>,
     pub recursive: Option<bool>,
+}
+
+/// Tagged union for collection-level PATCH /dirents operations.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DirentBatchOp {
+    /// Move (and optionally rename) one or more items to a destination folder.
+    /// `new_name` is allowed only when `sources.len() == 1` (the rename case).
+    Move {
+        sources: Vec<String>,
+        destination: String,
+        new_name: Option<String>,
+    },
+    /// Copy one or more items into a destination folder. Name collisions get
+    /// a " copy" suffix automatically (Finder-style).
+    Copy {
+        sources: Vec<String>,
+        destination: String,
+    },
 }

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -66,9 +66,10 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
         )
         .api_route(
             "/projects/{project_id}/dirents",
-            // Body limit disabled only for upload; GET list has no body.
+            // Body limit disabled only for upload; PATCH batch_op carries a small JSON body.
             post(handlers::upload.layer(axum::extract::DefaultBodyLimit::disable()))
-                .get(handlers::list),
+                .get(handlers::list)
+                .patch(handlers::batch_op),
         )
         .api_route(
             "/projects/{project_id}/dirents/{*path}",

--- a/backend/tests/dirent_test.rs
+++ b/backend/tests/dirent_test.rs
@@ -349,3 +349,168 @@ async fn list_prefix_filter_uses_path_component_boundary() {
         "src2/ must NOT appear with prefix=src: {paths:?}"
     );
 }
+
+// ── PATCH /dirents (batch move/copy) ──────────────────────────────────────────
+
+#[tokio::test]
+async fn batch_op_rename_via_move_with_new_name() {
+    // Rename = a single-source move whose destination is the same parent
+    // and whose new_name carries the new filename. The unified move handler
+    // must accept this and produce the new dirent in the response.
+    let (state, _tmp) = make_state_with_dir().await;
+    let app = common::make_app_with_state(state);
+    common::signup(&app, "grace", "Password123!").await;
+    let token = common::login(&app, "grace", "Password123!").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let pid = project["id"].as_str().unwrap();
+    upload_files(&app, &token, pid, &[("a.txt", b"hi")]).await;
+
+    let body = serde_json::json!({
+        "op": "move",
+        "sources": ["a.txt"],
+        "destination": "",
+        "new_name": "b.txt",
+    });
+    let (status, resp) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{pid}/dirents"),
+        &token,
+        Some(body),
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK, "rename body: {resp}");
+    let succeeded = resp["succeeded"].as_array().unwrap();
+    assert_eq!(succeeded.len(), 1);
+    assert_eq!(succeeded[0]["path"], "b.txt");
+    assert_eq!(resp["failed"].as_array().unwrap().len(), 0);
+
+    let (gone_status, _) = get_file_raw(&app, &token, pid, "a.txt").await;
+    assert_eq!(gone_status, axum::http::StatusCode::NOT_FOUND);
+    let (here_status, here_bytes) = get_file_raw(&app, &token, pid, "b.txt").await;
+    assert_eq!(here_status, axum::http::StatusCode::OK);
+    assert_eq!(here_bytes, b"hi");
+}
+
+#[tokio::test]
+async fn batch_op_copy_applies_finder_style_suffix() {
+    // Copying into a folder that already contains the same name must NOT fail.
+    // It should auto-append " copy" (and " copy 2", " copy 3"…) Finder-style.
+    let (state, _tmp) = make_state_with_dir().await;
+    let app = common::make_app_with_state(state);
+    common::signup(&app, "henry", "Password123!").await;
+    let token = common::login(&app, "henry", "Password123!").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let pid = project["id"].as_str().unwrap();
+    upload_files(&app, &token, pid, &[("note.txt", b"x")]).await;
+
+    let copy = |target: &str| {
+        let target = target.to_string();
+        let app = app.clone();
+        let token = token.clone();
+        let pid = pid.to_string();
+        async move {
+            let body = serde_json::json!({"op": "copy", "sources": [target], "destination": ""});
+            common::authed(
+                &app,
+                "PATCH",
+                &format!("/projects/{pid}/dirents"),
+                &token,
+                Some(body),
+            )
+            .await
+        }
+    };
+
+    let (s1, r1) = copy("note.txt").await;
+    assert_eq!(s1, axum::http::StatusCode::OK, "{r1}");
+    assert_eq!(r1["succeeded"][0]["path"], "note copy.txt");
+
+    let (s2, r2) = copy("note.txt").await;
+    assert_eq!(s2, axum::http::StatusCode::OK, "{r2}");
+    assert_eq!(r2["succeeded"][0]["path"], "note copy 2.txt");
+}
+
+#[tokio::test]
+async fn batch_op_move_folder_into_descendant_fails() {
+    // Moving a folder into one of its own descendants would create an
+    // unreachable cycle on disk; the handler must reject this with a clear
+    // error in `failed` (not silently 500 or actually perform the rename).
+    let (state, _tmp) = make_state_with_dir().await;
+    let app = common::make_app_with_state(state);
+    common::signup(&app, "iris", "Password123!").await;
+    let token = common::login(&app, "iris", "Password123!").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let pid = project["id"].as_str().unwrap();
+    upload_files(&app, &token, pid, &[("Outer/inner/keep.txt", b"y")]).await;
+
+    let body = serde_json::json!({
+        "op": "move",
+        "sources": ["Outer"],
+        "destination": "Outer/inner",
+    });
+    let (status, resp) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{pid}/dirents"),
+        &token,
+        Some(body),
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK, "{resp}");
+    assert_eq!(resp["succeeded"].as_array().unwrap().len(), 0);
+    let failed = resp["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 1, "{resp}");
+    let err = failed[0]["error"].as_str().unwrap();
+    assert!(
+        err.contains("itself") || err.contains("descendant"),
+        "expected self-into-itself error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn batch_op_partial_success_on_name_conflict() {
+    // When some sources can be moved but others would collide, the response
+    // must split into `succeeded` and `failed` rather than aborting the batch
+    // (matches the upload partial-success contract).
+    let (state, _tmp) = make_state_with_dir().await;
+    let app = common::make_app_with_state(state);
+    common::signup(&app, "jay", "Password123!").await;
+    let token = common::login(&app, "jay", "Password123!").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let pid = project["id"].as_str().unwrap();
+    upload_files(
+        &app,
+        &token,
+        pid,
+        &[("dst/blocker.txt", b"x"), ("blocker.txt", b"y"), ("free.txt", b"z")],
+    )
+    .await;
+
+    // Move both blocker.txt (will conflict with dst/blocker.txt) and free.txt (clean).
+    let body = serde_json::json!({
+        "op": "move",
+        "sources": ["blocker.txt", "free.txt"],
+        "destination": "dst",
+    });
+    let (status, resp) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{pid}/dirents"),
+        &token,
+        Some(body),
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK, "{resp}");
+    let succeeded = resp["succeeded"].as_array().unwrap();
+    let failed = resp["failed"].as_array().unwrap();
+    assert_eq!(succeeded.len(), 1, "succeeded should hold free.txt: {resp}");
+    assert_eq!(succeeded[0]["path"], "dst/free.txt");
+    assert_eq!(failed.len(), 1, "failed should hold blocker.txt: {resp}");
+    assert_eq!(failed[0]["path"], "blocker.txt");
+    assert!(
+        failed[0]["error"].as_str().unwrap().contains("already exists"),
+        "expected 'already exists', got: {}",
+        failed[0]["error"]
+    );
+}

--- a/backend/tests/dirent_test.rs
+++ b/backend/tests/dirent_test.rs
@@ -483,7 +483,11 @@ async fn batch_op_partial_success_on_name_conflict() {
         &app,
         &token,
         pid,
-        &[("dst/blocker.txt", b"x"), ("blocker.txt", b"y"), ("free.txt", b"z")],
+        &[
+            ("dst/blocker.txt", b"x"),
+            ("blocker.txt", b"y"),
+            ("free.txt", b"z"),
+        ],
     )
     .await;
 
@@ -509,7 +513,10 @@ async fn batch_op_partial_success_on_name_conflict() {
     assert_eq!(failed.len(), 1, "failed should hold blocker.txt: {resp}");
     assert_eq!(failed[0]["path"], "blocker.txt");
     assert!(
-        failed[0]["error"].as_str().unwrap().contains("already exists"),
+        failed[0]["error"]
+            .as_str()
+            .unwrap()
+            .contains("already exists"),
         "expected 'already exists', got: {}",
         failed[0]["error"]
     );

--- a/backend/tests/dirent_test.rs
+++ b/backend/tests/dirent_test.rs
@@ -514,3 +514,47 @@ async fn batch_op_partial_success_on_name_conflict() {
         failed[0]["error"]
     );
 }
+
+#[tokio::test]
+async fn batch_op_all_failed_does_not_materialise_dest_dir() {
+    // Regression: a batch op whose sources all fail must NOT leave an empty
+    // destination directory on disk. Creation of dest_dir is deferred to the
+    // first successful per-source op so that aborted batches leave no trace.
+    let (state, tmp) = make_state_with_dir().await;
+    let data_root = tmp.path().to_path_buf();
+    let app = common::make_app_with_state(state);
+    common::signup(&app, "jay", "Password123!").await;
+    let token = common::login(&app, "jay", "Password123!").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let pid = project["id"].as_str().unwrap();
+
+    // Move two non-existent sources into a destination path that has never
+    // been created before. Both sources fail at load_source.
+    let body = serde_json::json!({
+        "op": "move",
+        "sources": ["ghost-a.txt", "ghost-b.txt"],
+        "destination": "phantom-dir",
+    });
+    let (status, resp) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{pid}/dirents"),
+        &token,
+        Some(body),
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK, "{resp}");
+    assert!(resp["succeeded"].as_array().unwrap().is_empty(), "{resp}");
+    assert_eq!(resp["failed"].as_array().unwrap().len(), 2, "{resp}");
+
+    let dest_on_disk = data_root
+        .join("projects")
+        .join(pid)
+        .join("uploads")
+        .join("phantom-dir");
+    assert!(
+        !dest_on_disk.exists(),
+        "destination dir must not be created when every source fails: {}",
+        dest_on_disk.display()
+    );
+}


### PR DESCRIPTION
## Summary

- Add **move** and **copy** for project dirents (files and folders) with sidebar drag-drop and dropdown "이동…" / "복사…" entry points.
- **Unify rename:** drop the dedicated `PATCH /dirents/{*path}` handler. Rename now flows through a single collection-level `PATCH /dirents` endpoint with a tagged op (`move` | `copy`); the rename UX is expressed as a 1-source move that carries `new_name`.
- One response shape — `DirentBatchResult` — is shared by upload, move, and copy, so clients consume a single contract everywhere.

## API changes

`POST /projects/{id}/dirents` (multipart upload) now returns `DirentBatchResult { project_id, succeeded: Dirent[], failed: FailedFile[] }`.

`PATCH /projects/{id}/dirents` is new. Body is a tagged union:

```jsonc
{ "op": "move", "sources": ["a.txt"], "destination": "Drafts",         "new_name": null }
{ "op": "move", "sources": ["a.txt"], "destination": "",               "new_name": "b.txt" }  // rename
{ "op": "copy", "sources": ["note.txt", "spec.md"], "destination": "Drafts" }
```

Response is `DirentBatchResult`. The endpoint follows a **partial-success contract**: per-source failures accumulate in `failed[]` without aborting the batch. Batch-wide errors (empty `sources`, `destination` not a directory, `new_name` with multiple sources) return 4xx and short-circuit.

Removed: `PATCH /projects/{id}/dirents/{*path}` (`rename_path`), `RenameRequest`, `UploadResponse`, `UploadedFile`.

## Behaviour highlights

- **Folder copy is recursive** (symlinks rejected throughout).
- **Finder-style auto-suffix on copy:** `note.txt` → `note copy.txt` → `note copy 2.txt`. Hidden files (`.keep`) get no extension split.
- **Self-into-descendant rejection:** moving or copying a folder into its own subtree fails per-source with a clear message.
- **Path safety:** every source and destination passes through `safe_join` (rejects `..`, absolute paths, NUL); `prepare_dest_dir` re-confirms the resolved path is a directory.

## Frontend UX

- Sidebar tree folders + the project-root row are drop targets with a highlighted outline. `Alt`/`Ctrl`/`Cmd` during a drop switches `move` → `copy`.
- Compact custom drag image (a small pill showing the filename or item count) replaces the browser default so the drop area stays visible.
- Body drop is a **silent cancel** — sidebar folders are the only valid intra-app destinations, so an aborted drag does not produce a spurious "already exists" toast or API call.
- A custom MIME (`application/x-cowork-dirent-paths`) lets the existing external-file upload drop zone coexist with intra-app drag.
- New `FolderPickerDialog` (tree picker reusing `buildFolderTree`) drives menu/toolbar-based "이동…" / "복사…", with source folders + their descendants disabled to prevent self-into-self.
- The existing `RenameDialog` is unchanged at the UX level; it now drives the unified `moveMutation` via a `renamingRef` flag so the success toast remains "이름이 변경되었습니다" rather than "이동되었습니다".

## Implementation notes

- Backend handler decomposes into focused helpers — `prepare_dest_dir` (batch-wide validation, returns `ApiError`), `load_source` (per-source validation, returns `String`), `move_one` / `copy_one`, `copy_dir_recursive`, `find_available_name`, `build_dirent`. The split between `ApiError` and `String` encodes the partial-success contract at the type level.
- Upload handler now also populates `modified_at` on each succeeded `Dirent` (single extra `metadata()` call per file).
- Drag-end cleanup is wired globally on `window` so any aborted drag clears the drop-target highlight; `dragLeave` uses `relatedTarget` containment check to avoid child-element flicker.

## Test plan

- [x] `cd backend && cargo build` — clean
- [x] `cd backend && cargo test --test dirent_test` — **12 / 12 pass**, including 4 new batch_op regressions:
  - `batch_op_rename_via_move_with_new_name`
  - `batch_op_copy_applies_finder_style_suffix`
  - `batch_op_move_folder_into_descendant_fails`
  - `batch_op_partial_success_on_name_conflict`
- [x] `cd app && npx tsc --noEmit` — clean
- [x] Manual UI smoke (Playwright + curl against the cowork demo):
  - Upload returns the new `DirentBatchResult` shape with `kind` / `bytes` / `modified_at`.
  - F2 and dropdown Rename produce `PATCH /dirents` with `{op:"move", ..., new_name}`; toast says "이름이 변경되었습니다".
  - "이동…" opens `FolderPickerDialog`; moving into `Drafts` updates the sidebar count immediately.
  - Drag a card onto the sidebar Drafts row → moves; drag back onto the file body → silently cancelled (no toast, no network call).
  - Same-folder copy creates `… copy.txt`, then `… copy 2.txt`.
  - Folder copy recursively brings descendants along.
  - Dragging a folder onto its own descendant is rejected.
  - External file upload (drop onto file body) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)