### PR TITLE
Project settings page

### DIFF
--- a/app/src/api/projects.ts
+++ b/app/src/api/projects.ts
@@ -22,6 +22,21 @@ export async function getProject(projectRef: string): Promise<Project> {
   return toProject(raw);
 }
 
+export async function updateProject(
+  projectRef: string,
+  input: { name?: string; description?: string | null },
+): Promise<Project> {
+  const raw = await request<BackendProject>(`/projects/${projectRef}`, {
+    method: 'PATCH',
+    body: input,
+  });
+  return toProject(raw);
+}
+
+export async function deleteProject(projectRef: string): Promise<void> {
+  await request(`/projects/${projectRef}`, { method: 'DELETE' });
+}
+
 export async function listMembers(projectRef: string): Promise<User[]> {
   const res = await request<{ items: BackendMember[] }>(`/projects/${projectRef}/members`);
   return res.items.map(toMemberUser);

--- a/app/src/api/transformers.ts
+++ b/app/src/api/transformers.ts
@@ -35,6 +35,7 @@ export function toUser(backend: BackendUser): User {
   return {
     id: backend.id,
     name,
+    username: backend.username,
     roleLabel: backend.role === 'admin' ? 'Admin' : 'Member',
     avatar: initials(name),
     color: deterministicColor(backend.id),
@@ -46,6 +47,7 @@ export function toMemberUser(member: BackendMember): User {
   return {
     id: member.user_id,
     name,
+    username: member.username,
     roleLabel: 'Member',
     avatar: initials(name),
     color: deterministicColor(member.user_id),

--- a/app/src/domain/types.ts
+++ b/app/src/domain/types.ts
@@ -8,6 +8,7 @@ export type RouteKey = 'projects' | 'project' | 'session' | 'files' | 'skills' |
 export interface User {
   id: UserId;
   name: string;
+  username?: string;
   roleLabel: string;
   avatar: string;
   color: string;

--- a/app/src/lib/permissions.ts
+++ b/app/src/lib/permissions.ts
@@ -33,6 +33,18 @@ export function canRemoveMember(
   return targetUser.id === currentUser.id;             // self-leave
 }
 
+/**
+ * Mirrors backend `require_owner` for `PATCH /projects/{id}` and
+ * `DELETE /projects/{id}`. Both endpoints share the same predicate.
+ */
+export function canEditProject(
+  project: Project | null | undefined,
+  currentUser: User | null | undefined,
+): boolean {
+  if (!project || !currentUser) return false;
+  return project.ownerId === currentUser.id;
+}
+
 export function canLeaveProject(
   project: Project | null | undefined,
   currentUser: User | null | undefined,

--- a/app/src/routes/_app.projects.$projectSlug.settings.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.settings.tsx
@@ -1,7 +1,15 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
-import { getProject } from '@/api/projects';
-import { SectionLabel } from '@/components/uiPrimitives';
+import { useEffect, useState } from 'react';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deleteProject, getProject, listMembers, listProjects, updateProject } from '@/api/projects';
+import { Avatar, SectionLabel } from '@/components/uiPrimitives';
+import { Icon } from '@/components/Icon';
+import type { User } from '@/domain/types';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { useToastStore } from '@/components/Toast';
+import { useAuthStore } from '@/stores/auth';
+import { canEditProject } from '@/lib/permissions';
+import { ApiError } from '@/api/client';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/settings')({
   component: SettingsPage,
@@ -9,20 +17,384 @@ export const Route = createFileRoute('/_app/projects/$projectSlug/settings')({
 
 function SettingsPage() {
   const { projectSlug } = Route.useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const showToast = useToastStore((s) => s.show);
+  const currentUser = useAuthStore((s) => s.currentUser);
+
   const project = useQuery({ queryKey: ['project', projectSlug], queryFn: () => getProject(projectSlug) });
+  const members = useQuery({ queryKey: ['members', projectSlug], queryFn: () => listMembers(projectSlug) });
+
+  const editable = canEditProject(project.data, currentUser);
+
+  const ownerUser: User | null = (() => {
+    if (!project.data) return null;
+    const fromMembers = (members.data ?? []).find((m) => m.id === project.data!.ownerId);
+    if (fromMembers) return fromMembers;
+    if (currentUser?.id === project.data.ownerId) return currentUser;
+    return null;
+  })();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [editMode, setEditMode] = useState(false);
+  const [descEditMode, setDescEditMode] = useState(false);
+
+  // 서버 데이터가 도착하면 input 초깃값을 채운다. 사용자가 편집하는 동안
+  // 외부 refetch가 와도 입력을 덮어쓰지 않도록 project id 기반 dependency.
+  useEffect(() => {
+    if (project.data) {
+      setName(project.data.name);
+      setDescription(project.data.description ?? '');
+    }
+  }, [project.data?.id]);
+
+  const updateMutation = useMutation({
+    mutationFn: () => updateProject(projectSlug, { name: name.trim() }),
+    onSuccess: async (updated) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['project', projectSlug] }),
+        queryClient.invalidateQueries({ queryKey: ['projects'] }),
+      ]);
+      setName(updated.name);
+      setSubmitError(null);
+      setEditMode(false);
+      showToast('프로젝트 이름을 변경했습니다');
+    },
+    onError: (err) => setSubmitError(messageOf(err)),
+  });
+
+  const descMutation = useMutation({
+    mutationFn: () => updateProject(projectSlug, {
+      description: description.trim() ? description.trim() : null,
+    }),
+    onSuccess: async (updated) => {
+      await queryClient.invalidateQueries({ queryKey: ['project', projectSlug] });
+      setDescription(updated.description ?? '');
+      setSubmitError(null);
+      setDescEditMode(false);
+      showToast('설명을 변경했습니다');
+    },
+    onError: (err) => setSubmitError(messageOf(err)),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteProject(projectSlug),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['projects'] });
+      queryClient.removeQueries({ queryKey: ['project', projectSlug] });
+      const remaining = (await queryClient.fetchQuery({ queryKey: ['projects'], queryFn: listProjects })) ?? [];
+      showToast('프로젝트가 삭제되었습니다');
+      setDeleteOpen(false);
+      if (remaining[0]) {
+        navigate({ to: '/projects/$projectSlug', params: { projectSlug: remaining[0].slug } });
+      } else {
+        navigate({ to: '/projects' });
+      }
+    },
+    onError: (err) => {
+      showToast(`삭제 실패: ${messageOf(err)}`);
+    },
+  });
+
+  const trimmedName = name.trim();
+  const dirty = project.data ? trimmedName !== project.data.name : false;
+  const saveDisabled = !editable || !dirty || trimmedName.length === 0 || updateMutation.isPending;
+
+  const descDirty = project.data
+    ? description.trim() !== (project.data.description ?? '')
+    : false;
+  const descSaveDisabled = !editable || !descDirty || descMutation.isPending;
 
   return (
-    <section className="cw-page cw-simple-page cw-page-enter">
-      <SectionLabel>Project metadata</SectionLabel>
-      <h1>Settings</h1>
-      <p>프로젝트 메타데이터입니다. 편집 기능은 곧 추가됩니다.</p>
-      <div className="cw-simple-stack">
-        <code>name: {project.data?.name ?? '—'}</code>
-        <code>description: {project.data?.description || '—'}</code>
-        <code>slug: {projectSlug}</code>
-        <code>id: {project.data?.id ?? '—'}</code>
-        <code>owner_id: {project.data?.ownerId ?? '—'}</code>
+    <section className="cw-page cw-page-enter">
+      <SectionLabel>Project settings</SectionLabel>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 18,
+          flexWrap: 'wrap',
+          marginTop: 4,
+        }}
+      >
+        <div style={{ display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+          {editable && editMode ? (
+            <>
+              <input
+                autoFocus
+                value={name}
+                onChange={(e) => { setName(e.target.value); if (submitError) setSubmitError(null); }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!saveDisabled) updateMutation.mutate();
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    if (project.data) setName(project.data.name);
+                    setSubmitError(null);
+                    setEditMode(false);
+                  }
+                }}
+                disabled={updateMutation.isPending}
+                maxLength={100}
+                aria-label="프로젝트 이름"
+                style={{
+                  margin: 0,
+                  padding: '4px 10px',
+                  border: '1px solid var(--cw-line)',
+                  borderRadius: 8,
+                  background: 'var(--cw-paper)',
+                  color: 'var(--cw-ink)',
+                  fontSize: 'var(--cw-text-2xl)',
+                  lineHeight: 1.12,
+                  letterSpacing: '-0.025em',
+                  fontWeight: 650,
+                  fontFamily: 'inherit',
+                  minWidth: 280,
+                }}
+              />
+              <button
+                type="button"
+                className="cw-btn-primary"
+                onClick={() => updateMutation.mutate()}
+                disabled={saveDisabled}
+              >
+                {updateMutation.isPending ? '저장 중…' : '저장'}
+              </button>
+              <button
+                type="button"
+                className="cw-btn-secondary"
+                onClick={() => {
+                  if (project.data) setName(project.data.name);
+                  setSubmitError(null);
+                  setEditMode(false);
+                }}
+                disabled={updateMutation.isPending}
+              >
+                취소
+              </button>
+            </>
+          ) : (
+            <>
+              <h1 style={{ margin: 0 }}>{project.data?.name ?? '…'}</h1>
+              {editable && project.data && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSubmitError(null);
+                    setEditMode(true);
+                  }}
+                  aria-label="프로젝트 이름 편집"
+                  title="편집"
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 30,
+                    height: 30,
+                    border: '1px solid var(--cw-line)',
+                    borderRadius: 8,
+                    background: 'var(--cw-paper-2)',
+                    color: 'var(--cw-ink-3)',
+                    cursor: 'pointer',
+                    padding: 0,
+                  }}
+                >
+                  <Icon name="writing" size={14} />
+                </button>
+              )}
+            </>
+          )}
+        </div>
+        {ownerUser && (
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              fontSize: 13,
+              color: 'var(--cw-ink-3)',
+            }}
+          >
+            <span>Owned by</span>
+            <Avatar user={ownerUser} small />
+            <b style={{ color: 'var(--cw-ink-2)', fontWeight: 600 }}>{ownerUser.name}</b>
+          </span>
+        )}
       </div>
