### PR TITLE
feat(sessions): add origin field and switch to flat routes

### DIFF
--- a/app/src/api/backend-types.ts
+++ b/app/src/api/backend-types.ts
@@ -36,11 +36,14 @@ export interface BackendMember {
   added_at: string;
 }
 
+export type BackendSessionOrigin = 'user' | 'automation';
+
 export interface BackendSession {
   id: string;
   project_id: string;
   creator_id: string;
   share_mode: ShareMode;
+  origin: BackendSessionOrigin;
   title: string | null;
   last_message_at: string | null;
   last_message_snippet: string | null;

--- a/app/src/api/sessions.ts
+++ b/app/src/api/sessions.ts
@@ -4,14 +4,15 @@ import { toSession } from './transformers';
 import type { Session, ShareMode } from '@/domain/types';
 
 export async function listSessions(projectId: string): Promise<Session[]> {
-  const res = await request<{ items: BackendSession[] }>(`/projects/${projectId}/sessions`);
+  const qs = projectId ? `?project_id=${encodeURIComponent(projectId)}` : '';
+  const res = await request<{ items: BackendSession[] }>(`/sessions${qs}`);
   return res.items.map(toSession);
 }
 
 export async function createSession(projectId: string): Promise<Session> {
-  const raw = await request<BackendSession>(`/projects/${projectId}/sessions`, {
+  const raw = await request<BackendSession>(`/sessions`, {
     method: 'POST',
-    body: {},
+    body: { project_id: projectId },
   });
   return toSession(raw);
 }

--- a/app/src/api/transformers.ts
+++ b/app/src/api/transformers.ts
@@ -75,6 +75,7 @@ export function toSession(backend: BackendSession): Session {
     title: backend.title ?? '새 대화',
     creatorId: backend.creator_id,
     shareMode: backend.share_mode,
+    origin: backend.origin,
     intent: 'general',
     updatedAt: compactDate(backend.updated_at),
     lastMessageAt: backend.last_message_at,

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -411,7 +411,7 @@ export function Sidebar() {
               addDisabled={createSessionMutation.isPending}
             />
             <div className="cw-sessions-list" data-expanded={sessionsExpanded ? 'true' : 'false'}>
-              {(sessionsQuery.data ?? []).map((session) => {
+              {(sessionsQuery.data ?? []).filter((s) => s.origin === 'user').map((session) => {
                 const canDelete = canAdministerSession(session, activeProject, currentUser);
                 return (
                   <div

--- a/app/src/domain/types.ts
+++ b/app/src/domain/types.ts
@@ -21,12 +21,15 @@ export interface Project {
   memberIds: UserId[];
 }
 
+export type SessionOrigin = 'user' | 'automation';
+
 export interface Session {
   id: SessionId;
   projectId: ProjectId;
   title: string;
   creatorId: UserId;
   shareMode: ShareMode;
+  origin: SessionOrigin;
   intent: SessionIntent;
   updatedAt: string;
   lastMessageAt: string | null;

--- a/app/src/routes/_app.projects.$projectId.index.tsx
+++ b/app/src/routes/_app.projects.$projectId.index.tsx
@@ -70,7 +70,7 @@ function ProjectHome() {
 
   const memberList = members.data ?? [];
   const fileList = (files.data ?? []).filter((f) => f.type !== 'folder');
-  const sessionList = sessions.data ?? [];
+  const sessionList = (sessions.data ?? []).filter((s) => s.origin === 'user');
 
   return (
     <section className="cw-page cw-page-enter">

--- a/app/src/routes/_app.projects.index.tsx
+++ b/app/src/routes/_app.projects.index.tsx
@@ -62,7 +62,8 @@ function ProjectCard({ project, isActive, onOpen }: { project: Project; isActive
   const members = useQuery({ queryKey: ['members', project.id], queryFn: () => listMembers(project.id) });
   const sessions = useQuery({ queryKey: ['sessions', project.id], queryFn: () => listSessions(project.id) });
   const isOwner = currentUser?.id === project.ownerId;
-  const latest = latestUpdated(sessions.data ?? []);
+  const userSessions = (sessions.data ?? []).filter((s) => s.origin === 'user');
+  const latest = latestUpdated(userSessions);
   const memberUsers: User[] = members.data ?? [];
 
   return (
@@ -77,7 +78,7 @@ function ProjectCard({ project, isActive, onOpen }: { project: Project; isActive
       <p className="cw-project-card-desc">{project.description || '설명 없음'}</p>
       <div className="cw-project-card-footer">
         <AvatarStack users={memberUsers} />
-        <span className="cw-card-stats">{sessions.data?.length ?? 0}개 세션 · {latest}</span>
+        <span className="cw-card-stats">{userSessions.length}개 세션 · {latest}</span>
       </div>
     </button>
   );


### PR DESCRIPTION
## Description
This is a complementary PR for #87.
There are modifications to the `/sessions` API there, and I should have accompanied this with modifications to the frontend that is already using it, but I omitted them.

This caused a 404 error in the session-related APIs on the frontend.

This was originally part of #116, but is being separated for faster recovery. #116 has been moved to the branch of this PR.