### PR TITLE
feat(agents): add deep-research agent + split test_case cases module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ CLAUDE.md
 docs/superpowers/
 
 # Others
-artifacts
+artifacts/
+eval-runs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=a34356fb2c0aa6ebe90a87f3bd6fc0f31fa57802#a34356fb2c0aa6ebe90a87f3bd6fc0f31fa57802"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=353f10ee304694e30a3cca9fe6d03f32b4b9da2e#353f10ee304694e30a3cca9fe6d03f32b4b9da2e"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "knowledge-base-examples",
  "log",
  "regex",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "strum 0.27.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "a34356fb2c0aa6ebe90a87f3bd6fc0f31fa57802", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "353f10ee304694e30a3cca9fe6d03f32b4b9da2e", features = ["sandbox"] }

--- a/agent-k/Cargo.toml
+++ b/agent-k/Cargo.toml
@@ -30,6 +30,7 @@ indexmap = "2"
 knowledge-base-examples = { path = "../../knowledge-base-examples", optional = true }
 log = "0.4"
 regex = "1"
+reqwest = { version = "0.13", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }

--- a/agent-k/src/agents/coworker.rs
+++ b/agent-k/src/agents/coworker.rs
@@ -85,7 +85,7 @@ pub async fn get_coworker_agent(
     AgentBuilder::new(model.as_ref())
         .instruction(inst)
         .system_tools()
-        .web_search_tool()
+        .web_search_tool(vec![])
         .runenv(RunEnv::sandbox(config).await?)
         .build()
 }

--- a/agent-k/src/agents/deep_research.rs
+++ b/agent-k/src/agents/deep_research.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use ailoy::{
+    agent::{Agent, AgentBuilder},
+    runenv::{RunEnv, SandboxConfig, VolumeMount},
+    tool::WebSearchEngineKind,
+};
+
+const DEEP_RESEARCH_INSTRUCTION: &str = r#"You are {{NAME}}. Your primary role is to produce long-form research reports grounded in multiple web sources with inline citations.
+
+## Workflow
+- Start by writing an outline of 3-8 sections to `artifacts/outline.md`.
+- For each section: `web_search` with a few short, entity-anchored queries, then `web_fetch` the most useful URLs to read the actual body. Use the `urls` array form when fetching 2 or more independent URLs in one call.
+- Write `artifacts/report.md` section by section. Every factual sentence ends with one or more `[^N]` markers. Maintain `artifacts/citations.json` in parallel as `{"N": {"url", "title", "quote", "retrieved_at"}}`.
+- Before stopping, verify every `[^N]` maps to a citation, every cited URL was actually fetched in this session, and every `##` section has citations from at least 3 distinct domains.
+
+## Citations
+- Cite only URLs you actually `web_fetch`ed in this session. A URL seen only in a search snippet is not enough.
+- Quote text in `quote` must appear verbatim in the fetched body, or be a paraphrase you can defend.
+
+## Tools
+- Keep `web_search` short and specific (3-8 words). Cap at 8 search calls per report. If results are mostly off-topic, fetch the useful ones first instead of immediately rephrasing.
+- Send either `url` or `urls` to `web_fetch`, not both. Use `offset` to continue reading the same URL.
+- Total tool calls per report should fall between 15 and 40.
+
+## Artifacts
+- All outputs live under `artifacts/`: `outline.md`, `report.md`, `citations.json`, and one `sources/<slug>.md` per fetched page.
+- When done, tell the user the path to `artifacts/report.md`. Do not paste the whole report into the chat.
+
+## Others
+- You are running in a container environment with internet access.
+- Write the report in the user's language. Search queries may use whichever language has the best sources for the topic.
+- Always respond in the language the user used.
+
+## Information
+- Current time: {{TIME}}
+- OS: {{OS}}"#;
+
+/// name: Identity of the agent (interpolated into the system prompt).
+/// model: Model to use (e.g. `openai/gpt-5.5`).
+/// artifacts_dir: Host path mounted at `/workspace/artifacts` inside the sandbox.
+pub async fn get_deep_research_agent(
+    name: impl AsRef<str>,
+    model: impl AsRef<str>,
+    artifacts_dir: impl AsRef<Path>,
+) -> anyhow::Result<Agent> {
+    fn civil_from_days(days: i64) -> (i64, u32, u32) {
+        let z = days + 719_468;
+        let era = z.div_euclid(146_097);
+        let doe = z.rem_euclid(146_097) as u64;
+        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+        let y = yoe as i64 + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        let mp = (5 * doy + 2) / 153;
+        let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+        let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+        let y = if m <= 2 { y + 1 } else { y };
+        (y, m, d)
+    }
+
+    fn now_utc_iso8601() -> String {
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let days = secs.div_euclid(86_400);
+        let sod = secs.rem_euclid(86_400);
+        let (y, mo, d) = civil_from_days(days);
+        let h = sod / 3600;
+        let mi = (sod % 3600) / 60;
+        let s = sod % 60;
+        format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+    }
+
+    let mut config = SandboxConfig::default();
+    config.image = "brekkylab/agent-k:latest".into();
+    config.cpus = 8;
+    config.memory_mib = 1024;
+    config.workdir = "/workspace".into();
+    config.env.insert("HOME".into(), "/workspace".into());
+    config.volumes.push(VolumeMount::Bind {
+        host: artifacts_dir.as_ref().into(),
+        guest: "/workspace/artifacts".into(),
+        readonly: false,
+    });
+    config.persist = true;
+
+    let inst = DEEP_RESEARCH_INSTRUCTION
+        .replace("{{NAME}}", name.as_ref())
+        .replace("{{TIME}}", &now_utc_iso8601())
+        .replace("{{OS}}", "Debian GNU/Linux 13 (trixie)");
+
+    AgentBuilder::new(model.as_ref())
+        .instruction(inst)
+        .system_tools()
+        .web_search_tool(vec![
+            WebSearchEngineKind::Brave,
+            WebSearchEngineKind::DuckDuckGo,
+            WebSearchEngineKind::Mojeek,
+            WebSearchEngineKind::Bing,
+        ])
+        .web_fetch_tool()
+        .runenv(RunEnv::sandbox(config).await?)
+        .build()
+}

--- a/agent-k/src/agents/deep_research/agent.rs
+++ b/agent-k/src/agents/deep_research/agent.rs
@@ -1,16 +1,24 @@
 use std::path::Path;
 
 use ailoy::{
-    agent::{Agent, AgentBuilder},
+    agent::{Agent, AgentBuilder, default_provider_mut},
     runenv::{RunEnv, SandboxConfig, VolumeMount},
-    tool::WebSearchEngineKind,
 };