+      <p
+        style={{
+          margin: '6px 0 24px',
+          fontSize: 12,
+          color: 'var(--cw-ink-4)',
+          fontFamily: 'var(--cw-font-mono)',
+          fontStyle: 'italic',
+        }}
+      >
+        {projectSlug}
+      </p>
+
+      {project.data && (
+        <div style={{ marginBottom: 24 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+            <SectionLabel>Description</SectionLabel>
+            {editable && !descEditMode && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSubmitError(null);
+                  setDescEditMode(true);
+                }}
+                aria-label="설명 편집"
+                title="편집"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 22,
+                  height: 22,
+                  border: '1px solid var(--cw-line)',
+                  borderRadius: 6,
+                  background: 'var(--cw-paper-2)',
+                  color: 'var(--cw-ink-3)',
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                <Icon name="writing" size={12} />
+              </button>
+            )}
+          </div>
+
+          {editable && descEditMode ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <textarea
+                autoFocus
+                value={description}
+                onChange={(e) => { setDescription(e.target.value); if (submitError) setSubmitError(null); }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setDescription(project.data?.description ?? '');
+                    setSubmitError(null);
+                    setDescEditMode(false);
+                  }
+                }}
+                placeholder="이 프로젝트는 어떤 작업인가요?"
+                disabled={descMutation.isPending}
+                rows={3}
+                style={{
+                  resize: 'vertical',
+                  minHeight: 80,
+                  fontFamily: 'inherit',
+                  fontSize: 14,
+                  lineHeight: 1.6,
+                  padding: '10px 12px',
+                  border: '1px solid var(--cw-line)',
+                  borderRadius: 8,
+                  background: 'var(--cw-paper)',
+                  color: 'var(--cw-ink)',
+                }}
+              />
+              <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+                <button
+                  type="button"
+                  className="cw-btn-secondary"
+                  onClick={() => {
+                    setDescription(project.data?.description ?? '');
+                    setSubmitError(null);
+                    setDescEditMode(false);
+                  }}
+                  disabled={descMutation.isPending}
+                >
+                  취소
+                </button>
+                <button
+                  type="button"
+                  className="cw-btn-primary"
+                  onClick={() => descMutation.mutate()}
+                  disabled={descSaveDisabled}
+                >
+                  {descMutation.isPending ? '저장 중…' : '저장'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p
+              style={{
+                margin: 0,
+                color: project.data.description ? 'var(--cw-ink-2)' : 'var(--cw-ink-4)',
+                fontSize: 14,
+                lineHeight: 1.6,
+              }}
+            >
+              {project.data.description || '설명이 없습니다.'}
+            </p>
+          )}
+        </div>
+      )}
+
+      {submitError && (
+        <div className="cw-dialog-warn" role="alert" style={{ marginBottom: 20 }}>{submitError}</div>
+      )}
+
+      {editable && (
+        <div
+          style={{
+            marginTop: 24,
+            border: '1px solid var(--cw-destructive)',
+            borderRadius: 12,
+            background: 'var(--cw-paper-2)',
+            padding: 20,
+          }}
+        >
+          <SectionLabel>Danger zone</SectionLabel>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16, marginTop: 8 }}>
+            <div style={{ minWidth: 0 }}>
+              <h2 style={{ margin: 0, fontSize: 14, color: 'var(--cw-ink)' }}>프로젝트 삭제</h2>
+              <p style={{ margin: '4px 0 0', color: 'var(--cw-ink-3)', fontSize: 12, lineHeight: 1.55 }}>
+                세션·메시지·업로드 파일·sandbox 자원이 모두 함께 삭제됩니다. 이 작업은 되돌릴 수 없어요.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="cw-btn-primary"
+              style={{ background: 'var(--cw-destructive)', borderColor: 'var(--cw-destructive)' }}
+              onClick={() => setDeleteOpen(true)}
+            >
+              프로젝트 삭제
+            </button>
+          </div>
+        </div>
+      )}
+
+      {deleteOpen && project.data && (
+        <ConfirmDialog
+          title="프로젝트를 삭제하시겠어요?"
+          body={`"${project.data.name}"의 모든 세션·메시지·업로드가 함께 정리됩니다. 이 작업은 되돌릴 수 없습니다.`}
+          confirmLabel="삭제"
+          destructive
+          pending={deleteMutation.isPending}
+          onConfirm={() => deleteMutation.mutate()}
+          onClose={() => setDeleteOpen(false)}
+        />
+      )}
     </section>
   );
