### PR TITLE
[App] Refine layout shell and sidebar interactions

### DIFF
--- a/app/src/components/Icon.tsx
+++ b/app/src/components/Icon.tsx
@@ -6,13 +6,13 @@ export type IconName =
   | 'send' | 'sparkles' | 'check' | 'chevron' | 'zap' | 'calendar' | 'artifact'
   | 'shield' | 'x' | 'arrow-left' | 'analysis' | 'brainstorm' | 'writing'
   | 'recap' | 'general' | 'more' | 'upload' | 'trash' | 'download'
-  | 'list' | 'grid' | 'chevron-right'
+  | 'list' | 'grid' | 'chevron-right' | 'chevron-left'
   | 'file-pdf' | 'file-code' | 'file-archive' | 'file-video' | 'file-audio';
 
 type PreviewIconName =
   | 'lock' | 'eye' | 'message-square' | 'messages-square' | 'clipboard-list'
   | 'lightbulb' | 'pencil' | 'home' | 'folder' | 'folder-open' | 'users'
-  | 'settings' | 'plus' | 'chevron-down' | 'chevron-right' | 'more-horizontal' | 'check'
+  | 'settings' | 'plus' | 'chevron-down' | 'chevron-right' | 'chevron-left' | 'more-horizontal' | 'check'
   | 'x' | 'arrow-left' | 'send' | 'search' | 'file-text' | 'file-spreadsheet'
   | 'file' | 'image' | 'sparkles' | 'shield-check' | 'zap' | 'calendar'
   | 'trash-2' | 'download' | 'list' | 'grid-3x3'