+
+use super::tool::{get_api_search_tool_desc, get_api_search_tool_factory};
+
+fn ensure_api_search_registered() {
+    let mut provider = default_provider_mut();
+    provider
+        .tools
+        .insert_func_factory("api_search", get_api_search_tool_factory());
+}
 
 const DEEP_RESEARCH_INSTRUCTION: &str = r#"You are {{NAME}}. Your primary role is to produce long-form research reports grounded in multiple web sources with inline citations.
 
 ## Workflow
 - Start by writing an outline of 3-8 sections to `artifacts/outline.md`.
-- For each section: `web_search` with a few short, entity-anchored queries, then `web_fetch` the most useful URLs to read the actual body. Use the `urls` array form when fetching 2 or more independent URLs in one call.
+- For each section: `api_search` with a few short, entity-anchored queries, then `web_fetch` the most useful URLs to read the actual body. Use the `urls` array form when fetching 2 or more independent URLs in one call.
 - Write `artifacts/report.md` section by section. Every factual sentence ends with one or more `[^N]` markers. Maintain `artifacts/citations.json` in parallel as `{"N": {"url", "title", "quote", "retrieved_at"}}`.
 - Before stopping, verify every `[^N]` maps to a citation, every cited URL was actually fetched in this session, and every `##` section has citations from at least 3 distinct domains.
 
@@ -19,7 +27,7 @@ const DEEP_RESEARCH_INSTRUCTION: &str = r#"You are {{NAME}}. Your primary role i
 - Quote text in `quote` must appear verbatim in the fetched body, or be a paraphrase you can defend.
 
 ## Tools
-- Keep `web_search` short and specific (3-8 words). Cap at 8 search calls per report. If results are mostly off-topic, fetch the useful ones first instead of immediately rephrasing.
+- Keep `api_search` short and specific (3-8 words). Cap at 8 search calls per report. If results are mostly off-topic, fetch the useful ones first instead of immediately rephrasing.
 - Send either `url` or `urls` to `web_fetch`, not both. Use `offset` to continue reading the same URL.
 - Total tool calls per report should fall between 15 and 40.
 
@@ -36,6 +44,58 @@ const DEEP_RESEARCH_INSTRUCTION: &str = r#"You are {{NAME}}. Your primary role i
 - Current time: {{TIME}}
 - OS: {{OS}}"#;
 
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+fn now_utc_iso8601() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let days = secs.div_euclid(86_400);
+    let sod = secs.rem_euclid(86_400);
+    let (y, mo, d) = civil_from_days(days);
+    let h = sod / 3600;
+    let mi = (sod % 3600) / 60;
+    let s = sod % 60;
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+/// Host-side variant of `get_deep_research_agent` that skips sandbox
+/// startup. Intended for evaluation harnesses where the per-case latency
+/// of booting microVMs (~30s/case) dominates the total wall time. The
+/// agent reads/writes `./artifacts/` directly on the host filesystem.
+pub async fn get_deep_research_agent_local(
+    name: impl AsRef<str>,
+    model: impl AsRef<str>,
+) -> anyhow::Result<Agent> {
+    ensure_api_search_registered();
+
+    let inst = DEEP_RESEARCH_INSTRUCTION
+        .replace("{{NAME}}", name.as_ref())
+        .replace("{{TIME}}", &now_utc_iso8601())
+        .replace("{{OS}}", std::env::consts::OS);
+
+    AgentBuilder::new(model.as_ref())
+        .instruction(inst)
+        .system_tools()
+        .tool(get_api_search_tool_desc())
+        .web_fetch_tool()
+        .runenv(RunEnv::local())
+        .build()
+}
+
 /// name: Identity of the agent (interpolated into the system prompt).
 /// model: Model to use (e.g. `openai/gpt-5.5`).
 /// artifacts_dir: Host path mounted at `/workspace/artifacts` inside the sandbox.
@@ -44,34 +104,6 @@ pub async fn get_deep_research_agent(
     model: impl AsRef<str>,
     artifacts_dir: impl AsRef<Path>,
 ) -> anyhow::Result<Agent> {
-    fn civil_from_days(days: i64) -> (i64, u32, u32) {
-        let z = days + 719_468;
-        let era = z.div_euclid(146_097);
-        let doe = z.rem_euclid(146_097) as u64;
-        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
-        let y = yoe as i64 + era * 400;
-        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-        let mp = (5 * doy + 2) / 153;
-        let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
-        let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
-        let y = if m <= 2 { y + 1 } else { y };
-        (y, m, d)
-    }
-
-    fn now_utc_iso8601() -> String {
-        let secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0);
-        let days = secs.div_euclid(86_400);
-        let sod = secs.rem_euclid(86_400);
-        let (y, mo, d) = civil_from_days(days);
-        let h = sod / 3600;
-        let mi = (sod % 3600) / 60;
-        let s = sod % 60;
-        format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
-    }
-
     let mut config = SandboxConfig::default();
     config.image = "brekkylab/agent-k:latest".into();
     config.cpus = 8;