+}
+
+function messageOf(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.';
+    if (err.status === 403) return '권한이 없습니다 (소유자만 가능)';
+    if (err.status === 404) return '프로젝트를 찾을 수 없습니다.';
+    if (err.status === 409) return '같은 이름의 프로젝트가 이미 있어요.';
+    if (err.status === 422 || err.status === 400) return '입력값을 확인해 주세요.';
+    return `${err.status} — ${err.message}`;
+  }
+  if (err instanceof Error) return err.message;
+  return '요청에 실패했습니다.';
 }

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -220,7 +220,7 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
 .cw-brand-lockup:hover { background: var(--cw-bg-muted); }
 .cw-brand-lockup img:first-child { width: 28px; height: 28px; flex-shrink: 0; }
 .cw-brand-lockup strong { color: var(--cw-fg-1); font-size: 22px; line-height: 1; letter-spacing: -0.035em; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cw-section-label-app { padding: 10px 8px 5px; font-size: 10.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--cw-fg-3); font-weight: 500; }
+.cw-section-label-app { padding: 5px 3px 5px; font-size: 10.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--cw-fg-3); font-weight: 500; }
 .cw-nav-list, .cw-session-rail { display: flex; flex-direction: column; gap: 1px; }
 .cw-nav-row, .cw-session-row { width: 100%; min-height: 31px; display: flex; align-items: center; gap: 9px; border: 0; border-radius: var(--cw-radius-md); background: transparent; color: var(--cw-fg-2); padding: 6px 8px; text-align: left; font-size: 13px; transition: background 120ms, color 120ms, transform 120ms; }
 .cw-nav-row:hover, .cw-session-row:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
