### PR TITLE
feat(frontend): add new project creation dialog

### DIFF
--- a/app/src/components/NewProjectDialog.tsx
+++ b/app/src/components/NewProjectDialog.tsx
@@ -106,7 +106,7 @@ export function NewProjectDialog({ existingNames, onClose }: NewProjectDialogPro
             disabled={pending}
             aria-invalid={submitError !== null}
             aria-describedby={submitError ? 'cw-new-project-error' : undefined}
-            maxLength={120}
+            maxLength={100}
           />
         </label>
         <label className="cw-field">

--- a/app/src/components/NewProjectDialog.tsx
+++ b/app/src/components/NewProjectDialog.tsx
@@ -1,0 +1,167 @@
+// New project creation dialog. Composes two existing patterns:
+//   - InviteDialog: in-component mutation + invalidate + close
+//   - NewFolderDialog: client-side name validation + backdrop drag guard
+// On success we navigate straight into the created project so the user can
+// start working immediately (matches Slack/Notion/Linear post-create UX).
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { createProject, listProjects } from '@/api/projects';
+import { ApiError } from '@/api/client';
+import { Icon } from '@/components/Icon';
+
+interface NewProjectDialogProps {
+  existingNames: string[];
+  onClose: () => void;
+}
+
+function validate(raw: string, existing: string[]): string | null {
+  const name = raw.trim();
+  if (name.length === 0) return null;
+  if (name.length > 100) return '프로젝트 이름은 100자 이하로 입력해 주세요.';
+  if (existing.some((e) => e.toLowerCase() === name.toLowerCase())) {
+    return `"${name}" 이름의 프로젝트가 이미 있어요.`;
+  }
+  return null;
+}
+
+export function NewProjectDialog({ existingNames, onClose }: NewProjectDialogProps) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () => createProject({
+      name: name.trim(),
+      description: description.trim() || undefined,
+    }),
+    onSuccess: async (created) => {
+      await queryClient.invalidateQueries({ queryKey: ['projects'] });
+      onClose();
+      navigate({ to: '/projects/$projectId', params: { projectId: created.id } });
+    },
+    onError: (err) => {
+      setSubmitError(messageOf(err));
+    },
+  });
+
+  const pending = mutation.isPending;
+  const trimmed = name.trim();
+  const submitDisabled = trimmed.length === 0 || pending;
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape' && !pending) onClose(); }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, pending]);
+
+  function submit() {
+    if (submitDisabled) return;
+    const err = validate(name, existingNames);
+    if (err) {
+      setSubmitError(err);
+      return;
+    }
+    setSubmitError(null);
+    mutation.mutate();
+  }
+
+  const downOnBackdropRef = useRef(false);
+
+  // Portal escapes any ancestor stacking context (e.g. cw-page-enter's
+  // animation transform), guaranteeing the backdrop fills the viewport
+  // regardless of where in the tree this dialog is rendered.
+  return createPortal(
+    <div
+      className="cw-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+      onMouseDown={(e) => { downOnBackdropRef.current = e.target === e.currentTarget; }}
+      onClick={(e) => {
+        const wasDownOnBackdrop = downOnBackdropRef.current;
+        downOnBackdropRef.current = false;
+        if (!wasDownOnBackdrop) return;
+        if (e.target === e.currentTarget && !pending) onClose();
+      }}
+    >
+      <form className="cw-dialog" onSubmit={(e) => { e.preventDefault(); submit(); }}>
+        <button type="button" className="cw-close" onClick={onClose} disabled={pending} aria-label="close">
+          <Icon name="x" />
+        </button>
+        <h2 style={{ margin: '0 0 6px', fontSize: 18, letterSpacing: '-0.015em' }}>새 프로젝트</h2>
+        <p style={{ color: 'var(--cw-ink-3)', margin: '0 0 16px', fontSize: 13, lineHeight: 1.55 }}>
+          새 워크스페이스를 만듭니다. 생성 후 자동으로 이동합니다.
+        </p>
+        <label className="cw-field">
+          <span>이름</span>
+          <input
+            autoFocus
+            value={name}
+            onChange={(e) => { setName(e.target.value); if (submitError) setSubmitError(null); }}
+            placeholder="예: Quarterly Planning"
+            disabled={pending}
+            aria-invalid={submitError !== null}
+            aria-describedby={submitError ? 'cw-new-project-error' : undefined}
+            maxLength={120}
+          />
+        </label>
+        <label className="cw-field">
+          <span>설명 <span style={{ color: 'var(--cw-ink-4)', fontWeight: 400 }}>(선택)</span></span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="이 프로젝트는 어떤 작업인가요?"
+            disabled={pending}
+            rows={3}
+            style={{ resize: 'vertical', minHeight: 72, fontFamily: 'inherit' }}
+          />
+        </label>
+        {submitError && (
+          <div id="cw-new-project-error" className="cw-dialog-warn" role="alert">
+            <Icon name="x" size={12} /> {submitError}
+          </div>
+        )}
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 18 }}>
+          <button type="button" className="cw-btn-secondary" onClick={onClose} disabled={pending}>취소</button>
+          <button type="submit" className="cw-btn-primary" disabled={submitDisabled}>
+            {pending ? '생성 중…' : '만들기'}
+          </button>
+        </div>
+      </form>
+    </div>,
+    document.body,
+  );
+}
+
+// Convenience hook so multiple entry points (sidebar, projects page header, …)
+// can share state + dialog rendering without each duplicating
+// `existingNames` derivation and useState wiring. Returns the imperative
+// `open()` and the declarative `dialog` ReactNode to drop into JSX.
+export function useNewProjectDialog(): { open: () => void; dialog: ReactNode } {
+  const [isOpen, setIsOpen] = useState(false);
+  const projects = useQuery({ queryKey: ['projects'], queryFn: listProjects });
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const dialog = isOpen ? (
+    <NewProjectDialog
+      existingNames={(projects.data ?? []).map((p) => p.name)}
+      onClose={close}
+    />
+  ) : null;
+  return { open, dialog };
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.';
+    if (err.status === 409) return '같은 이름의 프로젝트가 이미 있어요.';
+    if (err.status === 422 || err.status === 400) return '입력값을 확인해 주세요.';
+    return `${err.status} — ${err.message}`;
+  }
+  if (err instanceof Error) return err.message;
+  return '프로젝트 생성에 실패했습니다.';
+}

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import { Avatar, IconPocket, SectionLabel } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
 import { useToastStore } from '@/components/Toast';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { useNewProjectDialog } from '@/components/NewProjectDialog';
 import { SessionCardMenu } from '@/components/SessionCardMenu';
 import { canAdministerSession } from '@/lib/permissions';
 import { ApiError } from '@/api/client';