@@ -90,15 +122,12 @@ pub async fn get_deep_research_agent(
         .replace("{{TIME}}", &now_utc_iso8601())
         .replace("{{OS}}", "Debian GNU/Linux 13 (trixie)");
 
+    ensure_api_search_registered();
+
     AgentBuilder::new(model.as_ref())
         .instruction(inst)
         .system_tools()
-        .web_search_tool(vec![
-            WebSearchEngineKind::Brave,
-            WebSearchEngineKind::DuckDuckGo,
-            WebSearchEngineKind::Mojeek,
-            WebSearchEngineKind::Bing,
-        ])
+        .tool(get_api_search_tool_desc())
         .web_fetch_tool()
         .runenv(RunEnv::sandbox(config).await?)
         .build()

--- a/agent-k/src/agents/deep_research/mod.rs
+++ b/agent-k/src/agents/deep_research/mod.rs
@@ -1,0 +1,4 @@
+mod agent;
+mod tool;
+
+pub use agent::*;

--- a/agent-k/src/agents/deep_research/tool/brave_search.rs
+++ b/agent-k/src/agents/deep_research/tool/brave_search.rs
@@ -1,0 +1,173 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use ailoy::{
+    datatype::Value,
+    to_value,
+    tool::{ToolDesc, ToolDescBuilder, ToolFunc},
+    tool_func,
+};
+use reqwest::Client;
+
+const BRAVE_API_BASE: &str = "https://api.search.brave.com/res/v1/web/search";
+const BRAVE_API_KEY_ENV: &str = "BRAVE_SEARCH_API_KEY";
+const REQUEST_TIMEOUT_SECS: u64 = 10;
+
+struct BraveState {
+    client: Client,
+    api_key: Option<String>,
+}
+
+impl BraveState {
+    fn new() -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .expect("reqwest::Client builder cannot fail with these settings");
+        let api_key = std::env::var(BRAVE_API_KEY_ENV).ok();
+        Self { client, api_key }
+    }
+}
+
+pub fn get_api_search_tool_desc() -> ToolDesc {
+    ToolDescBuilder::new("api_search")
+        .description(concat!(
+            "Search the web via a paid search API (currently Brave Search). ",
+            "Returns results ranked by the provider's own index, with the ",
+            "same `{results, total}` shape as ailoy's meta-search builtin. ",
+            "Use this to find current information, primary sources, ",
+            "documentation, or any web-accessible content. The provider ",
+            "and credentials are resolved from environment variables at ",
+            "process start; see the deep-research agent's documentation."
+        ))
+        .parameters(to_value!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query string"
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return. Default: 10. Max: 20.",
+                    "default": 10
+                }
+            },
+            "required": ["query"]
+        }))
+        .build()
+}
+
+pub fn get_api_search_tool_factory() -> impl Fn(&ToolDesc) -> ToolFunc {
+    let state = Arc::new(BraveState::new());
+    move |_| {
+        let state = state.clone();
+        tool_func!(async |args: Value| -> Value with [state = state.clone()] {
+            let query = args
+                .pointer("/query")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if query.is_empty() {
+                return to_value!({ "results": Value::array_empty(), "total": 0i64 });
+            }
+            let max_results = args
+                .pointer("/max_results")
+                .and_then(|v| v.as_unsigned())
+                .unwrap_or(10)
+                .min(20);
+
+            let Some(api_key) = state.api_key.as_deref() else {
+                return to_value!({
+                    "error": format!("missing required environment variable: {BRAVE_API_KEY_ENV}"),
+                    "results": Value::array_empty(),
+                    "total": 0i64
+                });
+            };
+
+            let resp = match state
+                .client
+                .get(BRAVE_API_BASE)
+                .header("X-Subscription-Token", api_key)
+                .header("Accept", "application/json")
+                .query(&[
+                    ("q", query.as_str()),
+                    ("count", &max_results.to_string()),
+                ])
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    let msg = format!("Brave Search request failed: {e}");
+                    return to_value!({
+                        "error": msg,
+                        "results": Value::array_empty(),
+                        "total": 0i64
+                    });
+                }
+            };
+
+            let status = resp.status();
+            if !status.is_success() {
+                let body: String = resp.text().await.unwrap_or_default();
+                let msg = format!("Brave Search returned HTTP {}: {body}", status.as_u16());
+                return to_value!({
+                    "error": msg,
+                    "results": Value::array_empty(),
+                    "total": 0i64
+                });
+            }
+
+            let json: serde_json::Value = match resp.json().await {
+                Ok(v) => v,
+                Err(e) => {
+                    let msg = format!("Brave Search JSON parse failed: {e}");
+                    return to_value!({
+                        "error": msg,
+                        "results": Value::array_empty(),
+                        "total": 0i64
+                    });
+                }
+            };
+
+            let items = json
+                .pointer("/web/results")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let results: Vec<Value> = items
+                .into_iter()
+                .map(|item| {
+                    let title = item
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let url = item
+                        .get("url")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let description = item
+                        .get("description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    to_value!({
+                        "title": title,
+                        "url": url,
+                        "description": description,
+                        "sources": Value::array([Value::string("Brave".to_string())])
+                    })
+                })
+                .collect();
+
+            let total = results.len() as i64;
+            to_value!({
+                "results": Value::array(results),
+                "total": total
+            })
+        })
+    }
+}

--- a/agent-k/src/agents/deep_research/tool/mod.rs
+++ b/agent-k/src/agents/deep_research/tool/mod.rs
@@ -1,0 +1,3 @@
+mod brave_search;
+
+pub use brave_search::*;

--- a/agent-k/src/agents/mod.rs
+++ b/agent-k/src/agents/mod.rs
@@ -1,7 +1,9 @@
 mod coworker;
+mod deep_research;
 mod router;
 mod speedwagon;
 
 pub use coworker::*;
+pub use deep_research::*;
 pub use router::*;
 pub use speedwagon::*;

--- a/agent-k/src/bin/test_case.rs
+++ b/agent-k/src/bin/test_case.rs
@@ -1,28 +1,62 @@
-//! Run a single test case against the coworker agent, then drop into
+//! Run a single test case against a chosen agent, then drop into
 //! interactive mode.
 //!
-//! cargo run -p agent-k --bin test_case -- 0
-//! cargo run -p agent-k --bin test_case -- 0 --model claude
-//! cargo run -p agent-k --bin test_case -- 0 --model gemini
+//! cargo run -p agent-k --bin test_case -- coworker 0
+//! cargo run -p agent-k --bin test_case -- coworker 0 --model claude
+//! cargo run -p agent-k --bin test_case -- deep-research 0
+//! cargo run -p agent-k --bin test_case -- deep-research 2 --model gemini
 
 use std::io::{self, BufRead, IsTerminal, Write};
 
-use agent_k::agents::get_coworker_agent;
+use agent_k::agents::{get_coworker_agent, get_deep_research_agent};
 use ailoy::{
     agent::Agent,
     message::{Message, Part, Role},
 };
 use futures::StreamExt;
 
-#[path = "test_case/cases.rs"]
+#[path = "test_case/cases/mod.rs"]
 mod cases;
-use cases::{Case, get_coworker_cases};
+use cases::{Case, get_coworker_cases, get_deep_research_cases};
 
 const COWORKER_AGENT_NAME: &str = "minerva";
-const COWORKER_AGENT_OPENAI_MODEL: &str = "openai/gpt-5.5";
-const COWORKER_AGENT_CLAUDE_MODEL: &str = "anthropic/claude-opus-4-7";
-const COWORKER_AGENT_GEMINI_MODEL: &str = "gemini/gemini-3.5-flash";
+const DEEP_RESEARCH_AGENT_NAME: &str = "vegapunk";
+
+const OPENAI_MODEL: &str = "openai/gpt-5.5";
+const CLAUDE_MODEL: &str = "anthropic/claude-opus-4-7";
+const GEMINI_MODEL: &str = "gemini/gemini-3.5-flash";
+
 const ARTIFACT_DIR: &str = "./artifacts";