@@ -52,6 +52,7 @@ const previewIconPath: Record<PreviewIconName, string> = {
   list: '<line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/>',
   'grid-3x3': '<rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/>',
   'chevron-right': '<path d="m9 18 6-6-6-6"/>',
+  'chevron-left': '<path d="m15 18-6-6 6-6"/>',
   /* Lucide file family. file-text and file-spreadsheet already exist above. */
   'file-code': '<path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M5 12V4a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2H7.5"/><path d="m10 13-3 3 3 3"/><path d="m14 13 3 3-3 3"/>',
   'file-archive': '<path d="M10 12v-1"/><path d="M10 18v-2"/><path d="M10 7V6"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M15.5 22H18a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h2.5"/><circle cx="10" cy="20" r="2"/>',
@@ -96,6 +97,7 @@ const iconAlias: Record<IconName, PreviewIconName> = {
   list: 'list',
   grid: 'grid-3x3',
   'chevron-right': 'chevron-right',
+  'chevron-left': 'chevron-left',
   /* PDF doesn't have its own Lucide glyph — reuse file-text and let colour
      (cw-file-pdf rose tint) carry the type signal. */
   'file-pdf': 'file-text',

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -15,11 +15,9 @@ import { Avatar, IconPocket } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
 import {
   getSidebarModeForDrag,
-  getSidebarModeWhileResizing,
   isSidebarRevealHoldPoint,
-  shouldCloseSidebarRevealOnNavigation,
-  shouldRevealSidebarAfterDrag,
   useLayoutStore,
+  SIDEBAR_MOBILE_BREAKPOINT,
   SIDEBAR_REVEAL_WIDTH,
 } from '@/stores/layout';
 import { useToastStore } from '@/components/Toast';
@@ -42,42 +40,42 @@ function SidebarResizer({ setRevealed }: { setRevealed: (revealed: boolean) => v
       const { sidebarMode, expandedWidth } = useLayoutStore.getState();
       // When hidden, the floating overlay shows at REVEAL_WIDTH, so the user's hand
       // is already at that x-coordinate — start from there so dragging is 1:1.
-      const hiddenAtStart = sidebarMode === 'hidden';
       const startW = sidebarMode === 'hidden' ? SIDEBAR_REVEAL_WIDTH : expandedWidth;
       let lastW = startW;
       let lastClientX = e.clientX;
-      let lastClientY = e.clientY;
       document.body.classList.add('is-resizing-sidebar');
 
       function onMove(ev: PointerEvent) {
         const w = startW + (ev.clientX - startX);
-        const modeAfterRelease = getSidebarModeForDrag(w, hiddenAtStart);
-        const modeWhileResizing = getSidebarModeWhileResizing(modeAfterRelease);
+        // Re-read the current mode every move so hysteresis tracks the live state:
+        // if the user drags into hidden mid-drag, the next move's threshold flips
+        // up to SIDEBAR_EXPAND_ABOVE, matching the "I'm in hidden now" mental model.
+        const liveHidden = useLayoutStore.getState().sidebarMode === 'hidden';
+        const nextMode = getSidebarModeForDrag(w, liveHidden);
         lastW = w;
         lastClientX = ev.clientX;
-        lastClientY = ev.clientY;
-        setRevealed(false);
-        if (modeWhileResizing === 'hidden') {
+        if (nextMode === 'hidden') {
+          // Keep the sidebar on screen as a floating reveal so the user's grip on
+          // the resizer survives the mode flip — release decides if it stays open.
           setSidebarMode('hidden');
+          setRevealed(true);
         } else {
           setSidebarMode('expanded');
           setExpandedWidth(w);  // store clamps to [MIN, MAX]
+          setRevealed(false);
         }
       }
       function onUp() {
         window.removeEventListener('pointermove', onMove);
         window.removeEventListener('pointerup', onUp);
         document.body.classList.remove('is-resizing-sidebar');
-        const modeAfterRelease = getSidebarModeForDrag(lastW, hiddenAtStart);
+        const liveHidden = useLayoutStore.getState().sidebarMode === 'hidden';
+        const modeAfterRelease = getSidebarModeForDrag(lastW, liveHidden);
         setSidebarMode(modeAfterRelease);
-        setRevealed(
-          shouldRevealSidebarAfterDrag(
-            modeAfterRelease,
-            lastClientX,
-            lastClientY,
-            window.innerHeight,
-          ),
-        );
+        // Keep reveal open only if the cursor is still resting on the floating
+        // sidebar (or its exit buffer) at release time. lastClientY unused: vertical
+        // bounds are the full viewport.
+        setRevealed(modeAfterRelease === 'hidden' && isSidebarRevealHoldPoint(lastClientX));
       }
       window.addEventListener('pointermove', onMove);
       window.addEventListener('pointerup', onUp);
@@ -157,9 +155,6 @@ export function Sidebar() {
   // Grace delay before closing on mouse-leave so brief excursions outside the
   // floating sidebar don't snap it shut. ~250ms feels intentional but not sticky.
   const closeTimerRef = useRef<number | null>(null);
-  const shouldHoldReveal = useCallback((clientX: number, clientY: number) => (
-    isSidebarRevealHoldPoint(clientX, clientY, window.innerHeight)
-  ), []);
   const cancelClose = useCallback(() => {
     if (closeTimerRef.current !== null) {
       window.clearTimeout(closeTimerRef.current);
@@ -170,18 +165,18 @@ export function Sidebar() {
     cancelClose();
     setRevealed(true);
   }, [cancelClose]);
-  const scheduleClose = useCallback((point?: { clientX: number; clientY: number }) => {
+  const scheduleClose = useCallback((point?: { clientX: number }) => {
     cancelClose();
-    if (point && shouldHoldReveal(point.clientX, point.clientY)) return;
+    if (point && isSidebarRevealHoldPoint(point.clientX)) return;
     closeTimerRef.current = window.setTimeout(() => setRevealed(false), 250);
-  }, [cancelClose, shouldHoldReveal]);
+  }, [cancelClose]);
   useEffect(() => cancelClose, [cancelClose]);
 
   useEffect(() => {
     if (sidebarMode !== 'hidden' || !revealed) return;
 
     function onPointerMove(ev: PointerEvent) {
-      if (shouldHoldReveal(ev.clientX, ev.clientY)) {
+      if (isSidebarRevealHoldPoint(ev.clientX)) {
         cancelClose();
       } else {
         scheduleClose();
@@ -190,7 +185,7 @@ export function Sidebar() {
 
     window.addEventListener('pointermove', onPointerMove);
     return () => window.removeEventListener('pointermove', onPointerMove);
-  }, [cancelClose, revealed, scheduleClose, shouldHoldReveal, sidebarMode]);
+  }, [cancelClose, revealed, scheduleClose, sidebarMode]);
 
   const projectsQuery = useQuery({ queryKey: ['projects'], queryFn: listProjects });
   // URL에 projectId가 있을 때만 활성 프로젝트로 인정한다 — /projects 같은 곳에서는
@@ -210,9 +205,8 @@ export function Sidebar() {
   // Close on navigation for mobile drawers, but keep desktop hidden/reveal open
   // so sidebar clicks don't immediately tuck it away.
   useEffect(() => {
-    if (shouldCloseSidebarRevealOnNavigation(sidebarMode, window.innerWidth)) {
-      setRevealed(false);
-    }
+    const isMobile = window.innerWidth < SIDEBAR_MOBILE_BREAKPOINT;
+    if (isMobile || sidebarMode !== 'hidden') setRevealed(false);
   }, [activeProjectId, activeSessionId, activeRoute, sidebarMode]);
 
   const createSessionMutation = useMutation({
@@ -295,7 +289,7 @@ export function Sidebar() {
         className={`cw-sidebar-app${revealed ? ' is-revealed' : ''}`}
         onPointerEnter={() => { if (sidebarMode === 'hidden') openReveal(); }}
         onPointerLeave={(e) => {
-          if (sidebarMode === 'hidden') scheduleClose({ clientX: e.clientX, clientY: e.clientY });
+          if (sidebarMode === 'hidden') scheduleClose({ clientX: e.clientX });
         }}
       >
       <div className="cw-sidebar-header">

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -1,16 +1,27 @@
-// Sidebar — markup follows app-live exactly: brand lockup, project nav, active
-// project block (Home/Files/Skills/Schedule/Members/Settings), Sessions rail,
-// sidebar-user. Only the routing API is swapped to TanStack Router.
+// Sidebar — header(brand) + 단일 스크롤 본문(PROJECTS section, active project
+// menu, Sessions section) + user-area 푸터. 폭은 사용자가 오른쪽 가장자리
+// resizer로 직접 조절(layout store에 persist). PROJECTS/Sessions는 sticky
+// SectionHeader를 통해 펼치고 접을 수 있고, 접힘 상태에서도 active 항목과
+// (Sessions 한정) unread 항목은 유지된다.
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import logoMark from '@/assets/logo-mark.svg';
 import { listProjects } from '@/api/projects';
 import { createSession, deleteSession, listSessions } from '@/api/sessions';
 import { Icon } from '@/components/Icon';
-import { Avatar, IconPocket, SectionLabel } from '@/components/uiPrimitives';
+import { Avatar, IconPocket } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
+import {
+  getSidebarModeForDrag,
+  getSidebarModeWhileResizing,
+  isSidebarRevealHoldPoint,
+  shouldCloseSidebarRevealOnNavigation,
+  shouldRevealSidebarAfterDrag,
+  useLayoutStore,
+  SIDEBAR_REVEAL_WIDTH,
+} from '@/stores/layout';
 import { useToastStore } from '@/components/Toast';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { useNewProjectDialog } from '@/components/NewProjectDialog';
@@ -20,16 +31,171 @@ import { ApiError } from '@/api/client';
 import { SessionTitleText } from '@/components/SessionTitleText';
 import type { Session } from '@/domain/types';
 
+function SidebarResizer({ setRevealed }: { setRevealed: (revealed: boolean) => void }) {
+  const setSidebarMode = useLayoutStore((s) => s.setSidebarMode);
+  const setExpandedWidth = useLayoutStore((s) => s.setExpandedWidth);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const { sidebarMode, expandedWidth } = useLayoutStore.getState();
+      // When hidden, the floating overlay shows at REVEAL_WIDTH, so the user's hand
+      // is already at that x-coordinate — start from there so dragging is 1:1.
+      const hiddenAtStart = sidebarMode === 'hidden';
+      const startW = sidebarMode === 'hidden' ? SIDEBAR_REVEAL_WIDTH : expandedWidth;
+      let lastW = startW;
+      let lastClientX = e.clientX;
+      let lastClientY = e.clientY;
+      document.body.classList.add('is-resizing-sidebar');
+
+      function onMove(ev: PointerEvent) {
+        const w = startW + (ev.clientX - startX);
+        const modeAfterRelease = getSidebarModeForDrag(w, hiddenAtStart);
+        const modeWhileResizing = getSidebarModeWhileResizing(modeAfterRelease);
+        lastW = w;
+        lastClientX = ev.clientX;
+        lastClientY = ev.clientY;
+        setRevealed(false);
+        if (modeWhileResizing === 'hidden') {
+          setSidebarMode('hidden');
+        } else {
+          setSidebarMode('expanded');
+          setExpandedWidth(w);  // store clamps to [MIN, MAX]
+        }
+      }
+      function onUp() {
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+        document.body.classList.remove('is-resizing-sidebar');
+        const modeAfterRelease = getSidebarModeForDrag(lastW, hiddenAtStart);
+        setSidebarMode(modeAfterRelease);
+        setRevealed(
+          shouldRevealSidebarAfterDrag(
+            modeAfterRelease,
+            lastClientX,
+            lastClientY,
+            window.innerHeight,
+          ),
+        );
+      }
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+    },
+    [setRevealed, setSidebarMode, setExpandedWidth],
+  );
+
+  return (
+    <div
+      className="cw-sidebar-resizer"
+      onPointerDown={onPointerDown}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="사이드바 폭 조절"
+    />
+  );
+}
+
+function SectionHeader({
+  label,
+  expanded,
+  onToggle,
+  onAdd,
+  addLabel,
+  addDisabled,
+}: {
+  label: string;
+  expanded: boolean;
+  onToggle: () => void;
+  onAdd?: () => void;
+  addLabel?: string;
+  addDisabled?: boolean;
+}) {
+  return (
+    <div className="cw-section-header">
+      <button
+        type="button"
+        className="cw-section-toggle"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        aria-controls={`section-${label}`}
+      >
+        <Icon
+          name="chevron-right"
+          size={12}
+          className={`cw-section-chevron ${expanded ? 'is-open' : ''}`}
+        />
+        <span>{label}</span>
+      </button>
+      {onAdd && (
+        <button
+          type="button"
+          className="cw-section-add"
+          onClick={(e) => { e.stopPropagation(); onAdd(); }}
+          disabled={addDisabled}
+          aria-label={addLabel ?? `${label} 추가`}
+          title={addLabel ?? `${label} 추가`}
+        >
+          <Icon name="plus" size={14} />
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function Sidebar() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const showToast = useToastStore((s) => s.show);
   const currentUser = useAuthStore((s) => s.currentUser);
+  const sidebarMode = useLayoutStore((s) => s.sidebarMode);
+  const projectsExpanded = useLayoutStore((s) => s.projectsExpanded);
+  const sessionsExpanded = useLayoutStore((s) => s.sessionsExpanded);
+  const toggleProjects = useLayoutStore((s) => s.toggleProjects);
+  const toggleSessions = useLayoutStore((s) => s.toggleSessions);
+  const [revealed, setRevealed] = useState(false);
+  // Grace delay before closing on mouse-leave so brief excursions outside the
+  // floating sidebar don't snap it shut. ~250ms feels intentional but not sticky.
+  const closeTimerRef = useRef<number | null>(null);
+  const shouldHoldReveal = useCallback((clientX: number, clientY: number) => (
+    isSidebarRevealHoldPoint(clientX, clientY, window.innerHeight)
+  ), []);
+  const cancelClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+  const openReveal = useCallback(() => {
+    cancelClose();
+    setRevealed(true);
+  }, [cancelClose]);
+  const scheduleClose = useCallback((point?: { clientX: number; clientY: number }) => {
+    cancelClose();
+    if (point && shouldHoldReveal(point.clientX, point.clientY)) return;
+    closeTimerRef.current = window.setTimeout(() => setRevealed(false), 250);
+  }, [cancelClose, shouldHoldReveal]);
+  useEffect(() => cancelClose, [cancelClose]);
+
+  useEffect(() => {
+    if (sidebarMode !== 'hidden' || !revealed) return;
+
+    function onPointerMove(ev: PointerEvent) {
+      if (shouldHoldReveal(ev.clientX, ev.clientY)) {
+        cancelClose();
+      } else {
+        scheduleClose();
+      }
+    }
+
+    window.addEventListener('pointermove', onPointerMove);
+    return () => window.removeEventListener('pointermove', onPointerMove);
+  }, [cancelClose, revealed, scheduleClose, shouldHoldReveal, sidebarMode]);
 
   const projectsQuery = useQuery({ queryKey: ['projects'], queryFn: listProjects });
-  const urlProjectId = useActiveProjectId();
-  // /projects URL에서도 첫 프로젝트의 sub-nav를 보여주기 위해 default fallback.
-  const activeProjectId = urlProjectId ?? projectsQuery.data?.[0]?.id ?? null;
+  // URL에 projectId가 있을 때만 활성 프로젝트로 인정한다 — /projects 같은 곳에서는
+  // sub-nav(Home/Files/.../Sessions)가 보이지 않아야 사용자 멘탈 모델과 일치.
+  const activeProjectId = useActiveProjectId();
   const activeProject = (projectsQuery.data ?? []).find((p) => p.id === activeProjectId);
 
   const sessionsQuery = useQuery({
@@ -40,6 +206,14 @@ export function Sidebar() {
 
   const activeSessionId = useActiveSessionId();
   const activeRoute = useActiveRouteKey();
+
+  // Close on navigation for mobile drawers, but keep desktop hidden/reveal open
+  // so sidebar clicks don't immediately tuck it away.
+  useEffect(() => {
+    if (shouldCloseSidebarRevealOnNavigation(sidebarMode, window.innerWidth)) {
+      setRevealed(false);
+    }
+  }, [activeProjectId, activeSessionId, activeRoute, sidebarMode]);
 
   const createSessionMutation = useMutation({
     mutationFn: (projectId: string) => createSession(projectId),
@@ -91,126 +265,180 @@ export function Sidebar() {
   }
 
   return (
-    <aside className="cw-sidebar-app">
+    <>
+      {sidebarMode === 'hidden' && (
+        <div
+          className="cw-sidebar-edge-trigger"
+          onPointerEnter={openReveal}
+          aria-hidden="true"
+        />
+      )}
       <button
-        className="cw-brand-lockup"
-        onClick={() => navigate({ to: '/projects' })}
-        aria-label="Cowork projects"
+        type="button"
+        className="cw-sidebar-hamburger"
+        onClick={() => setRevealed((v) => !v)}
+        aria-label={revealed ? '사이드바 닫기' : '사이드바 열기'}
+        aria-expanded={revealed}
       >
-        <img src={logoMark} alt="" />
-        <strong>Cowork</strong>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" width={18} height={18} aria-hidden="true">
+          <line x1="4" x2="20" y1="6" y2="6" /><line x1="4" x2="20" y1="12" y2="12" /><line x1="4" x2="20" y1="18" y2="18" />
+        </svg>
       </button>
-
-      <SectionLabel>PROJECTS</SectionLabel>
-      <nav className="cw-nav-list">
-        {(projectsQuery.data ?? []).map((item) => (
-          <button
-            key={item.id}
-            className={`cw-nav-row cw-project-nav-row ${item.id === activeProjectId ? 'is-active' : ''}`}
-            onClick={() => openProject(item.id)}
-          >
-            <span className="cw-project-swatch" />
-            <span>{item.name}</span>
-          </button>
-        ))}
+      {revealed && (
+        <div
+          className="cw-sidebar-backdrop"
+          onClick={() => setRevealed(false)}
+          aria-hidden="true"
+        />
+      )}
+      <aside
+        className={`cw-sidebar-app${revealed ? ' is-revealed' : ''}`}
+        onPointerEnter={() => { if (sidebarMode === 'hidden') openReveal(); }}
+        onPointerLeave={(e) => {
+          if (sidebarMode === 'hidden') scheduleClose({ clientX: e.clientX, clientY: e.clientY });
+        }}
+      >
+      <div className="cw-sidebar-header">
         <button
-          className="cw-nav-row is-ghost"
-          onClick={projectCreator.open}
+          className="cw-brand-lockup"
+          onClick={() => navigate({ to: '/projects' })}
+          aria-label="Cowork projects"
         >
-          <span className="cw-project-swatch is-plus">+</span>
-          <span>새 Project</span>
+          <img src={logoMark} alt="" />
+          <strong>Cowork</strong>
         </button>
-      </nav>
+      </div>
 
-      {activeProject && (
-        <div className="cw-project-block">
-          <div className="cw-project-name">{activeProject.name}</div>
-          <button
-            className={`cw-nav-row ${activeRoute === 'project' ? 'is-active' : ''}`}
-            onClick={() => openProject(activeProject.id)}
-          >
-            <IconPocket tone="home" icon="home" /> Home
-          </button>
-          <button
-            className={`cw-nav-row ${activeRoute === 'files' ? 'is-active' : ''}`}
-            onClick={() => navigate({ to: '/projects/$projectId/files', params: { projectId: activeProject.id } })}
-          >
-            <IconPocket tone="files" icon="folder-open" /> Files
-          </button>
-          <button
-            className={`cw-nav-row ${activeRoute === 'skills' ? 'is-active' : ''}`}
-            onClick={() => navigate({ to: '/projects/$projectId/skills', params: { projectId: activeProject.id } })}
-          >
-            <IconPocket tone="skills" icon="zap" /> Skills
-          </button>
-          <button
-            className={`cw-nav-row ${activeRoute === 'schedule' ? 'is-active' : ''}`}
-            onClick={() => navigate({ to: '/projects/$projectId/schedule', params: { projectId: activeProject.id } })}
-          >
-            <IconPocket tone="schedule" icon="calendar" /> Schedule
-          </button>
-          <button
-            className={`cw-nav-row ${activeRoute === 'members' ? 'is-active' : ''}`}
-            onClick={() => navigate({ to: '/projects/$projectId/members', params: { projectId: activeProject.id } })}
-          >
-            <IconPocket tone="members" icon="users" /> Members
-          </button>
-          <button
-            className={`cw-nav-row ${activeRoute === 'settings' ? 'is-active' : ''}`}
-            onClick={() => navigate({ to: '/projects/$projectId/settings', params: { projectId: activeProject.id } })}
-          >
-            <IconPocket tone="settings" icon="settings" /> Settings
-          </button>
+      <div className="cw-sidebar-scroll cw-scroll-quiet">
+        <SectionHeader
+          label="PROJECTS"
+          expanded={projectsExpanded}
+          onToggle={toggleProjects}
+          onAdd={projectCreator.open}
+          addLabel="새 Project"
+        />
+        <nav className="cw-projects-list" data-expanded={projectsExpanded ? 'true' : 'false'}>
+          {(projectsQuery.data ?? []).map((item) => (
+            <button
+              key={item.id}
+              className={`cw-nav-row cw-project-nav-row ${item.id === activeProjectId ? 'is-active' : ''}`}
+              onClick={() => openProject(item.id)}
+            >
+              <span className="cw-project-swatch" />
+              <span>{item.name}</span>
+            </button>
+          ))}
+        </nav>
+
+        {activeProject && (
+          <div className="cw-project-block">
+            <div className="cw-project-name">{activeProject.name}</div>
+            <button
+              className={`cw-nav-row ${activeRoute === 'project' ? 'is-active' : ''}`}
+              onClick={() => openProject(activeProject.id)}
+            >
+              <IconPocket tone="home" icon="home" /> <span>Home</span>
+            </button>
+            <button
+              className={`cw-nav-row ${activeRoute === 'files' ? 'is-active' : ''}`}
+              onClick={() => navigate({ to: '/projects/$projectId/files', params: { projectId: activeProject.id } })}
+            >
+              <IconPocket tone="files" icon="folder-open" /> <span>Files</span>
+            </button>
+            <button
+              className={`cw-nav-row ${activeRoute === 'skills' ? 'is-active' : ''}`}
+              onClick={() => navigate({ to: '/projects/$projectId/skills', params: { projectId: activeProject.id } })}
+            >
+              <IconPocket tone="skills" icon="zap" /> <span>Skills</span>
+            </button>
+            <button
+              className={`cw-nav-row ${activeRoute === 'schedule' ? 'is-active' : ''}`}
+              onClick={() => navigate({ to: '/projects/$projectId/schedule', params: { projectId: activeProject.id } })}
+            >
+              <IconPocket tone="schedule" icon="calendar" /> <span>Schedule</span>
+            </button>
+            <button
+              className={`cw-nav-row ${activeRoute === 'members' ? 'is-active' : ''}`}
+              onClick={() => navigate({ to: '/projects/$projectId/members', params: { projectId: activeProject.id } })}
+            >
+              <IconPocket tone="members" icon="users" /> <span>Members</span>
+            </button>
+            <button
+              className={`cw-nav-row ${activeRoute === 'settings' ? 'is-active' : ''}`}
+              onClick={() => navigate({ to: '/projects/$projectId/settings', params: { projectId: activeProject.id } })}
+            >
+              <IconPocket tone="settings" icon="settings" /> <span>Settings</span>
+            </button>
+          </div>
+        )}
+
+        {activeProject && (
+          <>
+            <SectionHeader
+              label="Sessions"
+              expanded={sessionsExpanded}
+              onToggle={toggleSessions}
+              onAdd={() => createSessionMutation.mutate(activeProject.id)}
+              addLabel={createSessionMutation.isPending ? '세션 생성 중…' : '새 Session'}
+              addDisabled={createSessionMutation.isPending}
+            />
+            <div className="cw-sessions-list" data-expanded={sessionsExpanded ? 'true' : 'false'}>
+              {(sessionsQuery.data ?? []).map((session) => {
+                const canDelete = canAdministerSession(session, activeProject, currentUser);
+                return (
+                  <div
+                    key={session.id}
+                    className={[
+                      'cw-session-row',
+                      session.id === activeSessionId ? 'is-active' : '',
+                      session.unreadCount > 0 ? 'is-unread' : '',
+                    ].filter(Boolean).join(' ')}
+                    onClick={() => openSession(activeProject.id, session.id)}
+                    role="button"
+                    tabIndex={0}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    {session.unreadCount > 0 ? (
+                      <span className="cw-unread-badge" aria-label={`unread ${session.unreadCount}`}>
+                        <span className="n">{session.unreadCount}</span>
+                      </span>
+                    ) : (
+                      <IconPocket tone="trust" icon="message-square" compact />
+                    )}
+                    <SessionTitleText title={session.title} />
+                    {session.isAutoAppend && <span className="auto-dot">●</span>}
+                    {canDelete && (
+                      <span className="cw-session-menu-wrap">
+                        <SessionCardMenu onDelete={() => setPendingDelete(session)} />
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+
+      {currentUser && (
+        <div className="cw-sidebar-user-area">
+          <div className="cw-sidebar-user">
+            <Avatar user={currentUser} />
+            <div className="cw-sidebar-user-meta">
+              <b>{currentUser.name.split(' ')[0]}</b>
+            </div>
+            <button
+              aria-label="logout"
+              onClick={() => { useAuthStore.getState().reset(); window.location.href = '/login'; }}
+              style={{ border: 0, background: 'transparent', padding: 0, color: 'var(--cw-ink-3)', cursor: 'pointer' }}
+            >
+              <Icon name="more" />
+            </button>
+          </div>
         </div>
       )}
 
-      {activeProject && (
-        <>
-          <SectionLabel>Sessions</SectionLabel>
-          <div className="cw-session-rail">
-            {(sessionsQuery.data ?? []).map((session) => {
-              const canDelete = canAdministerSession(session, activeProject, currentUser);
-              return (
-                <div
-                  key={session.id}
-                  className={[
-                    'cw-session-row',
-                    session.id === activeSessionId ? 'is-active' : '',
-                    session.unreadCount > 0 ? 'is-unread' : '',
-                  ].filter(Boolean).join(' ')}
-                  onClick={() => openSession(activeProject.id, session.id)}
-                  role="button"
-                  tabIndex={0}
-                  style={{ cursor: 'pointer' }}
-                >
-                  {session.unreadCount > 0 ? (
-                    <span className="cw-unread-badge" aria-label={`unread ${session.unreadCount}`}>
-                      <span className="n">{session.unreadCount}</span>
-                    </span>
-                  ) : (
-                    <IconPocket tone="trust" icon="message-square" compact />
-                  )}
-                  <SessionTitleText title={session.title} />
-                  {session.isAutoAppend && <span className="auto-dot">●</span>}
-                  {canDelete && (
-                    <span className="cw-session-menu-wrap">
-                      <SessionCardMenu onDelete={() => setPendingDelete(session)} />
-                    </span>
-                  )}
-                </div>
-              );
-            })}
-            <button
-              className="cw-session-row is-new"
-              onClick={() => activeProject && createSessionMutation.mutate(activeProject.id)}
-              disabled={createSessionMutation.isPending}
-            >
-              <IconPocket tone="add" icon="plus" compact />
-              <span>{createSessionMutation.isPending ? '생성 중…' : '새 session'}</span>
-            </button>
-          </div>
-        </>
-      )}
+      <SidebarResizer setRevealed={setRevealed} />
 
       {pendingDelete && (
         <ConfirmDialog
@@ -225,23 +453,8 @@ export function Sidebar() {
       )}
 
       {projectCreator.dialog}
-
-      {currentUser && (
-        <div className="cw-sidebar-user">
-          <Avatar user={currentUser} />
-          <div className="cw-sidebar-user-meta">
-            <b>{currentUser.name.split(' ')[0]}</b>
-          </div>
-          <button
-            aria-label="logout"
-            onClick={() => { useAuthStore.getState().reset(); window.location.href = '/login'; }}
-            style={{ border: 0, background: 'transparent', padding: 0, color: 'var(--cw-ink-3)', cursor: 'pointer' }}
-          >
-            <Icon name="more" />
-          </button>
-        </div>
-      )}
-    </aside>
+      </aside>
+    </>
   );
 }
 

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -18,7 +18,6 @@ import {
   isSidebarRevealHoldPoint,
   useLayoutStore,
   SIDEBAR_MOBILE_BREAKPOINT,
-  SIDEBAR_REVEAL_WIDTH,
 } from '@/stores/layout';
 import { useToastStore } from '@/components/Toast';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -37,45 +36,46 @@ function SidebarResizer({ setRevealed }: { setRevealed: (revealed: boolean) => v
     (e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault();
       const startX = e.clientX;
-      const { sidebarMode, expandedWidth } = useLayoutStore.getState();
-      // When hidden, the floating overlay shows at REVEAL_WIDTH, so the user's hand
-      // is already at that x-coordinate — start from there so dragging is 1:1.
-      const startW = sidebarMode === 'hidden' ? SIDEBAR_REVEAL_WIDTH : expandedWidth;
-      let lastW = startW;
+      // Resizer is only mounted in expanded mode (CSS hides it when hidden),
+      // so we always start from the persisted expandedWidth — no hidden branch.
+      const startW = useLayoutStore.getState().expandedWidth;
       let lastClientX = e.clientX;
       document.body.classList.add('is-resizing-sidebar');
 
       function onMove(ev: PointerEvent) {
-        const w = startW + (ev.clientX - startX);
-        // Re-read the current mode every move so hysteresis tracks the live state:
-        // if the user drags into hidden mid-drag, the next move's threshold flips
-        // up to SIDEBAR_EXPAND_ABOVE, matching the "I'm in hidden now" mental model.
-        const liveHidden = useLayoutStore.getState().sidebarMode === 'hidden';
-        const nextMode = getSidebarModeForDrag(w, liveHidden);
-        lastW = w;
         lastClientX = ev.clientX;
+        const w = startW + (ev.clientX - startX);
+        const currentMode = useLayoutStore.getState().sidebarMode;
+        if (currentMode === 'hidden') {
+          // Option B in hidden: drag adjusts the floating panel width only —
+          // it must NOT auto-pin back to expanded. The width persists, so when
+          // the user later expands via the hamburger / header button, the pin
+          // lands at exactly the width they dragged to.
+          setExpandedWidth(w);
+          return;
+        }
+        const nextMode = getSidebarModeForDrag(w);
         if (nextMode === 'hidden') {
-          // Keep the sidebar on screen as a floating reveal so the user's grip on
-          // the resizer survives the mode flip — release decides if it stays open.
+          // drag-to-hide: keep the panel revealed so the user sees it float
+          // (CSS will apply the floating inset style for this case).
           setSidebarMode('hidden');
           setRevealed(true);
         } else {
-          setSidebarMode('expanded');
           setExpandedWidth(w);  // store clamps to [MIN, MAX]
-          setRevealed(false);
         }
       }
       function onUp() {
         window.removeEventListener('pointermove', onMove);
         window.removeEventListener('pointerup', onUp);
         document.body.classList.remove('is-resizing-sidebar');
-        const liveHidden = useLayoutStore.getState().sidebarMode === 'hidden';
-        const modeAfterRelease = getSidebarModeForDrag(lastW, liveHidden);
-        setSidebarMode(modeAfterRelease);
-        // Keep reveal open only if the cursor is still resting on the floating
-        // sidebar (or its exit buffer) at release time. lastClientY unused: vertical
-        // bounds are the full viewport.
-        setRevealed(modeAfterRelease === 'hidden' && isSidebarRevealHoldPoint(lastClientX));
+        // If drag ended in hidden, decide whether the floating reveal sticks based
+        // on where the cursor was released (within the floating panel + buffer).
+        if (useLayoutStore.getState().sidebarMode === 'hidden') {
+          // Read the latest expandedWidth so the hold region matches the panel
+          // width the user just dragged to.
+          const w = useLayoutStore.getState().expandedWidth;
+          setRevealed(isSidebarRevealHoldPoint(lastClientX, w));
+        }
       }
       window.addEventListener('pointermove', onMove);
       window.addEventListener('pointerup', onUp);
@@ -147,11 +147,30 @@ export function Sidebar() {
   const showToast = useToastStore((s) => s.show);
   const currentUser = useAuthStore((s) => s.currentUser);
   const sidebarMode = useLayoutStore((s) => s.sidebarMode);
+  const setSidebarMode = useLayoutStore((s) => s.setSidebarMode);
   const projectsExpanded = useLayoutStore((s) => s.projectsExpanded);
   const sessionsExpanded = useLayoutStore((s) => s.sessionsExpanded);
   const toggleProjects = useLayoutStore((s) => s.toggleProjects);
   const toggleSessions = useLayoutStore((s) => s.toggleSessions);
   const [revealed, setRevealed] = useState(false);
+  // Button-toggled hide hands off to the floating-reveal hold logic: the user's
+  // cursor is still inside the sidebar at click time, so we stay revealed and let
+  // the width-only hold check decide closure as the cursor leaves horizontally.
+  // Drag-to-hide already keeps reveal=true via SidebarResizer.onMove; this aligns
+  // the button path with that behavior.
+  const collapseSidebar = useCallback(() => {
+    setRevealed(true);
+    setSidebarMode('hidden');
+  }, [setSidebarMode]);
+  const expandSidebar = useCallback(() => {
+    setRevealed(false);
+    setSidebarMode('expanded');
+  }, [setSidebarMode]);
+  // Hamburger is mobile-only (Outline pattern on desktop). On mobile this is a
+  // drawer toggle — sidebar-mode is not involved. Desktop CSS hides the button.
+  const onHamburgerClick = useCallback(() => {
+    setRevealed((v) => !v);
+  }, []);
   // Grace delay before closing on mouse-leave so brief excursions outside the
   // floating sidebar don't snap it shut. ~250ms feels intentional but not sticky.
   const closeTimerRef = useRef<number | null>(null);
@@ -167,7 +186,10 @@ export function Sidebar() {
   }, [cancelClose]);
   const scheduleClose = useCallback((point?: { clientX: number }) => {
     cancelClose();
-    if (point && isSidebarRevealHoldPoint(point.clientX)) return;
+    if (point) {
+      const w = useLayoutStore.getState().expandedWidth;
+      if (isSidebarRevealHoldPoint(point.clientX, w)) return;
+    }
     closeTimerRef.current = window.setTimeout(() => setRevealed(false), 250);
   }, [cancelClose]);
   useEffect(() => cancelClose, [cancelClose]);
@@ -176,7 +198,10 @@ export function Sidebar() {
     if (sidebarMode !== 'hidden' || !revealed) return;
 
     function onPointerMove(ev: PointerEvent) {
-      if (isSidebarRevealHoldPoint(ev.clientX)) {
+      // Width-only: y is intentionally ignored. Read latest width every move
+      // so dragging the panel wider during reveal also expands the hold area.
+      const w = useLayoutStore.getState().expandedWidth;
+      if (isSidebarRevealHoldPoint(ev.clientX, w)) {
         cancelClose();
       } else {
         scheduleClose();
@@ -270,7 +295,7 @@ export function Sidebar() {
       <button
         type="button"
         className="cw-sidebar-hamburger"
-        onClick={() => setRevealed((v) => !v)}
+        onClick={onHamburgerClick}
         aria-label={revealed ? '사이드바 닫기' : '사이드바 열기'}
         aria-expanded={revealed}
       >
@@ -300,6 +325,15 @@ export function Sidebar() {
         >
           <img src={logoMark} alt="" />
           <strong>Cowork</strong>
+        </button>
+        <button
+          type="button"
+          className="cw-sidebar-collapse-btn"
+          onClick={sidebarMode === 'hidden' ? expandSidebar : collapseSidebar}
+          aria-label={sidebarMode === 'hidden' ? '사이드바 고정' : '사이드바 접기'}
+          title={sidebarMode === 'hidden' ? '사이드바 고정' : '사이드바 접기'}
+        >
+          <Icon name={sidebarMode === 'hidden' ? 'chevron-right' : 'chevron-left'} size={16} />
         </button>
       </div>
 

--- a/app/src/routes/_app.tsx
+++ b/app/src/routes/_app.tsx
@@ -55,7 +55,14 @@ function AppShell() {
     <div
       className="cw-app-shell"
       data-sidebar-mode={sidebarMode}
-      style={{ '--cw-sidebar-w': `${sidebarWidth}px` } as React.CSSProperties}
+      style={{
+        // grid column width — collapses to 0 in hidden mode so main goes full bleed.
+        '--cw-sidebar-w': `${sidebarWidth}px`,
+        // sidebar's own width — always tracks expandedWidth so the floating reveal
+        // matches whatever width the user has set. Option B: drag in hidden adjusts
+        // this too, the panel just doesn't auto-pin back to expanded.
+        '--cw-sidebar-floating-w': `${expandedWidth}px`,
+      } as React.CSSProperties}
     >
       <Sidebar />
       <main className="cw-main-shell cw-scroll-quiet">

--- a/app/src/routes/_app.tsx
+++ b/app/src/routes/_app.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getToken } from '@/api/client';
 import { getMe } from '@/api/auth';
 import { useAuthStore } from '@/stores/auth';
+import { useLayoutStore } from '@/stores/layout';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { appWs } from '@/api/ws';
 import type { Session } from '@/domain/types';
@@ -17,6 +18,9 @@ export const Route = createFileRoute('/_app')({
 
 function AppShell() {
   const setCurrentUser = useAuthStore((s) => s.setCurrentUser);
+  const sidebarMode = useLayoutStore((s) => s.sidebarMode);
+  const expandedWidth = useLayoutStore((s) => s.expandedWidth);
+  const sidebarWidth = sidebarMode === 'expanded' ? expandedWidth : 0;
   const queryClient = useQueryClient();
   const me = useQuery({
     queryKey: ['me'],
@@ -48,9 +52,13 @@ function AppShell() {
   }, [queryClient]);
 
   return (
-    <div className="cw-app-shell">
+    <div
+      className="cw-app-shell"
+      data-sidebar-mode={sidebarMode}
+      style={{ '--cw-sidebar-w': `${sidebarWidth}px` } as React.CSSProperties}
+    >
       <Sidebar />
-      <main className="cw-main-shell">
+      <main className="cw-main-shell cw-scroll-quiet">
         <Outlet />
       </main>
     </div>

--- a/app/src/stores/layout.test.ts
+++ b/app/src/stores/layout.test.ts
@@ -2,26 +2,35 @@ import { describe, expect, it } from 'vitest';
 import {
   getSidebarModeForDrag,
   isSidebarRevealHoldPoint,
-  SIDEBAR_EXPAND_ABOVE,
   SIDEBAR_HIDDEN_BELOW,
   SIDEBAR_REVEAL_EXIT_BUFFER,
   SIDEBAR_REVEAL_WIDTH,
 } from './layout';
 
 describe('sidebar layout thresholds', () => {
-  it('uses separate thresholds for hiding and expanding', () => {
-    expect(getSidebarModeForDrag(SIDEBAR_HIDDEN_BELOW - 1, false)).toBe('hidden');
-    expect(getSidebarModeForDrag(SIDEBAR_HIDDEN_BELOW, false)).toBe('expanded');
-    expect(getSidebarModeForDrag(SIDEBAR_EXPAND_ABOVE - 1, true)).toBe('hidden');
-    expect(getSidebarModeForDrag(SIDEBAR_EXPAND_ABOVE, true)).toBe('expanded');
+  // Option B from the Notion/Outline review: shrink-to-hide stays one-way,
+  // expand-from-hidden does NOT auto-pin (handled by an explicit toggle button).
+  it('snaps to hidden only when drag drops below the shrink threshold', () => {
+    expect(getSidebarModeForDrag(SIDEBAR_HIDDEN_BELOW - 1)).toBe('hidden');
+    expect(getSidebarModeForDrag(SIDEBAR_HIDDEN_BELOW)).toBe('expanded');
+    // Wide drags stay expanded — there is no hysteresis flipping mode back and forth.
+    expect(getSidebarModeForDrag(300)).toBe('expanded');
   });
 
   it('keeps reveal open through the configured right-side buffer', () => {
-    const holdX = SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER;
+    // floatingWidth is the live panel width (= expandedWidth). The hold region
+    // is the panel width plus the configured exit buffer, inclusive on the
+    // right edge, exclusive after. clientY is not part of the contract.
+    const floatingWidth = SIDEBAR_REVEAL_WIDTH;
+    const holdX = floatingWidth + SIDEBAR_REVEAL_EXIT_BUFFER;
 
-    expect(holdX).toBe(230);
-    expect(isSidebarRevealHoldPoint(holdX)).toBe(true);
-    expect(isSidebarRevealHoldPoint(holdX + 1)).toBe(false);
-    expect(isSidebarRevealHoldPoint(-1)).toBe(false);
+    expect(isSidebarRevealHoldPoint(holdX, floatingWidth)).toBe(true);
+    expect(isSidebarRevealHoldPoint(holdX + 1, floatingWidth)).toBe(false);
+    expect(isSidebarRevealHoldPoint(-1, floatingWidth)).toBe(false);
+
+    // Larger panel → larger hold region, automatically.
+    const wider = 300;
+    expect(isSidebarRevealHoldPoint(wider + SIDEBAR_REVEAL_EXIT_BUFFER, wider)).toBe(true);
+    expect(isSidebarRevealHoldPoint(wider + SIDEBAR_REVEAL_EXIT_BUFFER + 1, wider)).toBe(false);
   });
 });

--- a/app/src/stores/layout.test.ts
+++ b/app/src/stores/layout.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSidebarModeForDrag,
+  getSidebarModeWhileResizing,
+  isSidebarRevealHoldPoint,
+  shouldCloseSidebarRevealOnNavigation,
+  shouldRevealSidebarAfterDrag,
+  SIDEBAR_EXPAND_ABOVE,
+  SIDEBAR_HIDDEN_BELOW,
+  SIDEBAR_MOBILE_BREAKPOINT,
+  SIDEBAR_REVEAL_EXIT_BUFFER,
+  SIDEBAR_REVEAL_WIDTH,
+} from './layout';
+
+describe('sidebar layout thresholds', () => {
+  it('uses separate thresholds for hiding and expanding', () => {
+    expect(getSidebarModeForDrag(SIDEBAR_HIDDEN_BELOW - 1, false)).toBe('hidden');
+    expect(getSidebarModeForDrag(SIDEBAR_HIDDEN_BELOW, false)).toBe('expanded');
+    expect(getSidebarModeForDrag(SIDEBAR_EXPAND_ABOVE - 1, true)).toBe('hidden');
+    expect(getSidebarModeForDrag(SIDEBAR_EXPAND_ABOVE, true)).toBe('expanded');
+  });
+
+  it('keeps the sidebar expanded while the resizer is actively held', () => {
+    expect(getSidebarModeWhileResizing('hidden')).toBe('expanded');
+    expect(getSidebarModeWhileResizing('expanded')).toBe('expanded');
+  });
+
+  it('keeps reveal open through the configured right-side buffer', () => {
+    const holdX = SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER;
+
+    expect(holdX).toBe(230);
+    expect(isSidebarRevealHoldPoint(holdX, 100, 720)).toBe(true);
+    expect(isSidebarRevealHoldPoint(holdX + 1, 100, 720)).toBe(false);
+  });
+
+  it('keeps desktop hidden reveal open across navigation', () => {
+    expect(shouldCloseSidebarRevealOnNavigation('hidden', SIDEBAR_MOBILE_BREAKPOINT)).toBe(false);
+    expect(shouldCloseSidebarRevealOnNavigation('hidden', SIDEBAR_MOBILE_BREAKPOINT - 1)).toBe(true);
+    expect(shouldCloseSidebarRevealOnNavigation('expanded', SIDEBAR_MOBILE_BREAKPOINT)).toBe(true);
+  });
+
+  it('keeps reveal visible when dragging into hidden while the cursor is inside it', () => {
+    expect(shouldRevealSidebarAfterDrag('hidden', SIDEBAR_REVEAL_WIDTH - 1, 100, 720)).toBe(true);
+    expect(shouldRevealSidebarAfterDrag('hidden', SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER + 1, 100, 720)).toBe(false);
+    expect(shouldRevealSidebarAfterDrag('expanded', SIDEBAR_REVEAL_WIDTH - 1, 100, 720)).toBe(false);
+  });
+});

--- a/app/src/stores/layout.test.ts
+++ b/app/src/stores/layout.test.ts
@@ -1,13 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   getSidebarModeForDrag,
-  getSidebarModeWhileResizing,
   isSidebarRevealHoldPoint,
-  shouldCloseSidebarRevealOnNavigation,
-  shouldRevealSidebarAfterDrag,
   SIDEBAR_EXPAND_ABOVE,
   SIDEBAR_HIDDEN_BELOW,
-  SIDEBAR_MOBILE_BREAKPOINT,
   SIDEBAR_REVEAL_EXIT_BUFFER,
   SIDEBAR_REVEAL_WIDTH,
 } from './layout';
@@ -20,28 +16,12 @@ describe('sidebar layout thresholds', () => {
     expect(getSidebarModeForDrag(SIDEBAR_EXPAND_ABOVE, true)).toBe('expanded');
   });
 
-  it('keeps the sidebar expanded while the resizer is actively held', () => {
-    expect(getSidebarModeWhileResizing('hidden')).toBe('expanded');
-    expect(getSidebarModeWhileResizing('expanded')).toBe('expanded');
-  });
-
   it('keeps reveal open through the configured right-side buffer', () => {
     const holdX = SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER;
 
     expect(holdX).toBe(230);
-    expect(isSidebarRevealHoldPoint(holdX, 100, 720)).toBe(true);
-    expect(isSidebarRevealHoldPoint(holdX + 1, 100, 720)).toBe(false);
-  });
-
-  it('keeps desktop hidden reveal open across navigation', () => {
-    expect(shouldCloseSidebarRevealOnNavigation('hidden', SIDEBAR_MOBILE_BREAKPOINT)).toBe(false);
-    expect(shouldCloseSidebarRevealOnNavigation('hidden', SIDEBAR_MOBILE_BREAKPOINT - 1)).toBe(true);
-    expect(shouldCloseSidebarRevealOnNavigation('expanded', SIDEBAR_MOBILE_BREAKPOINT)).toBe(true);
-  });
-
-  it('keeps reveal visible when dragging into hidden while the cursor is inside it', () => {
-    expect(shouldRevealSidebarAfterDrag('hidden', SIDEBAR_REVEAL_WIDTH - 1, 100, 720)).toBe(true);
-    expect(shouldRevealSidebarAfterDrag('hidden', SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER + 1, 100, 720)).toBe(false);
-    expect(shouldRevealSidebarAfterDrag('expanded', SIDEBAR_REVEAL_WIDTH - 1, 100, 720)).toBe(false);
+    expect(isSidebarRevealHoldPoint(holdX)).toBe(true);
+    expect(isSidebarRevealHoldPoint(holdX + 1)).toBe(false);
+    expect(isSidebarRevealHoldPoint(-1)).toBe(false);
   });
 });

--- a/app/src/stores/layout.ts
+++ b/app/src/stores/layout.ts
@@ -3,15 +3,14 @@ import { persist } from 'zustand/middleware';
 
 export type SidebarMode = 'expanded' | 'hidden';
 
-export const SIDEBAR_EXPANDED_MIN = 180;
+// Raised from 180 → 200 so the 'Cowork' brand text doesn't visually crunch at
+// the minimum resize width. Below this point shrinking only hurts legibility.
+export const SIDEBAR_EXPANDED_MIN = 200;
 export const SIDEBAR_EXPANDED_MAX = 420;
 // Drag must go below this width to snap into hidden mode. The gap between this
-// and SIDEBAR_EXPANDED_MIN (180 to 120) acts as a soft wall so the sidebar doesn't
+// and SIDEBAR_EXPANDED_MIN (200 to 120) acts as a soft wall so the sidebar doesn't
 // disappear the moment you reach the minimum width.
 export const SIDEBAR_HIDDEN_BELOW = 120;
-// Hidden to expanded uses a slightly higher threshold than the expanded minimum
-// so the sidebar does not flicker back open while the user is still near the edge.
-export const SIDEBAR_EXPAND_ABOVE = 185;
 // Hidden reveal floating width matches the smallest expanded width. The exit
 // buffer keeps reveal open just a little past that edge, up to roughly 230px.
 export const SIDEBAR_REVEAL_WIDTH = SIDEBAR_EXPANDED_MIN;
@@ -34,14 +33,21 @@ function clampExpanded(width: number): number {
   return Math.min(SIDEBAR_EXPANDED_MAX, Math.max(SIDEBAR_EXPANDED_MIN, width));
 }
 
-export function getSidebarModeForDrag(width: number, hiddenAtStart: boolean): SidebarMode {
-  if (hiddenAtStart && width < SIDEBAR_EXPAND_ABOVE) return 'hidden';
-  if (width < SIDEBAR_HIDDEN_BELOW) return 'hidden';
-  return 'expanded';
+// Drag only shrinks-into-hidden. Expanding from hidden no longer auto-pins —
+// pinning is a deliberate act via the toggle button. So this is one-way:
+// expanded → hidden when width drops below the threshold, expanded otherwise.
+// Callers should not invoke this from a hidden start state; the resizer is
+// hidden in that mode (see Sidebar.tsx / globals.css).
+export function getSidebarModeForDrag(width: number): SidebarMode {
+  return width < SIDEBAR_HIDDEN_BELOW ? 'hidden' : 'expanded';
 }
 
-export function isSidebarRevealHoldPoint(clientX: number): boolean {
-  return clientX >= 0 && clientX <= SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER;
+// Width-only reveal-hold check: clientY is intentionally ignored so the user can
+// freely move the cursor above/below the sidebar without losing the floating
+// reveal. floatingWidth is the live panel width (expandedWidth) so the hold
+// region grows/shrinks with the user-chosen size.
+export function isSidebarRevealHoldPoint(clientX: number, floatingWidth: number): boolean {
+  return clientX >= 0 && clientX <= floatingWidth + SIDEBAR_REVEAL_EXIT_BUFFER;
 }
 
 export const useLayoutStore = create<LayoutState>()(

--- a/app/src/stores/layout.ts
+++ b/app/src/stores/layout.ts
@@ -1,0 +1,88 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type SidebarMode = 'expanded' | 'hidden';
+
+export const SIDEBAR_EXPANDED_MIN = 180;
+export const SIDEBAR_EXPANDED_MAX = 420;
+// Drag must go below this width to snap into hidden mode. The gap between this
+// and SIDEBAR_EXPANDED_MIN (180 to 120) acts as a soft wall so the sidebar doesn't
+// disappear the moment you reach the minimum width.
+export const SIDEBAR_HIDDEN_BELOW = 120;
+// Hidden to expanded uses a slightly higher threshold than the expanded minimum
+// so the sidebar does not flicker back open while the user is still near the edge.
+export const SIDEBAR_EXPAND_ABOVE = 185;
+// Hidden reveal floating width matches the smallest expanded width. The exit
+// buffer keeps reveal open just a little past that edge, up to roughly 230px.
+export const SIDEBAR_REVEAL_WIDTH = SIDEBAR_EXPANDED_MIN;
+export const SIDEBAR_REVEAL_EXIT_BUFFER = 50;
+export const SIDEBAR_MOBILE_BREAKPOINT = 768;
+const SIDEBAR_EXPANDED_DEFAULT = 240;
+
+interface LayoutState {
+  sidebarMode: SidebarMode;
+  expandedWidth: number;
+  setSidebarMode: (mode: SidebarMode) => void;
+  setExpandedWidth: (width: number) => void;
+  projectsExpanded: boolean;
+  sessionsExpanded: boolean;
+  toggleProjects: () => void;
+  toggleSessions: () => void;
+}
+
+function clampExpanded(width: number): number {
+  return Math.min(SIDEBAR_EXPANDED_MAX, Math.max(SIDEBAR_EXPANDED_MIN, width));
+}
+
+export function getSidebarModeForDrag(width: number, hiddenAtStart: boolean): SidebarMode {
+  if (hiddenAtStart && width < SIDEBAR_EXPAND_ABOVE) return 'hidden';
+  if (width < SIDEBAR_HIDDEN_BELOW) return 'hidden';
+  return 'expanded';
+}
+
+export function getSidebarModeWhileResizing(modeAfterRelease: SidebarMode): SidebarMode {
+  return modeAfterRelease === 'hidden' ? 'expanded' : modeAfterRelease;
+}
+
+export function isSidebarRevealHoldPoint(
+  clientX: number,
+  clientY: number,
+  viewportHeight: number,
+): boolean {
+  return clientX >= 0
+    && clientX <= SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER
+    && clientY >= 0
+    && clientY <= viewportHeight;
+}
+
+export function shouldCloseSidebarRevealOnNavigation(
+  sidebarMode: SidebarMode,
+  viewportWidth: number,
+): boolean {
+  return viewportWidth < SIDEBAR_MOBILE_BREAKPOINT || sidebarMode !== 'hidden';
+}
+
+export function shouldRevealSidebarAfterDrag(
+  sidebarMode: SidebarMode,
+  clientX: number,
+  clientY: number,
+  viewportHeight: number,
+): boolean {
+  return sidebarMode === 'hidden' && isSidebarRevealHoldPoint(clientX, clientY, viewportHeight);
+}
+
+export const useLayoutStore = create<LayoutState>()(
+  persist(
+    (set) => ({
+      sidebarMode: 'expanded',
+      expandedWidth: SIDEBAR_EXPANDED_DEFAULT,
+      setSidebarMode: (sidebarMode) => set({ sidebarMode }),
+      setExpandedWidth: (width) => set({ expandedWidth: clampExpanded(width) }),
+      projectsExpanded: true,
+      sessionsExpanded: true,
+      toggleProjects: () => set((s) => ({ projectsExpanded: !s.projectsExpanded })),
+      toggleSessions: () => set((s) => ({ sessionsExpanded: !s.sessionsExpanded })),
+    }),
+    { name: 'cowork-layout' },
+  ),
+);

--- a/app/src/stores/layout.ts
+++ b/app/src/stores/layout.ts
@@ -40,35 +40,8 @@ export function getSidebarModeForDrag(width: number, hiddenAtStart: boolean): Si
   return 'expanded';
 }
 
-export function getSidebarModeWhileResizing(modeAfterRelease: SidebarMode): SidebarMode {
-  return modeAfterRelease === 'hidden' ? 'expanded' : modeAfterRelease;
-}
-
-export function isSidebarRevealHoldPoint(
-  clientX: number,
-  clientY: number,
-  viewportHeight: number,
-): boolean {
-  return clientX >= 0
-    && clientX <= SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER
-    && clientY >= 0
-    && clientY <= viewportHeight;
-}
-
-export function shouldCloseSidebarRevealOnNavigation(
-  sidebarMode: SidebarMode,
-  viewportWidth: number,
-): boolean {
-  return viewportWidth < SIDEBAR_MOBILE_BREAKPOINT || sidebarMode !== 'hidden';
-}
-
-export function shouldRevealSidebarAfterDrag(
-  sidebarMode: SidebarMode,
-  clientX: number,
-  clientY: number,
-  viewportHeight: number,
-): boolean {
-  return sidebarMode === 'hidden' && isSidebarRevealHoldPoint(clientX, clientY, viewportHeight);
+export function isSidebarRevealHoldPoint(clientX: number): boolean {
+  return clientX >= 0 && clientX <= SIDEBAR_REVEAL_WIDTH + SIDEBAR_REVEAL_EXIT_BUFFER;
 }
 
 export const useLayoutStore = create<LayoutState>()(

--- a/app/src/styles/cowork-design-system.css
+++ b/app/src/styles/cowork-design-system.css
@@ -172,7 +172,9 @@
   --cw-space-10: 40px;
 
   /* ── Layout constants ────────────────────────────────────────────────── */
-  --cw-sidebar-w:        200px;
+  --cw-sidebar-w:        240px;
+  --cw-sidebar-w-min:    180px;
+  --cw-sidebar-w-max:    420px;
   --cw-content-max:      1180px;
   --cw-chat-max:         760px;
 

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -3,7 +3,8 @@
 @import "highlight.js/styles/atom-one-light.css";
 
 * { box-sizing: border-box; }
-html, body, #root { min-height: 100%; }
+/* App is a fixed-viewport shell: nothing outside cw-app-shell should ever scroll. */
+html, body, #root { height: 100%; overflow: hidden; }
 body { margin: 0; min-width: 320px; background: var(--cw-bg); }
 button, input, select { font: inherit; }
 button { cursor: pointer; }
@@ -24,14 +25,115 @@ button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px s
 .cw-loading { min-height: 100vh; display: grid; place-items: center; align-content: center; gap: var(--cw-space-3); color: var(--cw-fg-3); }
 .cw-loading img { width: 36px; height: 36px; animation: cw-enter .32s ease both; }
 
-.cw-app-shell { display: grid; grid-template-columns: var(--cw-sidebar-w) minmax(0, 1fr); height: 100vh; overflow: hidden; background: var(--cw-bg); color: var(--cw-fg-1); }
-.cw-main-shell { min-width: 0; overflow: auto; display: flex; flex-direction: column; }
+.cw-app-shell { display: grid; grid-template-columns: var(--cw-sidebar-w) minmax(0, 1fr); height: 100vh; height: 100dvh; overflow: hidden; background: var(--cw-bg); color: var(--cw-fg-1); }
+.cw-sidebar-app { grid-column: 1; }
+.cw-main-shell { grid-column: 2; min-width: 0; overflow: auto; display: flex; flex-direction: column; }
 
-.cw-sidebar-app { width: var(--cw-sidebar-w); height: 100vh; overflow-y: auto; background: var(--cw-bg-subtle); border-right: 1px solid var(--cw-border); padding: 14px 10px 10px; display: flex; flex-direction: column; }
-.cw-brand-lockup { display: flex; align-items: center; gap: 9px; border: 0; background: transparent; padding: 6px 8px 18px; border-radius: var(--cw-radius-md); }
+.cw-sidebar-app { position: relative; width: 100%; height: 100vh; height: 100dvh; background: var(--cw-bg-subtle); border-right: 1px solid var(--cw-border); padding: 14px 10px 10px; display: flex; flex-direction: column; gap: 2px; overflow: hidden; }
+.cw-sidebar-header { display: flex; align-items: center; gap: 4px; flex-shrink: 0; padding-bottom: 12px; }
+.cw-sidebar-header .cw-brand-lockup { flex: 1; min-width: 0; padding: 6px 8px; }
+
+.cw-sidebar-resizer { position: absolute; top: 0; right: -3px; width: 6px; height: 100%; cursor: ew-resize; z-index: 5; touch-action: none; }
+.cw-sidebar-resizer::after { content: ''; position: absolute; top: 0; right: 2px; width: 2px; height: 100%; background: transparent; transition: background 120ms; }
+.cw-sidebar-resizer:hover::after { background: color-mix(in oklch, var(--cw-accent) 70%, transparent); }
+
+body.is-resizing-sidebar { cursor: ew-resize; user-select: none; }
+body.is-resizing-sidebar .cw-sidebar-resizer::after { background: color-mix(in oklch, var(--cw-accent) 90%, transparent); }
+body.is-resizing-sidebar * { cursor: ew-resize !important; user-select: none !important; }
+
+/* Hidden mode — sidebar floats off-screen (translateX -100%), main takes full width.
+   Hover on the left edge trigger slides it back in as a floating overlay. */
+.cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app {
+  position: fixed; left: 0; top: 0;
+  width: var(--cw-sidebar-w-min);
+  height: 100vh; height: 100dvh;
+  transform: translateX(-100%);
+  transition: transform 220ms ease;
+  z-index: 50;
+  box-shadow: var(--cw-shadow-popover);
+}
+.cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app.is-revealed { transform: translateX(0); }
+.cw-sidebar-edge-trigger {
+  position: fixed; left: 0; top: 0;
+  width: 8px; height: 100vh; height: 100dvh;
+  z-index: 49;
+}
+
+/* Mobile hamburger + backdrop — hidden on desktop, only used at narrow viewports. */
+.cw-sidebar-hamburger { display: none; }
+.cw-sidebar-backdrop { display: none; }
+
+@media (max-width: 767px) {
+  /* On mobile, the sidebar is always a floating drawer regardless of mode. */
+  .cw-app-shell { grid-template-columns: 0 minmax(0, 1fr); }
+  .cw-sidebar-app {
+    position: fixed; left: 0; top: 0;
+    width: min(85vw, 300px);
+    height: 100vh; height: 100dvh;
+    transform: translateX(-100%);
+    transition: transform 220ms ease;
+    z-index: 50;
+    box-shadow: var(--cw-shadow-popover);
+    padding: 14px 10px 10px;
+    border-right: 1px solid var(--cw-border);
+  }
+  .cw-sidebar-app.is-revealed { transform: translateX(0); }
+  /* Mobile drag-resize is awkward; hide the resizer and edge trigger. */
+  .cw-sidebar-resizer,
+  .cw-sidebar-edge-trigger { display: none; }
+  .cw-sidebar-hamburger {
+    display: inline-flex;
+    position: fixed; top: 10px; left: 10px;
+    width: 36px; height: 36px;
+    align-items: center; justify-content: center;
+    border: 1px solid var(--cw-border);
+    background: var(--cw-bg);
+    color: var(--cw-fg-1);
+    border-radius: var(--cw-radius-md);
+    z-index: 51;
+    box-shadow: var(--cw-shadow-sm);
+  }
+  .cw-sidebar-backdrop {
+    display: block;
+    position: fixed; inset: 0;
+    background: oklch(0.15 0.01 60 / 0.32);
+    z-index: 48;
+    animation: cw-rise .14s ease both;
+  }
+}
+
+.cw-sidebar-scroll { flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 1px; }
+.cw-sidebar-user-area { flex-shrink: 0; margin-top: auto; }
+
+.cw-section-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 4px 4px; position: sticky; top: 0; background: var(--cw-bg-subtle); z-index: 2; }
+.cw-section-toggle { display: inline-flex; align-items: center; gap: 5px; background: transparent; border: 0; padding: 4px 6px; color: var(--cw-fg-3); font-size: 10.5px; letter-spacing: .08em; text-transform: uppercase; font-weight: 500; cursor: pointer; border-radius: var(--cw-radius-sm); flex: 1; min-width: 0; }
+.cw-section-toggle > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cw-section-toggle:hover { color: var(--cw-fg-1); background: var(--cw-bg-muted); }
+.cw-section-chevron { flex-shrink: 0; transition: transform 160ms ease; }
+.cw-section-chevron.is-open { transform: rotate(90deg); }
+.cw-section-add { width: 22px; height: 22px; border: 0; background: transparent; color: var(--cw-fg-3); border-radius: var(--cw-radius-sm); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; flex-shrink: 0; transition: background 120ms, color 120ms; }
+.cw-section-add:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
+.cw-section-add:disabled { opacity: 0.4; cursor: default; }
+
+/* Section collapsed (toggle off): hide normal rows, but keep .is-active everywhere
+   and .is-unread for sessions visible. */
+.cw-projects-list[data-expanded="false"] .cw-nav-row:not(.is-active),
+.cw-sessions-list[data-expanded="false"] .cw-session-row:not(.is-active):not(.is-unread) { display: none; }
+
+/* Quiet scrollbar — transparent by default. Pointer hover snaps to a faint tone
+   instantly. Focus is intentionally NOT a trigger so clicking a row and leaving
+   the area hides the scrollbar even though keyboard focus remains. */
+.cw-scroll-quiet { scrollbar-width: thin; scrollbar-color: transparent transparent; }
+.cw-scroll-quiet:hover { scrollbar-color: color-mix(in oklch, var(--cw-fg-3) 40%, transparent) transparent; }
+.cw-scroll-quiet::-webkit-scrollbar { width: 8px; height: 8px; }
+.cw-scroll-quiet::-webkit-scrollbar-track { background: transparent; }
+.cw-scroll-quiet::-webkit-scrollbar-thumb { background-color: transparent; border-radius: 4px; }
+.cw-scroll-quiet:hover::-webkit-scrollbar-thumb { background-color: color-mix(in oklch, var(--cw-fg-3) 40%, transparent); }
+
+.cw-brand-lockup { display: flex; align-items: center; gap: 9px; border: 0; background: transparent; padding: 6px 8px 18px; border-radius: var(--cw-radius-md); min-width: 0; }
 .cw-brand-lockup:hover { background: var(--cw-bg-muted); }
-.cw-brand-lockup img:first-child { width: 28px; height: 28px; }
-.cw-brand-lockup strong { color: var(--cw-fg-1); font-size: 22px; line-height: 1; letter-spacing: -0.035em; font-weight: 650; }
+.cw-brand-lockup img:first-child { width: 28px; height: 28px; flex-shrink: 0; }
+.cw-brand-lockup strong { color: var(--cw-fg-1); font-size: 22px; line-height: 1; letter-spacing: -0.035em; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cw-section-label-app { padding: 10px 8px 5px; font-size: 10.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--cw-fg-3); font-weight: 500; }
 .cw-nav-list, .cw-session-rail { display: flex; flex-direction: column; gap: 1px; }
 .cw-nav-row, .cw-session-row { width: 100%; min-height: 31px; display: flex; align-items: center; gap: 9px; border: 0; border-radius: var(--cw-radius-md); background: transparent; color: var(--cw-fg-2); padding: 6px 8px; text-align: left; font-size: 13px; transition: background 120ms, color 120ms, transform 120ms; }
@@ -42,17 +144,18 @@ button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px s
 .cw-nav-row span, .cw-session-row span:not(.auto-dot):not(.cw-pocket):not(.cw-session-menu-wrap) { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cw-session-row .cw-session-title { flex: 1; min-width: 0; }
 .cw-session-menu-wrap { flex-shrink: 0; margin-left: auto; }
-.cw-project-block { margin-top: 24px; }
-.cw-project-name { padding: 10px 8px 5px; font-size: 11px; color: var(--cw-fg-2); font-weight: 600; }
-.cw-session-rail { }
+.cw-project-block { margin-top: 16px; }
+.cw-project-name { padding: 10px 8px 5px; font-size: 11px; color: var(--cw-fg-2); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cw-session-rail { padding-bottom: 6px; }
 .cw-session-row { min-height: 28px; padding: 5px 8px; font-size: 12.5px; color: var(--cw-fg-3); }
 .cw-session-row.is-active { background: color-mix(in oklch, var(--cw-accent) 12%, var(--cw-bg-subtle)); color: var(--cw-fg-1); font-weight: 600; }
 .cw-session-row.is-unread { color: var(--cw-fg-1); font-weight: 600; }
 .auto-dot { margin-left: auto; color: var(--cw-accent); font-size: 10px; }
-.cw-sidebar-user { margin-top: auto; border-top: 1px solid var(--cw-border); padding: 10px 6px 2px; display: grid; grid-template-columns: auto 1fr auto; gap: 9px; align-items: center; color: var(--cw-fg-2); }
+.cw-sidebar-user { border-top: 1px solid var(--cw-border); padding: 10px 6px 2px; display: grid; grid-template-columns: auto 1fr auto; gap: 9px; align-items: center; color: var(--cw-fg-2); }
 .cw-sidebar-user-meta { min-width: 0; }
 .cw-sidebar-user-meta b { display: block; font-size: 13px; color: var(--cw-fg-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cw-sidebar-user-meta span { display: block; font-family: var(--cw-font-mono); font-size: 10px; color: var(--cw-fg-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
 
 .cw-page { width: min(1084px, calc(100% - 80px)); margin: 0 auto; padding: 36px 0 72px; }
 .cw-page-enter { animation: cw-enter .26s ease both; }

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -25,41 +25,127 @@ button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px s
 .cw-loading { min-height: 100vh; display: grid; place-items: center; align-content: center; gap: var(--cw-space-3); color: var(--cw-fg-3); }
 .cw-loading img { width: 36px; height: 36px; animation: cw-enter .32s ease both; }
 
-.cw-app-shell { display: grid; grid-template-columns: var(--cw-sidebar-w) minmax(0, 1fr); height: 100vh; height: 100dvh; overflow: hidden; background: var(--cw-bg); color: var(--cw-fg-1); }
+/* Register --cw-sidebar-w as a typed length so its 0px ↔ Npx change between
+   hidden/expanded modes is *interpolated* by the browser. Plain CSS variables
+   do not animate; declaring @property turns it into an animatable token. */
+@property --cw-sidebar-w {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
+.cw-app-shell {
+  display: grid;
+  grid-template-columns: var(--cw-sidebar-w) minmax(0, 1fr);
+  height: 100vh; height: 100dvh;
+  overflow: hidden;
+  background: var(--cw-bg);
+  color: var(--cw-fg-1);
+  transition: --cw-sidebar-w 220ms ease;
+}
+/* While the user is actively dragging the resizer, every pointermove pushes a
+   new width into the store. A 220ms transition there would lag and feel rubbery —
+   kill the transition mid-drag and let pixels track the cursor 1:1. */
+body.is-resizing-sidebar .cw-app-shell { transition: none; }
 .cw-sidebar-app { grid-column: 1; }
 .cw-main-shell { grid-column: 2; min-width: 0; overflow: auto; display: flex; flex-direction: column; }
 
-.cw-sidebar-app { position: relative; width: 100%; height: 100vh; height: 100dvh; background: var(--cw-bg-subtle); border-right: 1px solid var(--cw-border); padding: 14px 10px 10px; display: flex; flex-direction: column; gap: 2px; overflow: hidden; }
+/* Sidebar is fixed in BOTH modes so the expanded ↔ hidden transition is a pure
+   property animation (top/left/bottom/height/radius/shadow/border) with no
+   position-jump. The main shell still reserves a column via --cw-sidebar-w in
+   grid-template-columns, so when expanded the fixed sidebar lines up exactly
+   with that reserved column. */
+.cw-sidebar-app {
+  position: fixed; top: 0; left: 0;
+  width: var(--cw-sidebar-floating-w);
+  height: 100vh; height: 100dvh;
+  background: var(--cw-bg-subtle);
+  border-right: 1px solid var(--cw-border);
+  padding: 14px 10px 10px;
+  display: flex; flex-direction: column; gap: 2px;
+  overflow: hidden;
+  z-index: 10;
+}
 .cw-sidebar-header { display: flex; align-items: center; gap: 4px; flex-shrink: 0; padding-bottom: 12px; }
 .cw-sidebar-header .cw-brand-lockup { flex: 1; min-width: 0; padding: 6px 8px; }
+
+/* Explicit collapse button — Notion-style affordance to drop the sidebar to
+   hidden mode without dragging. Lives in the header next to the brand lockup. */
+.cw-sidebar-collapse-btn {
+  width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 0; background: transparent;
+  color: var(--cw-fg-3);
+  border-radius: var(--cw-radius-sm);
+  cursor: pointer; flex-shrink: 0;
+  transition: background 120ms, color 120ms;
+}
+.cw-sidebar-collapse-btn:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
+/* Outline-style: the same header toggle button doubles as the expand-pin
+   action when the sidebar is in hidden mode + revealed (floating). The icon
+   and aria-label flip in JS — see Sidebar.tsx. We do NOT hide the button in
+   hidden mode anymore; it just rides along with the floating panel. */
 
 .cw-sidebar-resizer { position: absolute; top: 0; right: -3px; width: 6px; height: 100%; cursor: ew-resize; z-index: 5; touch-action: none; }
 .cw-sidebar-resizer::after { content: ''; position: absolute; top: 0; right: 2px; width: 2px; height: 100%; background: transparent; transition: background 120ms; }
 .cw-sidebar-resizer:hover::after { background: color-mix(in oklch, var(--cw-accent) 70%, transparent); }
+/* Option B: resizer stays alive in hidden mode too. Dragging adjusts the
+   floating panel width but does NOT auto-pin (handled in JS). */
 
 body.is-resizing-sidebar { cursor: ew-resize; user-select: none; }
 body.is-resizing-sidebar .cw-sidebar-resizer::after { background: color-mix(in oklch, var(--cw-accent) 90%, transparent); }
 body.is-resizing-sidebar * { cursor: ew-resize !important; user-select: none !important; }
 
-/* Hidden mode — sidebar floats off-screen (translateX -100%), main takes full width.
-   Hover on the left edge trigger slides it back in as a floating overlay. */
-.cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app {
-  position: fixed; left: 0; top: 0;
-  width: var(--cw-sidebar-w-min);
-  height: 100vh; height: 100dvh;
-  transform: translateX(-100%);
-  transition: transform 220ms ease;
-  z-index: 50;
-  box-shadow: var(--cw-shadow-popover);
+/* Unified transition graph on the (always-fixed) sidebar. Two distinct kinds
+   of state change have to look different:
+   1) expanded ↔ hidden — inset/height/radius/shadow/border change → full
+      property animation (panel transforms into floating card).
+   2) hidden + revealed ↔ hidden + not revealed — only transform changes →
+      panel slides in/out horizontally with no vertical motion at all. */
+.cw-sidebar-app {
+  transform: translateX(0);
+  transition: transform 220ms ease, top 220ms ease, left 220ms ease,
+              bottom 220ms ease, height 220ms ease, width 220ms ease,
+              box-shadow 220ms ease, border-radius 220ms ease,
+              border-right-width 220ms ease;
 }
-.cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app.is-revealed { transform: translateX(0); }
+/* During an active resize drag every property must follow the cursor pixel-for-pixel
+   with NO interpolation. Mirror each rule that sets transition on the sidebar and
+   prefix with the drag class so specificity always wins — no !important needed. */
+body.is-resizing-sidebar .cw-sidebar-app,
+body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app,
+body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app.is-revealed {
+  transition: none;
+}
+
+/* Hidden mode — floating Notion-style panel. Now that the desktop hamburger
+   is gone (mobile-only), the top inset goes back to a symmetric 8px so the
+   panel reads as a centered floating card. Panel is offscreen via translateX
+   until is-revealed flips on. Notice transform is the ONLY property that
+   differs between hidden and hidden.is-revealed — that is what makes reveal
+   open/close pure-horizontal with zero vertical motion. */
+.cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app {
+  top: 8px; bottom: 8px; left: 6px;
+  height: auto;
+  border-right: 0;
+  border-radius: var(--cw-radius-xl);
+  box-shadow: var(--cw-shadow-lg);
+  transform: translateX(-100%);
+  z-index: 50;
+}
+.cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-app.is-revealed {
+  transform: translateX(0);
+}
+
 .cw-sidebar-edge-trigger {
   position: fixed; left: 0; top: 0;
   width: 8px; height: 100vh; height: 100dvh;
   z-index: 49;
 }
 
-/* Mobile hamburger + backdrop — hidden on desktop, only used at narrow viewports. */
+/* Hamburger is mobile-only (Outline pattern on desktop). The DOM element stays
+   so the mobile media query below can pick it up as a drawer toggle. On desktop
+   the in-sidebar header toggle + the left edge-trigger handle all reveal cases. */
 .cw-sidebar-hamburger { display: none; }
 .cw-sidebar-backdrop { display: none; }
 


### PR DESCRIPTION
**Recommend to just try sidebar handling yourselves and give feedback**

## Summary

- Add persisted app layout state so the shell can drive sidebar mode and width.
- Refine the left sidebar into isolated project/session sections with desktop reveal, mobile drawer behavior, and resizer affordances.
- Tune hidden/reveal thresholds: hide below 120px, return to expanded near 185px, keep reveal usable within about 230px, and prevent the sidebar from disappearing while the resizer is held.

## Issues

Relates to #103, #104, #105

## Verification

- `pnpm -C app lint`
- `pnpm -C app test:unit -- src/stores/layout.test.ts`
- `git diff --check -- app/src/components/layout/Sidebar.tsx app/src/routes/_app.tsx app/src/styles/cowork-design-system.css app/src/styles/globals.css app/src/stores/layout.ts app/src/stores/layout.test.ts`
- Browser smoke on `http://127.0.0.1:4110/projects` with no console errors observed