@@ -247,7 +247,7 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
 .cw-page-enter { animation: cw-enter .26s ease both; }
 .cw-page-head, .cw-project-hero { display: flex; justify-content: space-between; gap: var(--cw-space-6); align-items: flex-start; padding-bottom: var(--cw-space-6); border-bottom: 1px solid var(--cw-border); margin-bottom: var(--cw-space-6); }
 .cw-page h1, .cw-project-hero h1, .cw-chat-head h1 { margin: 0; font-size: var(--cw-text-2xl); line-height: 1.12; letter-spacing: -0.025em; font-weight: 650; }
-.cw-page p, .cw-project-hero p { color: var(--cw-fg-3); margin: 12px 0 0; line-height: var(--cw-leading-relaxed); }
+.cw-page p, .cw-project-hero p { color: var(--cw-fg-3); margin: 8px 0 8px; line-height: var(--cw-leading-relaxed); }
 .cw-projects-page .cw-page-head h1 { font-size: 48px; letter-spacing: -0.04em; }
 .cw-projects-page .cw-page-head p { max-width: 590px; font-size: 18px; }
 .cw-btn-primary, .cw-btn-secondary { min-height: 34px; border-radius: var(--cw-radius-sm); padding: 7px 12px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; transition: background 120ms, border 120ms, transform 120ms; }