+
+enum AgentKind {
+    Coworker,
+    DeepResearch,
+}
+
+impl AgentKind {
+    fn parse(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "coworker" => Ok(Self::Coworker),
+            "deep-research" | "deep_research" => Ok(Self::DeepResearch),
+            other => anyhow::bail!(
+                "invalid agent '{}', expected 'coworker' or 'deep-research'",
+                other
+            ),
+        }
+    }
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Coworker => COWORKER_AGENT_NAME,
+            Self::DeepResearch => DEEP_RESEARCH_AGENT_NAME,
+        }
+    }
+    fn log_prefix(&self) -> &'static str {
+        match self {
+            Self::Coworker => "coworker",
+            Self::DeepResearch => "deep-research",
+        }
+    }
+}
 
 enum InputSource {
     Stdin,
@@ -34,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     let argv: Vec<String> = std::env::args().skip(1).collect();
-    let mut case_no_arg: Option<&str> = None;
+    let mut positional: Vec<&str> = Vec::new();
     let mut model_arg: Option<&str> = None;
     let mut i = 0;
     while i < argv.len() {
@@ -52,44 +86,47 @@ async fn main() -> anyhow::Result<()> {
                 i += 1;
             }
             s => {
-                if case_no_arg.is_some() {
-                    anyhow::bail!("unexpected argument '{}'", s);
-                }
-                case_no_arg = Some(s);
+                positional.push(s);
                 i += 1;
             }
         }
     }
 
-    let case_no: usize = match case_no_arg {
-        Some(s) => s.parse().map_err(|_| {
-            anyhow::anyhow!(
-                "invalid case number '{}', expected a non-negative integer",
-                s
-            )
-        })?,
-        None => {
-            eprintln!("usage: test_case <case_no> [--model openai|claude|gemini]");
-            std::process::exit(2);
-        }
-    };
+    if positional.len() != 2 {
+        eprintln!(
+            "usage: test_case <agent> <case_no> [--model openai|claude|gemini]\n\
+             agents: coworker, deep-research"
+        );
+        std::process::exit(2);
+    }
+    let agent_kind = AgentKind::parse(positional[0])?;
+    let case_no: usize = positional[1].parse().map_err(|_| {
+        anyhow::anyhow!(
+            "invalid case number '{}', expected a non-negative integer",
+            positional[1]
+        )
+    })?;
 