@@ -57,6 +58,7 @@ export function Sidebar() {
   });
 
   const [pendingDelete, setPendingDelete] = useState<Session | null>(null);
+  const projectCreator = useNewProjectDialog();
   const deleteMutation = useMutation({
     mutationFn: (sessionId: string) => deleteSession(sessionId),
     onSuccess: async (_, deletedId) => {
@@ -113,7 +115,7 @@ export function Sidebar() {
         ))}
         <button
           className="cw-nav-row is-ghost"
-          onClick={() => showToast('새 프로젝트 생성 다이얼로그는 곧 추가됩니다')}
+          onClick={projectCreator.open}
         >
           <span className="cw-project-swatch is-plus">+</span>
           <span>새 Project</span>
@@ -221,6 +223,8 @@ export function Sidebar() {
           onClose={() => setPendingDelete(null)}
         />
       )}
+
+      {projectCreator.dialog}
 
       {currentUser && (
         <div className="cw-sidebar-user">

--- a/app/src/routes/_app.projects.index.tsx
+++ b/app/src/routes/_app.projects.index.tsx
@@ -6,9 +6,9 @@ import { useQuery } from '@tanstack/react-query';
 import { listMembers, listProjects } from '@/api/projects';
 import { listSessions } from '@/api/sessions';
 import { Icon } from '@/components/Icon';
+import { useNewProjectDialog } from '@/components/NewProjectDialog';
 import { AvatarStack, SectionLabel } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
-import { useToastStore } from '@/components/Toast';
 import type { Project, Session, User } from '@/domain/types';
 
 function useActiveProjectIdFromRoute(): string | null {
@@ -26,9 +26,9 @@ export const Route = createFileRoute('/_app/projects/')({
 
 function ProjectsPage() {
   const navigate = useNavigate();
-  const showToast = useToastStore((s) => s.show);
   const projects = useQuery({ queryKey: ['projects'], queryFn: listProjects });
   const activeProjectId = useActiveProjectIdFromRoute() ?? projects.data?.[0]?.id ?? null;
+  const creator = useNewProjectDialog();
 
   return (
     <section className="cw-page cw-projects-page cw-page-enter">
@@ -37,7 +37,7 @@ function ProjectsPage() {
           <h1>Your projects</h1>
           <p>Each project is a workspace. Sessions, files, members, skills, schedule — all live inside.</p>
         </div>
-        <button className="cw-btn-primary" onClick={() => showToast('새 프로젝트 생성 다이얼로그는 곧 추가됩니다')}>
+        <button className="cw-btn-primary" onClick={creator.open}>
           <Icon name="plus" /> New project
         </button>
       </div>
@@ -52,6 +52,7 @@ function ProjectsPage() {
           />
         ))}
       </div>
+      {creator.dialog}
     </section>
   );
 }

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -330,7 +330,7 @@ button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px s
 .cw-intent-grid button span:last-child { grid-column: 2; color: var(--cw-fg-3); font-size: 12px; }
 .cw-intent-grid button.is-active { border-color: var(--cw-accent-line); background: var(--cw-accent-soft); }
 
-@keyframes cw-enter { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes cw-enter { from { opacity: 0; } to { opacity: 1; } }
 @keyframes cw-rise { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes cw-ping { 50% { opacity: .25; } }
 


### PR DESCRIPTION
Closing Issue https://github.com/brekkylab/agent-k/issues/92
## Summary
- Made the "New project" button on the ProjectsPage header and the "+ 새 Project" item in the Sidebar actually work. On successful creation with name/description input, auto-navigates to the new project (Slack/Notion style).
- The boilerplate of both entry points is encapsulated into the `useNewProjectDialog` hook. Callers only use `creator.open` / `creator.dialog`.
- Defended against the issue where the backdrop was trapped inside the page section box due to `cw-page-enter`'s transform residue (backdrop drawn narrowly on the main page) with two layers: ① changed the `cw-enter` keyframe to opacity-only ② mounted the NewProjectDialog backdrop directly on `document.body` via `React Portal`.

## Screenshots

### Projects page — entry points
_Header "New project" button + sidebar "+ 새 Project" item, both wired through the same hook._
<img width="1440" height="900" alt="pr111-01-projects-page" src="https://github.com/user-attachments/assets/b371da14-d112-4f51-9a8e-6d79946a859a" />

### Dialog opened (filled state) — backdrop covers full viewport
_Proves the Portal + opacity-only `cw-enter` fix: backdrop is no longer trapped inside the page section's stacking context._
<img width="1440" height="900" alt="pr111-02-dialog-filled" src="https://github.com/user-attachments/assets/901d0bec-d84f-477a-8dca-45401b2c120d" />

### Duplicate-name inline error
_Mutation does not fire; alert is shown beneath the description field._
<img width="1440" height="900" alt="pr111-03-dialog-duplicate-error" src="https://github.com/user-attachments/assets/328ba0f2-2939-477b-91db-2dfac04ff3e5" />

### Sidebar entry point — same dialog
_Confirms both entry points share the `useNewProjectDialog` hook (single source of truth)._
<img width="1440" height="900" alt="pr111-04-dialog-from-sidebar" src="https://github.com/user-attachments/assets/fb1df1ae-15f9-4df1-8049-0a904230a4b3" />

## Commits

- `feat(frontend): add new project creation dialog` — NewProjectDialog component + `useNewProjectDialog` hook + two entry points
- `fix(styles): drop translate from cw-enter to avoid stacking context leak` — 1 line in `globals.css`. Patches the CSS pitfall where `transform: translateY(0)`, even as an identity transform, creates a new containing block for fixed positioning. The 8px slide-up disappears (fade-in is preserved) for all elements using `cw-enter` (cw-page-enter, cw-dialog, cw-loading img, cw-bulk-toolbar-inline).

## Test plan
- [x] After entering `/projects`, click the "New project" button → dialog is displayed at the center of the viewport and backdrop covers the entire screen — _verified via DOM measurement: `.cw-dialog-backdrop` rect = `{0, 0, 1440, 900}` = exact viewport, and `parentElement` chain reaches `<body>` (React Portal mount confirmed)_
- [x] Click sidebar "+ 새 Project" → same dialog is invoked — _identical heading "새 프로젝트", same form fields, same backdrop class via single `useNewProjectDialog` hook_
- [x] Enter name only + "만들기" → auto-navigates to the new project, both sidebar and main list are refreshed — _URL changed to `/projects/{new uuid}`; sidebar grew from 3 → 4 entries; main list count label updated to "Projects · 4 projects"_
- [x] Enter description as well + "만들기" → description is shown on the new page — _description "Verification with description for T4" rendered as the first `<p>` in `main` on the new project page_
- [x] Enter duplicate name → inline error is shown, mutation is not fired — _alert "\"test\" 이름의 프로젝트가 이미 있어요." shown; dialog stayed open; project count unchanged_
- [x] Description can be left empty (matches backend `Option<String>`) — _empty-description project created successfully and renders "설명 없음" in the list_
- [x] Backdrop click / Esc / cancel all close consistently — _all three paths close the dialog; backdrop uses a mousedown+click drag-guard so accidental selection drags don't dismiss_
- [x] 0 console errors/warnings (on fresh load) — _0 errors on a clean reload. 1 warning remains but it's `app/src/api/ws.ts:38` WebSocket connection (backend ws endpoint not implemented) — pre-existing and unrelated to this PR's changes (NewProjectDialog / Sidebar / globals.css)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)