--- a/backend/src/handlers/project.rs
+++ b/backend/src/handlers/project.rs
@@ -50,24 +50,6 @@ pub async fn resolve_project_id(state: &Arc<AppState>, project_ref: &str) -> Api
     Err(AppError::not_found("project not found"))
 }
 
-/// Whether a slug is available for assignment to a new (or renamed) project.
-///
-/// Considers both active project slugs and retired ones — retired slugs are
-/// permanently reserved so the redirect history stays unambiguous.
-async fn is_slug_taken(repo: &SqliteRepository, candidate: &str) -> RepositoryResult<bool> {
-    if repo.get_project_by_slug(candidate).await?.is_some() {
-        return Ok(true);
-    }
-    if repo
-        .get_project_id_by_retired_slug(candidate)
-        .await?
-        .is_some()
-    {
-        return Ok(true);
-    }
-    Ok(false)
-}
-
 /// Reject a slug that another project has already retired.
 ///
 /// A retired slug stays bound to whichever project owned it last — links to
@@ -123,19 +105,35 @@ fn validate_explicit_slug(s: &str) -> ApiResult<()> {
 /// Generate a slug that is unique among active and retired project slugs.
 ///
 /// Starts from `slug::slugify(name)`; if that is empty, falls back to
-/// `project-<6-char nanoid>`. Appends `-2`, `-3`, … on collision.
-async fn generate_unique_slug(name: &str, repo: &SqliteRepository) -> RepositoryResult<String> {
+/// `project-<6-char nanoid>`. Appends `-2`, `-3`, … on collision. When
+/// `self_project_id` is provided, slugs already owned (active or retired) by
+/// that project are not treated as collisions — useful for rename flows where
+/// re-deriving the same slug should yield a no-op rather than `-2`.
+async fn generate_unique_slug(
+    name: &str,
+    repo: &SqliteRepository,
+    self_project_id: Option<Uuid>,
+) -> RepositoryResult<String> {
     let mut base = slug::slugify(name);
     if base.is_empty() {
         base = format!("project-{}", nanoid::nanoid!(6));
     }
     let mut candidate = base.clone();
     let mut suffix = 2u32;
-    while is_slug_taken(repo, &candidate).await? {
+    loop {
+        let active_owner = repo.get_project_by_slug(&candidate).await?.map(|p| p.id);
+        let retired_owner = repo.get_project_id_by_retired_slug(&candidate).await?;
+        let taken_by_other = match (active_owner, retired_owner) {
+            (Some(id), _) => Some(id) != self_project_id,
+            (None, Some(id)) => Some(id) != self_project_id,
+            (None, None) => false,
+        };
+        if !taken_by_other {
+            return Ok(candidate);
+        }
         candidate = format!("{base}-{suffix}");
         suffix += 1;
     }
-    Ok(candidate)
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────────────
@@ -152,7 +150,7 @@ pub async fn create_project(
             ensure_slug_not_retired_by_other(&state.repository, &s, None).await?;
             s
         }
-        None => generate_unique_slug(&payload.name, &state.repository)
+        None => generate_unique_slug(&payload.name, &state.repository, None)
             .await
             .map_err(|e| AppError::internal(e.to_string()))?,
     };
@@ -217,6 +215,10 @@ pub async fn get_project(
 }
 
 /// PATCH /projects/{project_ref} — owner only
+///
+/// Slug isn't taken from the payload; if `name` changes, the new slug is
+/// derived from it via `generate_unique_slug` (same path as create). The
+/// previous slug is retired so old links keep resolving.
 pub async fn update_project(
     State(state): State<Arc<AppState>>,
     Extension(auth_user): Extension<AuthUser>,
@@ -226,10 +228,15 @@ pub async fn update_project(
     let project_id = resolve_project_id(&state, &project_ref).await?;
     require_owner(&state, auth_user.id, project_id).await?;
 
-    if let Some(ref new_slug) = payload.slug {
-        validate_explicit_slug(new_slug)?;
-        ensure_slug_not_retired_by_other(&state.repository, new_slug, Some(project_id)).await?;
-    }
+    let new_slug = if let Some(ref new_name) = payload.name {
+        Some(
+            generate_unique_slug(new_name, &state.repository, Some(project_id))
+                .await
+                .map_err(|e| AppError::internal(e.to_string()))?,
+        )
+    } else {
+        None
+    };
 
     let updated = state
         .repository
@@ -237,7 +244,7 @@ pub async fn update_project(
             project_id,
             payload.name,
             payload.description.map(Some),
-            payload.slug,
+            new_slug,
         )
         .await
         .map_err(|e| match e {

--- a/backend/src/model/project.rs
+++ b/backend/src/model/project.rs
@@ -44,7 +44,6 @@ pub struct CreateProjectRequest {
 pub struct UpdateProjectRequest {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub slug: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/backend/tests/project_test.rs
+++ b/backend/tests/project_test.rs
@@ -359,3 +359,171 @@ async fn owner_leave_is_blocked() {
         "owner leave should be blocked: {body}"
     );
 }
+
+// ── update_project: rename re-derives slug from the new name ─────────────────
+
+#[tokio::test]
+async fn update_project_name_regenerates_slug() {
+    let repo = common::make_repo().await;
+    let app = common::make_app_with_repo(repo);
+
+    common::signup(&app, "alice", "password123").await;
+    let token = common::login(&app, "alice", "password123").await;
+
+    let payload = serde_json::json!({ "name": "Old Name" });
+    let (status, created) =
+        common::authed(&app, "POST", "/projects", &token, Some(payload)).await;
+    assert_eq!(status, StatusCode::CREATED, "create failed: {created}");
+    assert_eq!(created["slug"], "old-name");
+    let project_id = created["id"].as_str().unwrap().to_string();
+    let old_slug = created["slug"].as_str().unwrap().to_string();
+
+    let payload = serde_json::json!({ "name": "Cool Stuff" });
+    let (status, body) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{project_id}"),
+        &token,
+        Some(payload),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "rename failed: {body}");
+    assert_eq!(body["name"], "Cool Stuff");
+    assert_eq!(body["slug"], "cool-stuff");
+
+    // Old slug is retired but still resolves the same project.
+    let (status, fetched) = common::authed(
+        &app,
+        "GET",
+        &format!("/projects/{old_slug}"),
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "retired slug should still resolve: {fetched}");
+    assert_eq!(fetched["id"], project_id.as_str());
+    assert_eq!(fetched["slug"], "cool-stuff");
+}
+
+// ── update_project: description-only update leaves the slug alone ────────────
+
+#[tokio::test]
+async fn update_project_description_only_keeps_slug() {
+    let repo = common::make_repo().await;
+    let app = common::make_app_with_repo(repo);
+
+    common::signup(&app, "alice", "password123").await;
+    let token = common::login(&app, "alice", "password123").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let project_id = project["id"].as_str().unwrap();
+    let original_slug = project["slug"].as_str().unwrap().to_string();
+
+    let payload = serde_json::json!({ "description": "new description" });
+    let (status, body) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{project_id}"),
+        &token,
+        Some(payload),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "desc update failed: {body}");
+    assert_eq!(body["description"], "new description");
+    assert_eq!(body["slug"], original_slug.as_str());
+}
+
+// ── update_project: re-deriving the same slug is a no-op (no history entry) ──
+
+#[tokio::test]
+async fn update_project_same_slug_noop() {
+    let repo = common::make_repo().await;
+    let app = common::make_app_with_repo(repo);
+
+    common::signup(&app, "alice", "password123").await;
+    let token = common::login(&app, "alice", "password123").await;
+
+    let payload = serde_json::json!({ "name": "Stable Name" });
+    let (status, created) =
+        common::authed(&app, "POST", "/projects", &token, Some(payload)).await;
+    assert_eq!(status, StatusCode::CREATED, "create failed: {created}");
+    assert_eq!(created["slug"], "stable-name");
+    let project_id = created["id"].as_str().unwrap().to_string();
+
+    // A different spelling that slugifies to the same value.
+    let payload = serde_json::json!({ "name": "stable name" });
+    let (status, body) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{project_id}"),
+        &token,
+        Some(payload),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "rename failed: {body}");
+    assert_eq!(body["slug"], "stable-name");
+}
+
+// ── update_project: collision with another project's slug appends `-N` ───────
+
+#[tokio::test]
+async fn update_project_slug_collision_appends_suffix() {
+    let repo = common::make_repo().await;
+    let app = common::make_app_with_repo(repo);
+
+    common::signup(&app, "alice", "password123").await;
+    let token = common::login(&app, "alice", "password123").await;
+
+    // Another project already owns the slug "shared".
+    let payload = serde_json::json!({ "name": "shared" });
+    let (status, blocker) =
+        common::authed(&app, "POST", "/projects", &token, Some(payload)).await;
+    assert_eq!(status, StatusCode::CREATED, "create blocker failed: {blocker}");
+    assert_eq!(blocker["slug"], "shared");
+
+    let payload = serde_json::json!({ "name": "Other" });
+    let (status, target) =
+        common::authed(&app, "POST", "/projects", &token, Some(payload)).await;
+    assert_eq!(status, StatusCode::CREATED, "create target failed: {target}");
+    let target_id = target["id"].as_str().unwrap().to_string();
+
+    // Renaming target to a value that slugifies to "shared" should bump to -2.
+    let payload = serde_json::json!({ "name": "Shared" });
+    let (status, body) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{target_id}"),
+        &token,
+        Some(payload),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "rename failed: {body}");
+    assert_eq!(body["slug"], "shared-2");
+}
+
+// ── update_project: explicit slug in payload is rejected by deny_unknown ─────
+
+#[tokio::test]
+async fn update_project_rejects_explicit_slug_field() {
+    let repo = common::make_repo().await;
+    let app = common::make_app_with_repo(repo);
+
+    common::signup(&app, "alice", "password123").await;
+    let token = common::login(&app, "alice", "password123").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let project_id = project["id"].as_str().unwrap();
+
+    let payload = serde_json::json!({ "slug": "my-custom-slug" });
+    let (status, _) = common::authed(
+        &app,
+        "PATCH",
+        &format!("/projects/{project_id}"),
+        &token,
+        Some(payload),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "slug must no longer be accepted in update payload"
+    );
+}


### PR DESCRIPTION
## Ticket
resolves #101

## Description
Changed the project settings page from the existing read-only mockup page to an interactive page that allows editing.

## Screenshots
### basic
<img width="1102" height="663" alt="image" src="https://github.com/user-attachments/assets/84127125-1dd9-48fd-8ecc-93161256cf15" />

### interaction
edit `name` / edit `description` / delete
<img width="1094" height="741" alt="image" src="https://github.com/user-attachments/assets/5a94e168-bec7-4ca1-97a5-7b90490bd4e6" />

## Notes
Since the changes to the model configuration feature are quite significant, it will not be included in this PR but will be handled as a separate issue.