-    let coworker_agent_model = match model_arg {
-        None | Some("openai") => COWORKER_AGENT_OPENAI_MODEL,
-        Some("claude") | Some("anthropic") => COWORKER_AGENT_CLAUDE_MODEL,
-        Some("gemini") | Some("google") => COWORKER_AGENT_GEMINI_MODEL,
+    let agent_model = match model_arg {
+        None | Some("openai") => OPENAI_MODEL,
+        Some("claude") | Some("anthropic") => CLAUDE_MODEL,
+        Some("gemini") | Some("google") => GEMINI_MODEL,
         Some(other) => anyhow::bail!(
             "invalid --model '{}', expected 'openai', 'claude', or 'gemini'",
             other
         ),
     };
 
-    let mut cases = get_coworker_cases();
+    let mut cases = match agent_kind {
+        AgentKind::Coworker => get_coworker_cases(),
+        AgentKind::DeepResearch => get_deep_research_cases(),
+    };
     if case_no >= cases.len() {
         anyhow::bail!(
-            "case {} out of range (have {} case(s))",
+            "case {} out of range (have {} {} case(s))",
             case_no,
-            cases.len()
+            cases.len(),
+            agent_kind.log_prefix()
         );
     }
     let case = cases.swap_remove(case_no);
@@ -97,14 +134,23 @@ async fn main() -> anyhow::Result<()> {
     clean_artifact_dir();
     write_case_files(&case)?;
 
-    let mut agent =
-        get_coworker_agent(COWORKER_AGENT_NAME, coworker_agent_model, ARTIFACT_DIR).await?;
+    let mut agent = match agent_kind {
+        AgentKind::Coworker => {
+            get_coworker_agent(agent_kind.name(), agent_model, ARTIFACT_DIR).await?
+        }
+        AgentKind::DeepResearch => {
+            get_deep_research_agent(agent_kind.name(), agent_model, ARTIFACT_DIR).await?
+        }
+    };
     println!(
-        "[coworker] starting as '{}' ({}) — case #{}",
-        COWORKER_AGENT_NAME, coworker_agent_model, case_no
+        "[{}] starting as '{}' ({}) — case #{}",
+        agent_kind.log_prefix(),
+        agent_kind.name(),
+        agent_model,
+        case_no
     );
 
-    if let Err(e) = stream_turn(&mut agent, case.query).await {
+    if let Err(e) = stream_turn(&mut agent, case.query, agent_kind.log_prefix()).await {
         println!("[error] {e}");
     }
 
@@ -135,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
             continue;
         }
         let query = Message::new(Role::User).with_contents([Part::text(&user_input)]);
-        if let Err(e) = stream_turn(&mut agent, query).await {
+        if let Err(e) = stream_turn(&mut agent, query, agent_kind.log_prefix()).await {
             println!("[error] {e}");
         }
     }
@@ -166,7 +212,7 @@ fn write_case_files(case: &Case) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn stream_turn(agent: &mut Agent, query: Message) -> anyhow::Result<()> {
+async fn stream_turn(agent: &mut Agent, query: Message, log_prefix: &str) -> anyhow::Result<()> {
     let mut stream = agent.run(query);
     while let Some(event) = stream.next().await {
         let event = event?;
@@ -186,7 +232,7 @@ async fn stream_turn(agent: &mut Agent, query: Message) -> anyhow::Result<()> {
                         if let Some((_id, name, args)) = tc.as_function() {
                             let args_json = serde_json::to_string(args)
                                 .unwrap_or_else(|_| "<unprintable>".into());
-                            println!("[coworker] tool: {name} {args_json}");
+                            println!("[{log_prefix}] tool: {name} {args_json}");
                         }
                     }
                 }
@@ -194,10 +240,10 @@ async fn stream_turn(agent: &mut Agent, query: Message) -> anyhow::Result<()> {
             Role::Tool => {
                 for part in &msg.contents {
                     if let Some(t) = part.as_text() {
-                        println!("[coworker] tool result: {t}");
+                        println!("[{log_prefix}] tool result: {t}");
                     } else if let Some(v) = part.as_value() {
                         let s = serde_json::to_string(v).unwrap_or_else(|_| "<unprintable>".into());
-                        println!("[coworker] tool result: {s}");
+                        println!("[{log_prefix}] tool result: {s}");
                     }
                 }
             }

--- a/agent-k/src/bin/test_case.rs
+++ b/agent-k/src/bin/test_case.rs
@@ -8,7 +8,9 @@
 
 use std::io::{self, BufRead, IsTerminal, Write};
 
-use agent_k::agents::{get_coworker_agent, get_deep_research_agent};
+use agent_k::agents::{
+    get_coworker_agent, get_deep_research_agent, get_deep_research_agent_local,
+};
 use ailoy::{
     agent::Agent,
     message::{Message, Part, Role},
@@ -70,6 +72,7 @@ async fn main() -> anyhow::Result<()> {
     let argv: Vec<String> = std::env::args().skip(1).collect();
     let mut positional: Vec<&str> = Vec::new();
     let mut model_arg: Option<&str> = None;
+    let mut local_flag = false;
     let mut i = 0;
     while i < argv.len() {
         let a = argv[i].as_str();
@@ -83,6 +86,10 @@ async fn main() -> anyhow::Result<()> {
             }
             s if s.starts_with("--model=") => {
                 model_arg = Some(&s["--model=".len()..]);
+                i += 1;
+            }
+            "--local" => {
+                local_flag = true;
                 i += 1;
             }
             s => {
@@ -136,10 +143,17 @@ async fn main() -> anyhow::Result<()> {
 
     let mut agent = match agent_kind {
         AgentKind::Coworker => {
+            if local_flag {
+                anyhow::bail!("--local is only supported for deep-research");
+            }
             get_coworker_agent(agent_kind.name(), agent_model, ARTIFACT_DIR).await?
         }
         AgentKind::DeepResearch => {
-            get_deep_research_agent(agent_kind.name(), agent_model, ARTIFACT_DIR).await?
+            if local_flag {
+                get_deep_research_agent_local(agent_kind.name(), agent_model).await?
+            } else {
+                get_deep_research_agent(agent_kind.name(), agent_model, ARTIFACT_DIR).await?
+            }
         }
     };
     println!(

--- a/agent-k/src/bin/test_case/cases/coworker.rs
+++ b/agent-k/src/bin/test_case/cases/coworker.rs
@@ -2,10 +2,7 @@ use std::path::PathBuf;
 
 use ailoy::message::{Message, Part, Role};
 
-pub struct Case {
-    pub query: Message,
-    pub files: Vec<(Vec<u8>, PathBuf)>,
-}
+use super::Case;
 
 pub fn get_coworker_cases() -> Vec<Case> {
     vec![
@@ -29,7 +26,7 @@ pub fn get_coworker_cases() -> Vec<Case> {
                 "Split payslip document into separate single-page PDFs.",
             )]),
             files: vec![(
-                include_bytes!("payslips.pdf").to_vec(),
+                include_bytes!("../payslips.pdf").to_vec(),
                 PathBuf::from("payslips.pdf"),
             )],
         },
@@ -39,7 +36,7 @@ pub fn get_coworker_cases() -> Vec<Case> {
                 "급여명세서 문서를 각각 한 페이지짜리 PDF들로 분리해주세요.",
             )]),
             files: vec![(
-                include_bytes!("payslips.pdf").to_vec(),
+                include_bytes!("../payslips.pdf").to_vec(),
                 PathBuf::from("payslips.pdf"),
             )],
         },
@@ -49,7 +46,7 @@ pub fn get_coworker_cases() -> Vec<Case> {
                 "Visualize co2.csv as a journal-submission-ready figure.",
             )]),
             files: vec![(
-                include_bytes!("co2.csv").to_vec(),
+                include_bytes!("../co2.csv").to_vec(),
                 PathBuf::from("co2.csv"),
             )],
         },
@@ -59,7 +56,7 @@ pub fn get_coworker_cases() -> Vec<Case> {
                 "co2.csv 를 저널 투고용 figure로 시각화해줘",
             )]),
             files: vec![(
-                include_bytes!("co2.csv").to_vec(),
+                include_bytes!("../co2.csv").to_vec(),
                 PathBuf::from("co2.csv"),
             )],
         },
@@ -77,11 +74,11 @@ pub fn get_coworker_cases() -> Vec<Case> {
             )]),
             files: vec![
                 (
-                    include_bytes!("receipt_1.png").to_vec(),
+                    include_bytes!("../receipt_1.png").to_vec(),
                     PathBuf::from("receipt_1.png"),
                 ),
                 (
-                    include_bytes!("receipt_2.png").to_vec(),
+                    include_bytes!("../receipt_2.png").to_vec(),
                     PathBuf::from("receipt_2.png"),
                 ),
             ],
@@ -100,11 +97,11 @@ pub fn get_coworker_cases() -> Vec<Case> {
             )]),
             files: vec![
                 (
-                    include_bytes!("receipt_1.png").to_vec(),
+                    include_bytes!("../receipt_1.png").to_vec(),
                     PathBuf::from("receipt_1.png"),
                 ),
                 (
-                    include_bytes!("receipt_2.png").to_vec(),
+                    include_bytes!("../receipt_2.png").to_vec(),
                     PathBuf::from("receipt_2.png"),
                 ),
             ],

--- a/agent-k/src/bin/test_case/cases/deep_research.rs
+++ b/agent-k/src/bin/test_case/cases/deep_research.rs
@@ -1,0 +1,105 @@
+use ailoy::message::{Message, Part, Role};
+
+use super::Case;
+
+/// Ten GAIA/BrowseComp-style multi-hop research queries spanning five
+/// distinct domains and two difficulty levels. Each topic appears as an
+/// English/Korean pair, matching the convention in `coworker.rs`:
+///
+///   0/1 — space/astronomy, medium
+///   2/3 — history, medium
+///   4/5 — climate/energy, medium
+///   6/7 — philosophy, hard
+///   8/9 — cuisine/food, hard
+pub fn get_deep_research_cases() -> Vec<Case> {
+    vec![
+        // Case 0 — space/astronomy, en, medium.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "Which space agencies have successfully landed on the Moon since 2020, \
+                 and what specific payload did each lander carry?",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 1 — space/astronomy, ko, medium.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "2020년 이후 달 착륙에 성공한 우주 기관들은 어디고, \
+                 각 착륙선이 어떤 페이로드를 싣고 갔는지 정리해줘.",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 2 — history, en, medium. Cross-reference at least two sources.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "Which of the first ten US presidents (Washington through Tyler) owned \
+                 slaves at the time of their inauguration? Cross-reference at least two sources.",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 3 — history, ko, medium.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "초대 미국 대통령부터 10대 대통령(워싱턴부터 타일러까지) 중에서 \
+                 취임 시점에 노예를 소유하고 있던 대통령이 누구인지 \
+                 최소 두 개의 출처를 교차 검증해서 정리해줘.",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 4 — climate/energy, en, medium. Comparison across four technologies.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "Compare LCOE (levelized cost of energy) trajectories from 2015 to 2024 \
+                 for utility-scale solar, onshore wind, offshore wind, and natural gas \
+                 combined cycle. Which one had the steepest absolute decline?",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 5 — climate/energy, ko, medium.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "유틸리티 규모 태양광, 육상 풍력, 해상 풍력, 천연가스 복합화력에 대해 \
+                 2015년부터 2024년까지의 LCOE(균등화 발전 원가) 추이를 비교하고, \
+                 어떤 기술의 절대 하락폭이 가장 컸는지 정리해줘.",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 6 — philosophy, en, hard. Western philosophy + Buddhist comparison.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "Compare Derek Parfit's view of personal identity in 'Reasons and Persons' (1984) \
+                 with the bundle theory associated with David Hume. In what specific respect does \
+                 Parfit go beyond Hume, and where does he agree with Buddhist anatta?",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 7 — philosophy, ko, hard.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "Derek Parfit이 '이유와 인격(Reasons and Persons, 1984)'에서 제시한 \
+                 인격 동일성 견해를 David Hume의 다발 이론(bundle theory)과 비교해줘. \
+                 Parfit이 Hume보다 *어느 지점에서 더 멀리 갔는지*, 그리고 불교의 무아(anātman) \
+                 개념과 *정확히 어디서 겹치는지* 분리해서.",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 8 — cuisine/food, en, hard. Microbiology + comparative process detail.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "Compare the traditional preparation of three fermented soybean products: \
+                 Korean doenjang, Japanese miso, and Chinese douchi. Which microorganisms \
+                 are dominant in each, and how do salt content and fermentation duration differ?",
+            )]),
+            files: Vec::new(),
+        },
+        // Case 9 — cuisine/food, ko, hard.
+        Case {
+            query: Message::new(Role::User).with_contents([Part::text(
+                "전통 발효 콩 식품 세 가지 — 한국 된장, 일본 미소, 중국 두시 — 의 \
+                 전통적 제조 과정을 비교해줘. 각각의 우점 미생물이 무엇이고 \
+                 염도와 발효 기간이 어떻게 다른지 정리.",
+            )]),
+            files: Vec::new(),
+        },
+    ]
+}

--- a/agent-k/src/bin/test_case/cases/mod.rs
+++ b/agent-k/src/bin/test_case/cases/mod.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+use ailoy::message::Message;
+
+pub struct Case {
+    pub query: Message,
+    pub files: Vec<(Vec<u8>, PathBuf)>,
+}
+
+mod coworker;
+mod deep_research;
+
+pub use coworker::get_coworker_cases;
+pub use deep_research::get_deep_research_cases;

--- a/scripts/run_deep_research_eval.py
+++ b/scripts/run_deep_research_eval.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Run all 10 deep-research test cases sequentially, persist each run's
+artifacts, and produce a summary report.
+
+Outputs land under `eval-runs/deep-research-<timestamp>/`:
+    runs/<case_no>/                # the agent's artifacts/ directory
+    runs/<case_no>/stdout.txt
+    runs/<case_no>/stderr.txt
+    results.jsonl                  # one JSON line per case
+    results.csv                    # flattened metrics for spreadsheet use
+    report.md                      # human-readable summary
+    report.html                    # same summary rendered as HTML
+
+Usage:
+    python3 scripts/run_deep_research_eval.py [--model openai|claude|gemini] [--timeout SEC]
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BINARY = REPO_ROOT / "target" / "release" / "test_case"
+ARTIFACT_DIR = REPO_ROOT / "artifacts"
+EVAL_BASE = REPO_ROOT / "eval-runs"
+
+# 10 cases, paired EN/KO per topic, matching cases/deep_research.rs.
+CASES = [
+    (0, "space/astronomy", "en", "medium"),
+    (1, "space/astronomy", "ko", "medium"),
+    (2, "history", "en", "medium"),
+    (3, "history", "ko", "medium"),
+    (4, "climate/energy", "en", "medium"),
+    (5, "climate/energy", "ko", "medium"),
+    (6, "philosophy", "en", "hard"),
+    (7, "philosophy", "ko", "hard"),
+    (8, "cuisine/food", "en", "hard"),
+    (9, "cuisine/food", "ko", "hard"),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default="openai", choices=["openai", "claude", "gemini"])
+    p.add_argument("--timeout", type=int, default=600, help="per-case timeout in seconds")
+    p.add_argument("--only", type=str, default=None, help="comma-separated case numbers")
+    p.add_argument("--local", action="store_true",
+                   help="use RunEnv::local() (skip sandbox; ~3-4× faster, evaluation only)")
+    return p.parse_args()
+
+
+def run_one(case_no: int, model: str, timeout: int, run_dir: Path, local: bool = False) -> dict:
+    """Run one test_case invocation. Returns a dict of metrics."""
+    if ARTIFACT_DIR.exists():
+        shutil.rmtree(ARTIFACT_DIR)
+
+    case_dir = run_dir / f"case_{case_no:02d}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [str(BINARY), "deep-research", str(case_no), "--model", model]
+    if local:
+        cmd.append("--local")
+
+    start = time.monotonic()
+    timed_out = False
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            input="",
+        )
+        stdout, stderr, exit_code = proc.stdout, proc.stderr, proc.returncode
+    except subprocess.TimeoutExpired as e:
+        timed_out = True
+        stdout = (e.stdout.decode("utf-8", "replace") if e.stdout else "")
+        stderr = (e.stderr.decode("utf-8", "replace") if e.stderr else "")
+        exit_code = -1
+    elapsed = time.monotonic() - start
+
+    (case_dir / "stdout.txt").write_text(stdout)
+    (case_dir / "stderr.txt").write_text(stderr)
+
+    artifacts_out = case_dir / "artifacts"
+    if ARTIFACT_DIR.exists():
+        shutil.copytree(ARTIFACT_DIR, artifacts_out, dirs_exist_ok=True)
+    # Allow timed_out to be inspected by caller via proc.stdout regex match later.
+    proc_stdout = stdout
+
+    # Count tool calls from stdout — the agent prints `[deep-research] tool: NAME ARGS_JSON`.
+    tool_lines = re.findall(r"\[deep-research\] tool: (\S+)\s+(\{.*?\})\s*$", proc_stdout, re.M)
+    counts: dict[str, int] = {}
+    for name, _ in tool_lines:
+        counts[name] = counts.get(name, 0) + 1
+
+    report_path = artifacts_out / "report.md"
+    citations_path = artifacts_out / "citations.json"
+    report_bytes = report_path.stat().st_size if report_path.exists() else 0
+    n_citations = 0
+    n_marker_unique = 0
+    if citations_path.exists():
+        try:
+            cites = json.loads(citations_path.read_text())
+            if isinstance(cites, dict):
+                n_citations = len(cites)
+        except Exception:
+            pass
+    if report_path.exists():
+        body = report_path.read_text()
+        n_marker_unique = len(set(re.findall(r"\[\^(\d+)\]", body)))
+
+    return {
+        "case_no": case_no,
+        "exit_code": exit_code,
+        "timed_out": timed_out,
+        "wall_seconds": round(elapsed, 1),
+        "report_bytes": report_bytes,
+        "n_citations": n_citations,
+        "n_unique_citation_markers": n_marker_unique,
+        "api_search_calls": counts.get("api_search", 0),
+        "web_fetch_calls": counts.get("web_fetch", 0),
+        "shell_calls": counts.get("shell", 0),
+        "total_tool_calls": sum(counts.values()),
+    }
+
+
+def render_markdown_report(rows: list[dict], meta: dict, out: Path) -> None:
+    lines: list[str] = []
+    lines.append(f"# Deep-research eval — {meta['timestamp']}")
+    lines.append("")
+    lines.append(f"- Model: `{meta['model']}`")
+    lines.append(f"- Per-case timeout: {meta['timeout']}s")
+    lines.append(f"- Cases run: {len(rows)} / 10")
+    lines.append(f"- ailoy rev: `{meta.get('ailoy_rev', 'unknown')}`")
+    lines.append("")
+    lines.append("## Per-case results")
+    lines.append("")
+    lines.append(
+        "| # | domain | lang | difficulty | exit | wall (s) | report bytes | citations | api_search | web_fetch | total tools |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|---|---|---|")
+    for r in rows:
+        case_no = r["case_no"]
+        info = next(c for c in CASES if c[0] == case_no)
+        domain, lang, diff = info[1], info[2], info[3]
+        lines.append(
+            f"| {case_no} | {domain} | {lang} | {diff} | {r['exit_code']} | "
+            f"{r['wall_seconds']} | {r['report_bytes']} | {r['n_citations']} | "
+            f"{r['api_search_calls']} | {r['web_fetch_calls']} | {r['total_tool_calls']} |"
+        )
+    lines.append("")
+    completed = [r for r in rows if r["exit_code"] == 0 and r["report_bytes"] > 0]
+    lines.append(f"- Completed (exit=0 with non-empty report): {len(completed)} / {len(rows)}")
+    if completed:
+        avg_wall = sum(r["wall_seconds"] for r in completed) / len(completed)
+        avg_cites = sum(r["n_citations"] for r in completed) / len(completed)
+        avg_search = sum(r["api_search_calls"] for r in completed) / len(completed)
+        avg_fetch = sum(r["web_fetch_calls"] for r in completed) / len(completed)
+        lines.append(f"- Avg wall (completed only): {avg_wall:.1f}s")
+        lines.append(f"- Avg citations: {avg_cites:.1f}")
+        lines.append(f"- Avg api_search calls: {avg_search:.1f}")
+        lines.append(f"- Avg web_fetch calls: {avg_fetch:.1f}")
+    out.write_text("\n".join(lines))
+
+
+def render_html_report(rows: list[dict], meta: dict, out: Path) -> None:
+    import html
+
+    table_rows = ""
+    for r in rows:
+        info = next(c for c in CASES if c[0] == r["case_no"])
+        table_rows += (
+            f"<tr><td>{r['case_no']}</td><td>{html.escape(info[1])}</td>"
+            f"<td>{info[2]}</td><td>{info[3]}</td>"
+            f"<td>{r['exit_code']}</td><td>{r['wall_seconds']}</td>"
+            f"<td>{r['report_bytes']}</td><td>{r['n_citations']}</td>"
+            f"<td>{r['api_search_calls']}</td><td>{r['web_fetch_calls']}</td>"
+            f"<td>{r['total_tool_calls']}</td></tr>\n"
+        )
+    completed = [r for r in rows if r["exit_code"] == 0 and r["report_bytes"] > 0]
+    summary_extra = ""
+    if completed:
+        avg_wall = sum(r["wall_seconds"] for r in completed) / len(completed)
+        summary_extra = (
+            f"<p>Completed: {len(completed)} / {len(rows)}. "
+            f"Avg wall on completed: {avg_wall:.1f}s.</p>"
+        )
+    body = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>Deep-research eval — {meta['timestamp']}</title>
+<style>
+body {{ font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif;
+        max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ border: 1px solid #d0d7de; padding: 6px 10px; text-align: right; font-variant-numeric: tabular-nums; }}
+th:nth-child(2), td:nth-child(2),
+th:nth-child(3), td:nth-child(3),
+th:nth-child(4), td:nth-child(4) {{ text-align: left; }}
+th {{ background: #f6f8fa; }}
+caption {{ font-weight: 600; padding: 8px 0; }}
+</style></head>
+<body>
+<h1>Deep-research eval — {meta['timestamp']}</h1>
+<p>Model: <code>{meta['model']}</code> · Timeout: {meta['timeout']}s · ailoy rev: <code>{meta.get('ailoy_rev','unknown')}</code></p>
+{summary_extra}
+<table>
+<caption>Per-case metrics</caption>
+<thead>
+<tr><th>#</th><th>domain</th><th>lang</th><th>difficulty</th>
+<th>exit</th><th>wall (s)</th><th>report bytes</th><th>citations</th>
+<th>api_search</th><th>web_fetch</th><th>total tools</th></tr>
+</thead>
+<tbody>
+{table_rows}
+</tbody></table>
+</body></html>"""
+    out.write_text(body)
+
+
+def main() -> int:
+    args = parse_args()
+    if not BINARY.exists():
+        print(f"binary not built: {BINARY}", file=sys.stderr)
+        return 2
+
+    selected = (
+        [int(s) for s in args.only.split(",")] if args.only
+        else [c[0] for c in CASES]
+    )
+
+    ts = dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+    run_root = EVAL_BASE / f"deep-research-{args.model}-{ts}"
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    ailoy_rev = "unknown"
+    cargo_toml = REPO_ROOT / "Cargo.toml"
+    if cargo_toml.exists():
+        m = re.search(r'rev\s*=\s*"([0-9a-f]+)"', cargo_toml.read_text())
+        if m:
+            ailoy_rev = m.group(1)[:12]
+
+    meta = {
+        "timestamp": ts,
+        "model": args.model,
+        "timeout": args.timeout,
+        "ailoy_rev": ailoy_rev,
+    }
+    (run_root / "meta.json").write_text(json.dumps(meta, indent=2))
+
+    results: list[dict] = []
+    jsonl = (run_root / "results.jsonl").open("w")
+    for case_no in selected:
+        info = next(c for c in CASES if c[0] == case_no)
+        print(
+            f"[{case_no}/{max(selected)}] domain={info[1]} lang={info[2]} diff={info[3]} ...",
+            flush=True,
+        )
+        row = run_one(case_no, args.model, args.timeout, run_root, local=args.local)
+        flag = " TIMEOUT" if row.get("timed_out") else ""
+        print(
+            f"  -> exit={row['exit_code']}{flag} wall={row['wall_seconds']}s "
+            f"report={row['report_bytes']}B cites={row['n_citations']} "
+            f"api_search={row['api_search_calls']} web_fetch={row['web_fetch_calls']}",
+            flush=True,
+        )
+        results.append(row)
+        jsonl.write(json.dumps(row) + "\n")
+        jsonl.flush()
+    jsonl.close()
+
+    fields = list(results[0].keys()) if results else []
+    with (run_root / "results.csv").open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for r in results:
+            w.writerow(r)
+
+    render_markdown_report(results, meta, run_root / "report.md")
+    render_html_report(results, meta, run_root / "report.html")
+    print(f"\nrun root: {run_root}")
+    print(f"  report.md  : {run_root / 'report.md'}")
+    print(f"  report.html: {run_root / 'report.html'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a `deep-research` agent mirroring the structure of the coworker agent (PR #88) and depending on the `web_fetch` builtin added in brekkylab/ailoy#412. The agent produces long-form research reports under `artifacts/` with inline `[^N]` citations grounded in URLs fetched during the same session.

Test cases for the two agents are split into a `test_case/cases/` module, with ten English/Korean paired research cases for deep-research alongside the existing coworker cases.

This PR is opened as a draft because end-to-end smoke testing surfaced a search-quality issue described in the notes below.

## Surface

- `agent_k::agents::get_deep_research_agent(name, model, artifacts_dir)` mirrors `get_coworker_agent` exactly in signature, sandbox setup, and runenv handling.
- The agent's tool stack is `system_tools()` + `web_search_tool(vec![Brave, DuckDuckGo, Mojeek, Bing])` + `web_fetch_tool()` (the latter from brekkylab/ailoy#412).
- The system prompt follows the coworker layout (`Workflow / Citations / Tools / Artifacts / Others / Information`), augmented with rules specific to research output (outline-first sectioning, citation pre-flight, source diversity).
- `test_case` accepts a leading positional argument `coworker | deep-research` to select the agent:
  ```
  cargo run -p agent-k --bin test_case -- coworker 0
  cargo run -p agent-k --bin test_case -- deep-research 0 --model claude
  ```
- All three model vendors (openai, claude, gemini) are accepted via `--model`, matching the coworker test runner.

## test_case layout

```
agent-k/src/bin/test_case/
├── cases/
│   ├── mod.rs           # `Case` struct + re-exports
│   ├── coworker.rs      # `get_coworker_cases()`  — 8 cases (unchanged)
│   └── deep_research.rs # `get_deep_research_cases()` — 10 cases
├── co2.csv
├── payslips.pdf
├── receipt_1.png
└── receipt_2.png
```

Binary assets stay at the top level of `test_case/`, so the coworker cases continue to reference them with `include_bytes!("../co2.csv")` etc. The asset files themselves are not moved or renamed.

## deep-research cases

Ten paired English/Korean cases spanning five domains and two difficulty levels:

| Case | Domain | Lang | Difficulty |
|---|---|---|---|
| 0 / 1 | space/astronomy | en / ko | medium |
| 2 / 3 | history | en / ko | medium |
| 4 / 5 | climate/energy | en / ko | medium |
| 6 / 7 | philosophy | en / ko | hard |
| 8 / 9 | cuisine/food | en / ko | hard |

The English/Korean pairing follows the convention already used by the coworker cases.

## Dependencies

- `ailoy` pinned to commit `353f10e` on `feat/web-fetch-tool` (brekkylab/ailoy#412 head), which is the branch adding `web_fetch_tool()` and the `urls=[]` empty-array fallback. When that PR merges, this PR should rebase its ailoy pin onto the merged develop commit.

## Why draft

End-to-end smoke runs on this host (Korea-located IP) consistently hit a search-noise loop: the meta-search engines fall back to Korean-localised results for English queries because of client IP geolocation, the LLM treats those results as off-topic, and search retries explode until the time budget is exhausted before the agent gets to the fetch/report stages. The same code is expected to behave normally from a US-located IP, but until a more general fix lands in the search layer, the smoke test outcome on this machine is not representative.

This is an upstream / environment issue rather than a defect of this PR's code: the deep-research agent itself, the `test_case` split, the case set, and the wiring to the ailoy builtins all work correctly. The PR is being opened as a draft to surface the work, collect review on the agent shape and case set, and decide between several mitigation paths (per-call region parameters on the search builtins, client-side language filtering of results, or proxying the search requests).

Once a search-layer mitigation lands and an end-to-end smoke run completes from a US-located environment, the draft will be flipped to ready-for-review.

## Notes

- No public API changes outside of adding `get_deep_research_agent` and renaming the `test_case` argument layout.
- `coworker.rs` was touched only to migrate from `web_search_tool()` to `web_search_tool(vec![])` per the new ailoy signature introduced in brekkylab/ailoy#411.
- `cargo build -p agent-k --bin test_case` passes; `cargo test --lib` passes.
