### PR TITLE
feat(speedwagon): corpus Q&A with web_search fallback over per-project Store

### DIFF
--- a/agent-k/src/agents/speedwagon/agent.rs
+++ b/agent-k/src/agents/speedwagon/agent.rs
@@ -1,11 +1,15 @@
-use ailoy::agent::{AgentCard, AgentSpec};
-
-use super::tool::{
-    get_calculate_tool_desc, get_find_in_document_tool_desc, get_read_document_tool_desc,
-    get_search_document_tool_desc,
+use ailoy::{
+    agent::{Agent, AgentCard, AgentProvider, AgentSpec},
+    runenv::RunEnv,
 };
 
-pub const SYSTEM_PROMPT: &str = r#"You are an expert research assistant. Your task is to answer questions by systematically searching through a document corpus using the provided tools. Think step by step.
+use super::tool::{
+    build_tools, get_calculate_tool_desc, get_find_in_document_tool_desc,
+    get_read_document_tool_desc, get_search_document_tool_desc,
+};
+use crate::knowledge_base::SharedStore;
+
+pub const SYSTEM_PROMPT: &str = r#"You are {{NAME}}, an expert research assistant. Your task is to answer questions by systematically searching through a document corpus using the provided tools. Think step by step.
 
 # Strategy
 
@@ -28,11 +32,18 @@ Repeat until you can confidently answer.
 
 - Use `calculate` for single arithmetic expressions (percentages, ratios, unit conversions). Examples: `"1577 * 1.08"`, `"sqrt(2) * pi"`.
 
+## Web fallback
+
+- If `web_search` is available and the corpus search yields no usable matches after at least two distinct queries, or if the question is clearly outside the corpus (current events, public facts not in any uploaded document), use `web_search` to gather candidate answers.
+- Treat the corpus as the primary, trusted source. Use the web only when the corpus cannot answer.
+- When the corpus disagrees with the web, prefer the corpus and note the discrepancy.
+
 # Choosing the right approach
 
 - **Document questions** (facts, quotes, data from the corpus): Use `search_document` first, then `find_in_document` and `read_document` to inspect. ALWAYS cite filepath and line numbers.
 - **Computation questions** (single expressions): Use `calculate` directly.
 - **Mixed questions** (e.g. "what is 3M's revenue growth rate?"): Find the raw data in documents first, then use `calculate` to compute.
+- **Public-knowledge questions** the corpus does not cover: Try `search_document` once to confirm, then use `web_search`.
 
 If unsure whether the answer is in the corpus, try a quick search first.
 
@@ -40,9 +51,11 @@ If unsure whether the answer is in the corpus, try a quick search first.
 
 - If `find_in_document` returns no matches, try synonym keywords or a broader term.
 - For document-based answers: ALWAYS cite the specific document (filepath) and line numbers.
-- **NEVER give up after a single tool call.** Try alternative tools and keywords before concluding.
+- For web-based answers: ALWAYS cite the source URL.
+- **NEVER give up after a single tool call.** Try alternative tools and keywords before concluding. If the corpus is empty or off-topic and `web_search` is available, fall back to it before giving up.
 - If you cannot find the answer after exhausting all approaches, say so and explain what you tried.
-- Be concise in your final answer. Lead with the direct answer, then provide the source reference."#;
+- Be concise in your final answer. Lead with the direct answer, then provide the source reference.
+- Current time: {{TIME}}."#;
 
 #[derive(Debug, Clone)]
 pub struct SpeedwagonSpec {
@@ -61,6 +74,15 @@ impl SpeedwagonSpec {
 
     pub fn card(mut self, card: AgentCard) -> Self {
         self.spec.card = Some(card);
+        self
+    }
+
+    /// Advertise `web_search` as an available tool. Use when the agent should
+    /// fall back to the public web for questions the corpus cannot answer.
+    /// The runtime `ToolFunc` for `web_search` is provided by ailoy's default
+    /// `ToolProvider`, so no extra wiring is required at registration time.
+    pub fn with_web_search(mut self) -> Self {
+        self.spec = self.spec.web_search_tool(vec![]);
         self
     }
 
@@ -87,5 +109,122 @@ impl Default for SpeedwagonSpec {
 impl From<SpeedwagonSpec> for AgentSpec {
     fn from(value: SpeedwagonSpec) -> Self {
         value.spec
+    }
+}
+
+/// UTC timestamp in ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`) using only stdlib.
+/// Mirrors `coworker::now_utc_iso8601` so both prompts share a wall-clock token.
+fn now_utc_iso8601() -> String {
+    fn civil_from_days(days: i64) -> (i64, u32, u32) {
+        let z = days + 719_468;
+        let era = z.div_euclid(146_097);
+        let doe = z.rem_euclid(146_097) as u64;
+        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+        let y = yoe as i64 + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        let mp = (5 * doy + 2) / 153;
+        let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+        let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+        let y = if m <= 2 { y + 1 } else { y };
+        (y, m, d)
+    }
+
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let days = secs.div_euclid(86_400);
+    let sod = secs.rem_euclid(86_400);
+    let (y, mo, d) = civil_from_days(days);
+    let h = sod / 3600;
+    let mi = (sod % 3600) / 60;
+    let s = sod % 60;
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+/// Build a standalone Speedwagon `Agent` bound to `store`.
+///
+/// Mirrors `get_coworker_agent` in shape (`name`, `model`, plus the agent's
+/// resource handle), but Speedwagon needs neither a sandbox nor mounted
+/// directories — only a `SharedStore` for the corpus tools. The `RunEnv` is a
+/// `Local` instance because the agent does not execute user code.
+///
+/// `web_search` is enabled by default; pass the returned `Agent` straight to
+/// `agent.run(...)` or hand the underlying `SpeedwagonSpec` to a parent agent
+/// via `.subagent(...)`.
+pub async fn get_speedwagon_agent(
+    name: impl AsRef<str>,
+    model: impl AsRef<str>,
+    store: SharedStore,
+) -> anyhow::Result<Agent> {
+    let inst = SYSTEM_PROMPT
+        .replace("{{NAME}}", name.as_ref())
+        .replace("{{TIME}}", &now_utc_iso8601());
+
+    let spec = SpeedwagonSpec::new()
+        .model(model.as_ref())
+        .with_web_search()
+        .into_spec()
+        .instruction(inst);
+
+    let mut provider = AgentProvider::new();
+    provider.tools = build_tools(store);
+
+    Agent::try_with_provider_and_runenv(spec, &provider, RunEnv::local())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool_names(spec: &AgentSpec) -> Vec<&str> {
+        spec.tools.iter().map(|t| t.name.as_str()).collect()
+    }
+
+    #[test]
+    fn default_spec_has_four_corpus_tools_and_no_web_search() {
+        let spec = SpeedwagonSpec::new().into_spec();
+        let names = tool_names(&spec);
+        assert!(names.contains(&"search_document"), "missing search_document: {names:?}");
+        assert!(names.contains(&"find_in_document"), "missing find_in_document: {names:?}");
+        assert!(names.contains(&"read_document"), "missing read_document: {names:?}");
+        assert!(names.contains(&"calculate"), "missing calculate: {names:?}");
+        assert!(!names.contains(&"web_search"), "web_search should be opt-in: {names:?}");
+        assert_eq!(names.len(), 4, "expected exactly 4 default tools, got {names:?}");
+    }
+
+    #[test]
+    fn with_web_search_adds_fifth_tool() {
+        let spec = SpeedwagonSpec::new().with_web_search().into_spec();
+        let names = tool_names(&spec);
+        assert!(names.contains(&"web_search"), "web_search not advertised: {names:?}");
+        assert_eq!(names.len(), 5, "expected 5 tools after with_web_search, got {names:?}");
+    }
+
+    #[test]
+    fn system_prompt_describes_corpus_first_with_web_fallback() {
+        // The prompt has to teach the model BOTH that corpus comes first AND
+        // that web_search is the fallback. If either half is removed the
+        // agent's behaviour drifts.
+        assert!(
+            SYSTEM_PROMPT.contains("search_document"),
+            "prompt lost corpus-tool guidance"
+        );
+        assert!(
+            SYSTEM_PROMPT.contains("web_search"),
+            "prompt lost web_search fallback guidance"
+        );
+        assert!(
+            SYSTEM_PROMPT.to_ascii_lowercase().contains("fallback"),
+            "prompt lost explicit fallback wording"
+        );
+    }
+
+    #[test]
+    fn model_builder_overrides_default() {
+        let spec = SpeedwagonSpec::new()
+            .model("anthropic/claude-haiku-4-5")
+            .into_spec();
+        assert_eq!(spec.model, "anthropic/claude-haiku-4-5");
     }
 }

--- a/backend/migrations/0007_ingest_jobs.sql
+++ b/backend/migrations/0007_ingest_jobs.sql
@@ -1,0 +1,35 @@
+-- Auto-ingest pipeline: enqueue dirent uploads (PDF/MD/TXT) for Store ingestion
+-- by a background worker. project_documents tracks the resulting (project, path)
+-- → document_id mapping so that delete and re-ingest are idempotent.
+
+CREATE TABLE ingest_jobs (
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    source_path     TEXT NOT NULL,            -- relative path under projects/{id}/uploads/
+    status          TEXT NOT NULL,            -- queued | running | done | failed
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    lease_until     TEXT,                     -- NULL when not leased; reaper uses this
+    document_id     TEXT,                     -- agent-k Store document id once status=done
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+
+CREATE INDEX idx_ingest_jobs_status_created ON ingest_jobs(status, created_at);
+CREATE INDEX idx_ingest_jobs_project ON ingest_jobs(project_id);
+CREATE INDEX idx_ingest_jobs_lease ON ingest_jobs(lease_until) WHERE status = 'running';
+-- One queued/running/done row per (project, path). On re-upload we update the
+-- existing row (status -> queued, attempts reset) rather than insert a new one.
+CREATE UNIQUE INDEX idx_ingest_jobs_project_path ON ingest_jobs(project_id, source_path);
+
+-- Mapping from (project, source_path) to the Store document. Populated when an
+-- ingest_job completes; deleted when dirent.delete removes the file.
+CREATE TABLE project_documents (
+    project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    source_path     TEXT NOT NULL,
+    document_id     TEXT NOT NULL,
+    ingested_at     TEXT NOT NULL,
+    PRIMARY KEY (project_id, source_path)
+);
+
+CREATE INDEX idx_project_documents_doc ON project_documents(document_id);

--- a/backend/src/handlers/dirent.rs
+++ b/backend/src/handlers/dirent.rs
@@ -204,6 +204,24 @@ pub async fn upload(
             .ok()
             .and_then(|m| m.modified().ok())
             .map(DateTime::<Utc>::from);
+
+        // Auto-ingest: queue PDF/MD/TXT files for the background worker. Failures
+        // here do not roll back the upload — the file is on disk regardless and
+        // the user can re-trigger by re-uploading.
+        if crate::model::is_ingestable_filename(&filename) {
+            if let Err(e) = state
+                .repository
+                .enqueue_ingest_job(project_id, &filename)
+                .await
+            {
+                tracing::warn!(
+                    project = %project_id,
+                    path = %filename,
+                    "failed to enqueue ingest job: {e}"
+                );
+            }
+        }
+
         succeeded.push(Dirent {
             path: filename,
             kind: DirentKind::File,
@@ -433,6 +451,10 @@ pub async fn delete_path(
     }
 
     if meta.is_dir() {
+        // Directory deletion does not currently walk the tree to purge per-file
+        // project_documents entries. Files under a removed dir become orphan
+        // rows; a future migration / reaper sweeps them. Single-file delete
+        // does clean up below.
         tokio::fs::remove_dir_all(&host_path)
             .await
             .map_err(|e| AppError::internal(format!("failed to remove directory: {e}")))?;
@@ -440,6 +462,46 @@ pub async fn delete_path(
         tokio::fs::remove_file(&host_path)
             .await
             .map_err(|e| AppError::internal(format!("failed to remove file: {e}")))?;
+
+        // Auto-ingest cleanup: drop the project_documents row + ingest_job, and
+        // remove the document from the agent-k Store if one was indexed. Best
+        // effort — log and continue on individual failures.
+        match state
+            .repository
+            .delete_project_document(project_id, &path_str)
+            .await
+        {
+            Ok(Some(document_id)) => match Uuid::parse_str(&document_id) {
+                Ok(uuid) => {
+                    let store = state.get_store(project_id).await;
+                    let mut store = store.write().await;
+                    if let Err(e) = store.purge(uuid) {
+                        tracing::warn!(
+                            project = %project_id,
+                            path = %path_str,
+                            doc = %document_id,
+                            "failed to purge document from store: {e}"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        project = %project_id,
+                        path = %path_str,
+                        doc = %document_id,
+                        "invalid document_id (not a Uuid): {e}"
+                    );
+                }
+            },
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    project = %project_id,
+                    path = %path_str,
+                    "failed to delete project_document row: {e}"
+                );
+            }
+        }
     }
 
     tracing::info!(project = %project_id, path = %path_str, "dirent deleted");

--- a/backend/src/handlers/document.rs
+++ b/backend/src/handlers/document.rs
@@ -29,12 +29,14 @@ pub struct ListDocumentsQuery {
 
 pub async fn list_documents(
     State(state): State<Arc<AppState>>,
+    Path(project_id): Path<Uuid>,
     Query(query): Query<ListDocumentsQuery>,
 ) -> ApiResult<Json<Vec<DocumentResponse>>> {
     let page = query.page.unwrap_or(0);
     let page_size = query.page_size.unwrap_or(50);
 
-    let store = state.store.read().await;
+    let store = state.get_store(project_id).await;
+    let store = store.read().await;
     let docs = store
         .list(false, page, page_size)
         .map_err(|e| AppError::internal(e.to_string()))?;
@@ -44,9 +46,10 @@ pub async fn list_documents(
 
 pub async fn get_document(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<Uuid>,
+    Path((project_id, id)): Path<(Uuid, Uuid)>,
 ) -> ApiResult<Json<DocumentResponse>> {
-    let store = state.store.read().await;
+    let store = state.get_store(project_id).await;
+    let store = store.read().await;
     match store.get(id) {
         Some(doc) => Ok(Json(DocumentResponse::from(doc))),
         None => Err(AppError::not_found("document not found")),
@@ -66,6 +69,7 @@ fn parse_filetype(filename: &str) -> Result<FileType, String> {
 
 pub async fn ingest_document(
     State(state): State<Arc<AppState>>,
+    Path(project_id): Path<Uuid>,
     NoApi(mut multipart): NoApi<Multipart>,
 ) -> ApiResult<(StatusCode, Json<BatchIngestResponse>)> {
     let mut valid_items: Vec<(Vec<u8>, FileType)> = Vec::new();
@@ -107,7 +111,8 @@ pub async fn ingest_document(
         ));
     }
 
-    let mut store = state.store.write().await;
+    let store = state.get_store(project_id).await;
+    let mut store = store.write().await;
     let result = store
         .ingest_many(valid_items)
         .await
@@ -145,9 +150,10 @@ pub async fn ingest_document(
 
 pub async fn purge_document(
     State(state): State<Arc<AppState>>,
-    Path(id): Path<Uuid>,
+    Path((project_id, id)): Path<(Uuid, Uuid)>,
 ) -> ApiResult<StatusCode> {
-    let mut store = state.store.write().await;
+    let store = state.get_store(project_id).await;
+    let mut store = store.write().await;
     match store
         .purge(id)
         .map_err(|e| AppError::internal(e.to_string()))?
@@ -162,6 +168,7 @@ pub async fn purge_document(
 
 pub async fn purge_documents(
     State(state): State<Arc<AppState>>,
+    Path(project_id): Path<Uuid>,
     Json(payload): Json<BulkPurgeRequest>,
 ) -> ApiResult<(StatusCode, Json<BatchPurgeResponse>)> {
     if payload.ids.is_empty() {
@@ -183,7 +190,8 @@ pub async fn purge_documents(
         }
     }
 
-    let mut store = state.store.write().await;
+    let store = state.get_store(project_id).await;
+    let mut store = store.write().await;
     let result = store.purge_many(ids);
     drop(store);
 

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -37,6 +37,29 @@ pub(crate) fn sandbox_name_for(id: &Uuid) -> String {
     format!("session-{}", &s[..12])
 }
 
+/// Pick the runenv for a session. When `AGENT_K_DISABLE_SANDBOX=1` is set
+/// (local E2E, no microsandbox / docker available), fall back to
+/// `RunEnv::local()`. The coworker's shell/python tools then run on the host
+/// instead of inside a container — fine for local dev, NOT for production.
+pub(crate) async fn build_runenv(
+    state: &Arc<AppState>,
+    project_id: Uuid,
+    session_id: Uuid,
+) -> Result<RunEnv, String> {
+    if std::env::var("AGENT_K_DISABLE_SANDBOX")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        tracing::warn!(
+            project = %project_id,
+            session = %session_id,
+            "AGENT_K_DISABLE_SANDBOX=1 set; using RunEnv::local() (no isolation)"
+        );
+        return Ok(RunEnv::local());
+    }
+    build_sandbox(state, project_id, session_id).await
+}
+
 pub(crate) async fn build_sandbox(
     state: &Arc<AppState>,
     project_id: Uuid,
@@ -68,7 +91,11 @@ pub(crate) async fn build_sandbox(
     RunEnv::sandbox(cfg).await.map_err(|e| e.to_string())
 }
 
-pub(crate) async fn build_agent(runenv: RunEnv) -> Result<Agent, String> {
+pub(crate) async fn build_agent(
+    state: &Arc<AppState>,
+    project_id: Uuid,
+    runenv: RunEnv,
+) -> Result<Agent, String> {
     // TODO: Remove the subagent. This is added for testing frontend UI.
     let math_spec = AgentSpec::new(DEFAULT_MODEL)
         .instruction(
@@ -83,10 +110,35 @@ pub(crate) async fn build_agent(runenv: RunEnv) -> Result<Agent, String> {
             skills: vec![],
         });
 
+    // Speedwagon subagent: answers questions over the project's auto-ingested
+    // document corpus. The corpus is built from files the user has uploaded
+    // via `POST /projects/{id}/dirents` and queued by the ingest worker.
+    let speedwagon_spec = agent_k::agents::SpeedwagonSpec::new()
+        .model(DEFAULT_MODEL)
+        .with_web_search()
+        .card(AgentCard {
+            name: "speedwagon".into(),
+            description: "Answer questions about the documents uploaded to this \
+                project. Use for factual lookups over the uploaded corpus, with \
+                web_search as fallback when the corpus does not cover the question."
+                .into(),
+            skills: vec![],
+        })
+        .into_spec();
+
+    // Per-call AgentProvider: ailoy's default ToolProvider auto-registers the
+    // built-in tools (bash, python_repl, web_search, ...), and we layer the
+    // project's Speedwagon corpus tools on top via `build_tools`. This is the
+    // ToolProvider that both the parent agent and every subagent (math,
+    // speedwagon) see — subagents inherit `provider` from the parent.
+    let store = state.get_store(project_id).await;
+    let mut provider = ailoy::agent::AgentProvider::new();
+    provider.tools = agent_k::agents::build_tools(store);
+
     AgentBuilder::new(DEFAULT_MODEL)
         .instruction(concat!(
             "You are a versatile assistant with access to code execution tools ",
-            "(bash, python), web search, and a math subagent. ",
+            "(bash, python), web search, and two subagents (math, speedwagon). ",
             "Your working directory is /workspace, which is read-write — you can freely ",
             "create, edit, and delete files there for intermediate work, scripts, and results. ",
             "Project files uploaded by the user are available read-only at /workspace/.uploads/. ",
@@ -95,13 +147,19 @@ pub(crate) async fn build_agent(runenv: RunEnv) -> Result<Agent, String> {
             "To modify or analyse uploaded files, copy them into /workspace first. ",
             "New uploads appear in /workspace/.uploads immediately without restarting. ",
             "You MUST delegate ALL math and numeric problems to the math tool. ",
+            "For questions about the contents of uploaded documents (facts, quotes, ",
+            "data from the user's files), delegate to the speedwagon subagent — it ",
+            "has search/find/read tools over the indexed corpus and can fall back to ",
+            "web_search when the corpus does not cover the question. ",
             "Use bash and python tools for computation, data analysis, and code execution tasks. ",
             "Only skip tools for greetings or casual conversation.",
         ))
         .system_tools()
         .web_search_tool(vec![])
+        .provider(provider)
         .runenv(runenv)
         .subagent(math_spec)
+        .subagent(speedwagon_spec)
         .build()
         .map_err(|e| e.to_string())
 }
@@ -179,11 +237,11 @@ async fn resolve_agent_for(
         .map_err(|e| AppError::internal(e.to_string()))?;
     let history: Vec<Message> = rows.into_iter().map(|r| r.message).collect();
 
-    let sandbox = build_sandbox(state, project_id, session_id)
+    let runenv = build_runenv(state, project_id, session_id)
         .await
         .map_err(|e| AppError::internal(e))?;
 
-    let mut agent = build_agent(sandbox)
+    let mut agent = build_agent(state, project_id, runenv)
         .await
         .map_err(|e| AppError::internal(e))?;
 
@@ -223,14 +281,14 @@ pub async fn create_session(
         .map_err(|e| AppError::internal(e.to_string()))?;
 
     let sandbox_name = sandbox_name_for(&session.id);
-    let sandbox = match build_sandbox(&state, project_id, session.id).await {
+    let runenv = match build_runenv(&state, project_id, session.id).await {
         Ok(s) => s,
         Err(e) => {
             let _ = state.repository.delete_session(session.id).await;
             return Err(AppError::internal(e));
         }
     };
-    let agent = match build_agent(sandbox).await {
+    let agent = match build_agent(&state, project_id, runenv).await {
         Ok(a) => a,
         Err(e) => {
             let _ = Sandbox::remove_persisted(&sandbox_name).await;

--- a/backend/src/ingest_worker.rs
+++ b/backend/src/ingest_worker.rs
@@ -1,0 +1,217 @@
+//! Auto-ingest worker. Polls `ingest_jobs` for queued rows, reads the file
+//! from disk, runs `Store::ingest`, and records the resulting document id in
+//! `project_documents`. Mirrors the lease + heartbeat + reaper pattern from
+//! `worker.rs` (automation), simplified — no idempotency keys, no events
+//! table, no per-run cancellation.
+//!
+//! Crash safety: each claimed job has its `lease_until` heartbeated by the
+//! same task that runs the ingest. If the task panics or the process exits,
+//! the housekeeper requeues the row once the lease expires.
+
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use agent_k::knowledge_base::FileType;
+use chrono::Utc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::{repository::DbIngestJob, state::AppState};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const REAP_INTERVAL: Duration = Duration::from_secs(60);
+const LEASE_MINUTES: i64 = 5;
+
+const MAX_ATTEMPTS: i64 = 3;
+
+pub fn spawn_ingest_workers(state: Arc<AppState>, count: usize) {
+    for idx in 0..count {
+        let state = state.clone();
+        tokio::spawn(async move { worker_loop(state, idx).await });
+    }
+    tracing::info!(count, "ingest workers spawned");
+}
+
+pub fn spawn_ingest_housekeeper(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(REAP_INTERVAL);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Discard immediate first tick — let workers run for a moment first.
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+            match state
+                .repository
+                .reap_expired_ingest_jobs(Utc::now())
+                .await
+            {
+                Ok(0) => {}
+                Ok(n) => tracing::warn!(count = n, "ingest reap: requeued expired jobs"),
+                Err(e) => tracing::error!("ingest reap failed: {e}"),
+            }
+        }
+    });
+}
+
+async fn worker_loop(state: Arc<AppState>, idx: usize) {
+    let mut tick = tokio::time::interval(POLL_INTERVAL);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    tracing::info!(worker = idx, "ingest worker started");
+
+    loop {
+        tick.tick().await;
+
+        let lease_until = Utc::now() + chrono::Duration::minutes(LEASE_MINUTES);
+        let job = match state.repository.claim_ingest_job(lease_until).await {
+            Ok(Some(j)) => j,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::error!(worker = idx, "claim failed: {e}");
+                continue;
+            }
+        };
+
+        tracing::info!(
+            worker = idx,
+            job = %job.id,
+            project = %job.project_id,
+            path = %job.source_path,
+            attempt = %job.attempts,
+            "ingest job claimed"
+        );
+
+        let attempts = job.attempts;
+        let job_id = job.id;
+
+        let state_for_hb = state.clone();
+        let hb_token = CancellationToken::new();
+        let hb_token_child = hb_token.clone();
+        let hb_handle = tokio::spawn(async move {
+            heartbeat_loop(state_for_hb, job_id, hb_token_child).await;
+        });
+
+        let result = run_one_ingest(&state, &job).await;
+        hb_token.cancel();
+        let _ = hb_handle.await;
+
+        match result {
+            Ok(document_id) => {
+                match state
+                    .repository
+                    .finalize_ingest_done(job_id, job.project_id, &job.source_path, &document_id)
+                    .await
+                {
+                    Ok(true) => tracing::info!(
+                        worker = idx,
+                        job = %job_id,
+                        doc = %document_id,
+                        "ingest done"
+                    ),
+                    Ok(false) => tracing::warn!(
+                        worker = idx,
+                        job = %job_id,
+                        "finalize_done found no running row (likely reaped)"
+                    ),
+                    Err(e) => tracing::error!(
+                        worker = idx,
+                        job = %job_id,
+                        "finalize_done failed: {e}"
+                    ),
+                }
+            }
+            Err(msg) => {
+                tracing::warn!(
+                    worker = idx,
+                    job = %job_id,
+                    "ingest failed (attempt {attempts}/{MAX_ATTEMPTS}): {msg}"
+                );
+                if attempts >= MAX_ATTEMPTS {
+                    if let Err(e2) =
+                        state.repository.finalize_ingest_failed(job_id, &msg).await
+                    {
+                        tracing::error!(job = %job_id, "finalize_failed errored: {e2}");
+                    }
+                } else {
+                    // Surface the lease so the reaper requeues on the next pass.
+                    if let Err(e2) = state
+                        .repository
+                        .renew_ingest_lease(job_id, Utc::now() - chrono::Duration::seconds(1))
+                        .await
+                    {
+                        tracing::error!(job = %job_id, "fail-requeue errored: {e2}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Periodically renew the lease while the worker is running the ingest.
+async fn heartbeat_loop(
+    state: Arc<AppState>,
+    job_id: Uuid,
+    cancel: CancellationToken,
+) {
+    let mut tick = tokio::time::interval(HEARTBEAT_INTERVAL);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Discard immediate first tick — the claim already set a fresh lease.
+    tick.tick().await;
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => return,
+            _ = tick.tick() => {
+                let new_until = Utc::now() + chrono::Duration::minutes(LEASE_MINUTES);
+                match state.repository.renew_ingest_lease(job_id, new_until).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        tracing::warn!(job = %job_id, "lease lost during heartbeat");
+                        return;
+                    }
+                    Err(e) => {
+                        tracing::error!(job = %job_id, "heartbeat errored: {e}");
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run_one_ingest(state: &Arc<AppState>, job: &DbIngestJob) -> Result<String, String> {
+    let host_path: PathBuf = state
+        .data_root
+        .join("projects")
+        .join(job.project_id.to_string())
+        .join("uploads")
+        .join(&job.source_path);
+
+    let bytes = tokio::fs::read(&host_path)
+        .await
+        .map_err(|e| format!("failed to read {}: {e}", host_path.display()))?;
+
+    let filetype = parse_filetype_for_ingest(&job.source_path)
+        .ok_or_else(|| format!("unsupported file type for {}", job.source_path))?;
+
+    let store = state.get_store(job.project_id).await;
+    let mut store = store.write().await;
+    let document_id = store
+        .ingest(bytes, filetype)
+        .await
+        .map_err(|e| format!("Store::ingest failed: {e}"))?;
+    drop(store);
+
+    Ok(document_id.to_string())
+}
+
+fn parse_filetype_for_ingest(filename: &str) -> Option<FileType> {
+    let ext = filename
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "pdf" => Some(FileType::PDF),
+        "md" | "markdown" | "txt" => Some(FileType::MD),
+        _ => None,
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cron;
 pub mod error;
 pub mod events;
 pub mod handlers;
+pub mod ingest_worker;
 pub mod model;
 pub mod repository;
 pub mod router;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,22 +2,14 @@ mod cli;
 
 use std::{path::PathBuf, sync::Arc};
 
-use agent_k::{
-    agents::{
-        get_calculate_tool_func, get_find_in_document_tool_func, get_search_document_tool_func,
-    },
-    knowledge_base::Store,
-};
-use agent_k_backend::{auth, repository, router, state::AppState, worker};
+use agent_k_backend::{auth, ingest_worker, repository, router, state::AppState, worker};
 use aide::{
     axum::ApiRouter,
     openapi::{Info, OpenApi},
     scalar::Scalar,
 };
-use ailoy::agent::default_provider_mut;
 use axum::{Extension, response::IntoResponse};
 use clap::Parser;
-use tokio::sync::RwLock;
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::cli::{Cli, Command, ServeArgs, ServeMode};
@@ -76,27 +68,12 @@ async fn run_server(mode: ServeMode) -> std::io::Result<()> {
         auth::bootstrap_admin_if_needed(&repo).await;
     }
 
-    let store_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".speedwagon");
-    let store = Arc::new(RwLock::new(
-        Store::new(&store_path).expect("speedwagon store init"),
-    ));
-
-    // Tool registration is required for both modes — workers execute agents
-    // directly, and the API can also drive inline agent invocations.
-    {
-        let mut provider = default_provider_mut();
-        provider
-            .tools
-            .insert_func("calculate", get_calculate_tool_func());
-        provider.tools.insert_func(
-            "search_document",
-            get_search_document_tool_func(store.clone()),
-        );
-        provider.tools.insert_func(
-            "find_in_document",
-            get_find_in_document_tool_func(store.clone()),
-        );
-    }
+    // Per-project Speedwagon stores live under data_root/projects/{id}/.speedwagon
+    // and are created lazily by AppState::get_store. Tools are no longer
+    // registered against the process-wide default provider — build_agent
+    // constructs a per-call provider so each session sees only its project's
+    // corpus. ailoy's default ToolProvider still supplies the built-in
+    // web_search/python/bash factories.
 
     let data_root = std::env::var("AGENT_K_DATA_ROOT")
         .map(PathBuf::from)
@@ -105,7 +82,7 @@ async fn run_server(mode: ServeMode) -> std::io::Result<()> {
     tracing::info!("data root: {}", data_root.display());
     tracing::info!("serve mode: {:?}", mode);
 
-    let app_state = Arc::new(AppState::new(repo, store, jwt, data_root));
+    let app_state = Arc::new(AppState::new(repo, jwt, data_root));
 
     if mode.runs_worker() {
         let worker_count = std::env::var("AGENT_K_WORKER_COUNT")
@@ -115,6 +92,13 @@ async fn run_server(mode: ServeMode) -> std::io::Result<()> {
         worker::spawn_workers(app_state.clone(), worker_count);
         worker::spawn_housekeeper(app_state.clone());
         worker::spawn_cron_ticker(app_state.clone());
+
+        let ingest_worker_count = std::env::var("AGENT_K_INGEST_WORKER_COUNT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1usize);
+        ingest_worker::spawn_ingest_workers(app_state.clone(), ingest_worker_count);
+        ingest_worker::spawn_ingest_housekeeper(app_state.clone());
     }
 
     if mode.runs_api() {

--- a/backend/src/model/ingest.rs
+++ b/backend/src/model/ingest.rs
@@ -1,0 +1,76 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::repository::DbIngestJob;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestStatus {
+    Queued,
+    Running,
+    Done,
+    Failed,
+}
+
+impl IngestStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IngestStatus::Queued => "queued",
+            IngestStatus::Running => "running",
+            IngestStatus::Done => "done",
+            IngestStatus::Failed => "failed",
+        }
+    }
+
+    pub fn from_db(s: &str) -> Result<Self, String> {
+        Ok(match s {
+            "queued" => IngestStatus::Queued,
+            "running" => IngestStatus::Running,
+            "done" => IngestStatus::Done,
+            "failed" => IngestStatus::Failed,
+            other => return Err(format!("invalid ingest_jobs.status: {other}")),
+        })
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct IngestJobResponse {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub source_path: String,
+    pub status: IngestStatus,
+    pub attempts: i64,
+    pub last_error: Option<String>,
+    pub document_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<DbIngestJob> for IngestJobResponse {
+    fn from(j: DbIngestJob) -> Self {
+        Self {
+            id: j.id,
+            project_id: j.project_id,
+            source_path: j.source_path,
+            status: j.status,
+            attempts: j.attempts,
+            last_error: j.last_error,
+            document_id: j.document_id,
+            created_at: j.created_at,
+            updated_at: j.updated_at,
+        }
+    }
+}
+
+/// True for file extensions that the auto-ingest pipeline recognizes.
+/// Mirrors `handlers::document::parse_filetype`.
+pub fn is_ingestable_filename(filename: &str) -> bool {
+    let ext = filename
+        .rsplit('.')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    matches!(ext.as_str(), "pdf" | "md" | "markdown" | "txt")
+}

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -1,6 +1,7 @@
 mod automation;
 mod dirent;
 mod document;
+mod ingest;
 mod project;
 mod session;
 mod user;
@@ -8,6 +9,7 @@ mod user;
 pub use automation::*;
 pub use dirent::*;
 pub use document::*;
+pub use ingest::*;
 pub use project::*;
 pub use session::*;
 pub use user::*;

--- a/backend/src/repository/ingest.rs
+++ b/backend/src/repository/ingest.rs
@@ -1,0 +1,323 @@
+use chrono::{DateTime, SecondsFormat, Utc};
+use sqlx::Row;
+use uuid::Uuid;
+
+use super::SqliteRepository;
+use crate::{
+    model::IngestStatus,
+    repository::{RepositoryError, RepositoryResult},
+};
+
+#[derive(Debug, Clone)]
+pub struct DbIngestJob {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub source_path: String,
+    pub status: IngestStatus,
+    pub attempts: i64,
+    pub last_error: Option<String>,
+    pub lease_until: Option<DateTime<Utc>>,
+    pub document_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DbProjectDocument {
+    pub project_id: Uuid,
+    pub source_path: String,
+    pub document_id: String,
+    pub ingested_at: DateTime<Utc>,
+}
+
+impl SqliteRepository {
+    fn row_to_ingest_job(row: &sqlx::sqlite::SqliteRow) -> RepositoryResult<DbIngestJob> {
+        let id: String = row.try_get("id")?;
+        let project_id: String = row.try_get("project_id")?;
+        let source_path: String = row.try_get("source_path")?;
+        let status: String = row.try_get("status")?;
+        let attempts: i64 = row.try_get("attempts")?;
+        let last_error: Option<String> = row.try_get("last_error")?;
+        let lease_until: Option<String> = row.try_get("lease_until")?;
+        let document_id: Option<String> = row.try_get("document_id")?;
+        let created_at: String = row.try_get("created_at")?;
+        let updated_at: String = row.try_get("updated_at")?;
+
+        Ok(DbIngestJob {
+            id: Uuid::parse_str(&id)
+                .map_err(|e| RepositoryError::InvalidData(format!("ingest_jobs.id: {e}")))?,
+            project_id: Uuid::parse_str(&project_id).map_err(|e| {
+                RepositoryError::InvalidData(format!("ingest_jobs.project_id: {e}"))
+            })?,
+            source_path,
+            status: IngestStatus::from_db(&status).map_err(RepositoryError::InvalidData)?,
+            attempts,
+            last_error,
+            lease_until: lease_until
+                .as_deref()
+                .map(parse_ts)
+                .transpose()?,
+            document_id,
+            created_at: parse_ts(&created_at)?,
+            updated_at: parse_ts(&updated_at)?,
+        })
+    }
+
+    fn row_to_project_document(
+        row: &sqlx::sqlite::SqliteRow,
+    ) -> RepositoryResult<DbProjectDocument> {
+        let project_id: String = row.try_get("project_id")?;
+        let source_path: String = row.try_get("source_path")?;
+        let document_id: String = row.try_get("document_id")?;
+        let ingested_at: String = row.try_get("ingested_at")?;
+        Ok(DbProjectDocument {
+            project_id: Uuid::parse_str(&project_id).map_err(|e| {
+                RepositoryError::InvalidData(format!("project_documents.project_id: {e}"))
+            })?,
+            source_path,
+            document_id,
+            ingested_at: parse_ts(&ingested_at)?,
+        })
+    }
+
+    /// Idempotent enqueue. If a row already exists for (project_id, source_path),
+    /// reset it to `queued` (attempts=0, last_error=NULL) so a re-uploaded file
+    /// goes back through the worker. The returned row is the post-upsert state.
+    pub async fn enqueue_ingest_job(
+        &self,
+        project_id: Uuid,
+        source_path: &str,
+    ) -> RepositoryResult<DbIngestJob> {
+        let now = Self::now_string();
+        let new_id = Uuid::new_v4().to_string();
+
+        sqlx::query(
+            "INSERT INTO ingest_jobs (id, project_id, source_path, status, attempts, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, 'queued', 0, ?4, ?4) \
+             ON CONFLICT(project_id, source_path) DO UPDATE SET \
+                status = 'queued', attempts = 0, last_error = NULL, \
+                lease_until = NULL, document_id = NULL, updated_at = ?4",
+        )
+        .bind(&new_id)
+        .bind(project_id.to_string())
+        .bind(source_path)
+        .bind(&now)
+        .execute(&self.pool)
+        .await?;
+
+        let row = sqlx::query(
+            "SELECT id, project_id, source_path, status, attempts, last_error, lease_until, document_id, created_at, updated_at \
+             FROM ingest_jobs WHERE project_id = ? AND source_path = ?",
+        )
+        .bind(project_id.to_string())
+        .bind(source_path)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Self::row_to_ingest_job(&row)
+    }
+
+    /// Atomic queued→running pickup, oldest first. Mirrors `claim_due_run`.
+    pub async fn claim_ingest_job(
+        &self,
+        lease_until: DateTime<Utc>,
+    ) -> RepositoryResult<Option<DbIngestJob>> {
+        let lease_s = ts_string(lease_until);
+        let updated = Self::now_string();
+        let row = sqlx::query(
+            "UPDATE ingest_jobs SET status='running', lease_until = ?1, attempts = attempts + 1, updated_at = ?2 \
+             WHERE id = ( \
+                SELECT id FROM ingest_jobs WHERE status = 'queued' \
+                ORDER BY created_at ASC LIMIT 1 \
+             ) \
+             RETURNING id, project_id, source_path, status, attempts, last_error, lease_until, document_id, created_at, updated_at",
+        )
+        .bind(&lease_s)
+        .bind(&updated)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.as_ref().map(Self::row_to_ingest_job).transpose()
+    }
+
+    pub async fn renew_ingest_lease(
+        &self,
+        job_id: Uuid,
+        new_lease_until: DateTime<Utc>,
+    ) -> RepositoryResult<bool> {
+        let lease_s = ts_string(new_lease_until);
+        let updated = Self::now_string();
+        let res = sqlx::query(
+            "UPDATE ingest_jobs SET lease_until = ?, updated_at = ? \
+             WHERE id = ? AND status = 'running'",
+        )
+        .bind(&lease_s)
+        .bind(&updated)
+        .bind(job_id.to_string())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Finalize a running job to `done`, recording the resulting document id
+    /// and inserting the project_documents mapping in the same transaction.
+    pub async fn finalize_ingest_done(
+        &self,
+        job_id: Uuid,
+        project_id: Uuid,
+        source_path: &str,
+        document_id: &str,
+    ) -> RepositoryResult<bool> {
+        let mut tx = self.pool.begin().await?;
+        let now = Self::now_string();
+
+        let res = sqlx::query(
+            "UPDATE ingest_jobs SET status='done', document_id = ?, lease_until = NULL, last_error = NULL, updated_at = ? \
+             WHERE id = ? AND status = 'running'",
+        )
+        .bind(document_id)
+        .bind(&now)
+        .bind(job_id.to_string())
+        .execute(&mut *tx)
+        .await?;
+
+        if res.rows_affected() != 1 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        sqlx::query(
+            "INSERT INTO project_documents (project_id, source_path, document_id, ingested_at) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(project_id, source_path) DO UPDATE SET \
+                document_id = ?3, ingested_at = ?4",
+        )
+        .bind(project_id.to_string())
+        .bind(source_path)
+        .bind(document_id)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    pub async fn finalize_ingest_failed(
+        &self,
+        job_id: Uuid,
+        error: &str,
+    ) -> RepositoryResult<bool> {
+        let now = Self::now_string();
+        let res = sqlx::query(
+            "UPDATE ingest_jobs SET status='failed', last_error = ?, lease_until = NULL, updated_at = ? \
+             WHERE id = ? AND status = 'running'",
+        )
+        .bind(error)
+        .bind(&now)
+        .bind(job_id.to_string())
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Reap running jobs whose lease has expired — put them back into `queued`.
+    /// Returns the number of rows reaped.
+    pub async fn reap_expired_ingest_jobs(
+        &self,
+        now: DateTime<Utc>,
+    ) -> RepositoryResult<u64> {
+        let now_s = ts_string(now);
+        let updated = Self::now_string();
+        let res = sqlx::query(
+            "UPDATE ingest_jobs SET status='queued', lease_until = NULL, updated_at = ? \
+             WHERE status='running' AND lease_until IS NOT NULL AND lease_until < ?",
+        )
+        .bind(&updated)
+        .bind(&now_s)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
+    }
+
+    pub async fn list_ingest_jobs_for_project(
+        &self,
+        project_id: Uuid,
+    ) -> RepositoryResult<Vec<DbIngestJob>> {
+        let rows = sqlx::query(
+            "SELECT id, project_id, source_path, status, attempts, last_error, lease_until, document_id, created_at, updated_at \
+             FROM ingest_jobs WHERE project_id = ? ORDER BY created_at DESC",
+        )
+        .bind(project_id.to_string())
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter().map(Self::row_to_ingest_job).collect()
+    }
+
+    pub async fn get_project_document(
+        &self,
+        project_id: Uuid,
+        source_path: &str,
+    ) -> RepositoryResult<Option<DbProjectDocument>> {
+        let row = sqlx::query(
+            "SELECT project_id, source_path, document_id, ingested_at \
+             FROM project_documents WHERE project_id = ? AND source_path = ?",
+        )
+        .bind(project_id.to_string())
+        .bind(source_path)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.as_ref().map(Self::row_to_project_document).transpose()
+    }
+
+    /// Remove the mapping and its ingest_job in one transaction. The caller is
+    /// responsible for removing the actual document from the agent-k Store
+    /// — that side effect lives in handler code where the Store is in scope.
+    pub async fn delete_project_document(
+        &self,
+        project_id: Uuid,
+        source_path: &str,
+    ) -> RepositoryResult<Option<String>> {
+        let mut tx = self.pool.begin().await?;
+
+        let row = sqlx::query(
+            "SELECT document_id FROM project_documents \
+             WHERE project_id = ? AND source_path = ?",
+        )
+        .bind(project_id.to_string())
+        .bind(source_path)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let document_id: Option<String> = row.map(|r| r.get("document_id"));
+
+        sqlx::query(
+            "DELETE FROM project_documents WHERE project_id = ? AND source_path = ?",
+        )
+        .bind(project_id.to_string())
+        .bind(source_path)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "DELETE FROM ingest_jobs WHERE project_id = ? AND source_path = ?",
+        )
+        .bind(project_id.to_string())
+        .bind(source_path)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(document_id)
+    }
+}
+
+fn parse_ts(s: &str) -> RepositoryResult<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| RepositoryError::InvalidData(format!("invalid timestamp '{s}': {e}")))
+}
+
+fn ts_string(ts: DateTime<Utc>) -> String {
+    ts.to_rfc3339_opts(SecondsFormat::Millis, true)
+}

--- a/backend/src/repository/mod.rs
+++ b/backend/src/repository/mod.rs
@@ -1,4 +1,5 @@
 mod automation;
+mod ingest;
 mod project;
 mod session;
 mod sqlite;
@@ -8,6 +9,7 @@ use std::{sync::Arc, time::Duration};
 pub use automation::{
     DbAutomation, DbAutomationRun, DbAutomationRunEvent, DbAutomationTrigger,
 };
+pub use ingest::{DbIngestJob, DbProjectDocument};
 pub use project::{DbProject, DbProjectMember};
 pub use session::{
     DbSenderKind, DbSession, DbSessionMessage, NewSessionMessage, SessionAccess, SessionOrigin,

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -147,15 +147,19 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
 
     let document_routes = ApiRouter::new()
         .api_route(
-            "/documents",
+            "/projects/{project_id}/documents",
             get(handlers::list_documents)
                 .post(handlers::ingest_document)
                 .delete(handlers::purge_documents),
         )
         .api_route(
-            "/documents/{id}",
+            "/projects/{project_id}/documents/{id}",
             get(handlers::get_document).delete(handlers::purge_document),
-        );
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth_required,
+        ));
 
     // Auth-exempt route: webhook firing is gated only on the bearer token.
     // The token IS the identifier — trigger is resolved by its stored hash,

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,17 +1,18 @@
 use std::{path::PathBuf, sync::Arc};
 
-use agent_k::knowledge_base::SharedStore;
+use agent_k::knowledge_base::{SharedStore, Store};
 use ailoy::agent::Agent;
 use dashmap::DashMap;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, RwLock, broadcast};
 use uuid::Uuid;
 
 use crate::{auth::JwtConfig, events::WsEvent, repository::AppRepository};
 
 pub struct AppState {
     agents: DashMap<Uuid, Arc<Mutex<Agent>>>,
+    /// Per-project Speedwagon stores. Lazily created on first `get_store`.
+    stores: DashMap<Uuid, SharedStore>,
     pub repository: AppRepository,
-    pub store: SharedStore,
     pub jwt: JwtConfig,
     pub data_root: PathBuf,
     pub max_upload_bytes: usize,
@@ -19,12 +20,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(
-        repository: AppRepository,
-        store: SharedStore,
-        jwt: JwtConfig,
-        data_root: PathBuf,
-    ) -> Self {
+    pub fn new(repository: AppRepository, jwt: JwtConfig, data_root: PathBuf) -> Self {
         let max_upload_bytes = std::env::var("AGENT_K_MAX_UPLOAD_BYTES")
             .ok()
             .and_then(|v| {
@@ -40,8 +36,8 @@ impl AppState {
         let (ws_tx, _) = broadcast::channel(128);
         Self {
             agents: DashMap::new(),
+            stores: DashMap::new(),
             repository,
-            store,
             jwt,
             data_root,
             max_upload_bytes,
@@ -59,5 +55,31 @@ impl AppState {
 
     pub fn get_agent(&self, id: &Uuid) -> Option<Arc<Mutex<Agent>>> {
         self.agents.get(id).map(|entry| entry.value().clone())
+    }
+
+    /// Return the per-project Speedwagon `Store`, creating it on first access.
+    /// Index lives under `<data_root>/projects/{id}/.speedwagon`.
+    ///
+    /// Panics if the index directory cannot be created or opened — at boot
+    /// the parent `projects/{id}` directory is already set up by the project
+    /// handler, so the only realistic failure is a corrupt on-disk index that
+    /// the agent-k Store auto-rebuild cannot recover from.
+    pub async fn get_store(&self, project_id: Uuid) -> SharedStore {
+        if let Some(s) = self.stores.get(&project_id) {
+            return s.value().clone();
+        }
+        let path = self
+            .data_root
+            .join("projects")
+            .join(project_id.to_string())
+            .join(".speedwagon");
+        let store = Store::new(&path)
+            .unwrap_or_else(|e| panic!("failed to open Speedwagon store at {path:?}: {e}"));
+        let shared: SharedStore = Arc::new(RwLock::new(store));
+        let entry = self
+            .stores
+            .entry(project_id)
+            .or_insert_with(|| shared.clone());
+        entry.value().clone()
     }
 }

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use crate::{
     cron::next_fire_after,
-    handlers::session::{attribute_messages, build_agent, build_sandbox},
+    handlers::session::{attribute_messages, build_agent, build_runenv},
     model::{EventKind, RunStatus, TriggerSpec},
     repository::DbAutomationRun,
     state::AppState,
@@ -395,8 +395,8 @@ async fn execute_run(
         .await
         .map_err(|e| e.to_string())?;
 
-    let sandbox = build_sandbox(state, automation.project_id, run.session_id).await?;
-    let agent = build_agent(sandbox).await?;
+    let runenv = build_runenv(state, automation.project_id, run.session_id).await?;
+    let agent = build_agent(state, automation.project_id, runenv).await?;
     state.insert_agent(run.session_id, agent);
 
     for (idx, prompt) in automation.prompts.iter().enumerate() {

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -60,22 +60,15 @@ pub fn make_test_store() -> agent_k::knowledge_base::SharedStore {
 
 pub async fn make_app_repo_state() -> (axum::Router, repository::AppRepository, Arc<AppState>) {
     let repo = make_repo().await;
-    let store = make_test_store();
     let data_root = std::env::temp_dir().join(format!("agent-k-test-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(
-        repo.clone(),
-        store,
-        test_jwt_config(),
-        data_root,
-    ));
+    let state = Arc::new(AppState::new(repo.clone(), test_jwt_config(), data_root));
     let app = make_app_with_state(state.clone());
     (app, repo, state)
 }
 
 pub fn make_app_with_repo(repo: repository::AppRepository) -> axum::Router {
-    let store = make_test_store();
     let data_root = std::env::temp_dir().join(format!("agent-k-test-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(repo, store, test_jwt_config(), data_root));
+    let state = Arc::new(AppState::new(repo, test_jwt_config(), data_root));
     make_app_with_state(state)
 }
 
@@ -490,10 +483,15 @@ pub async fn clear_message_history_status(
 
 // ── Document helpers ─────────────────────────────────────────────────────────
 
-pub async fn list_documents(app: &axum::Router) -> Vec<serde_json::Value> {
+pub async fn list_documents(
+    app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
+) -> Vec<serde_json::Value> {
     let req = Request::builder()
         .method("GET")
-        .uri("/documents")
+        .uri(format!("/projects/{project_id}/documents"))
+        .header("authorization", format!("Bearer {token}"))
         .body(Body::empty())
         .unwrap();
 
@@ -525,10 +523,12 @@ pub fn build_multipart_body(files: &[(&str, &[u8])]) -> (String, Vec<u8>) {
 /// Ingest a single file and return the first succeeded document.
 pub async fn ingest_document(
     app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
     filename: &str,
     content: &[u8],
 ) -> serde_json::Value {
-    let batch = ingest_documents(app, &[(filename, content)]).await;
+    let batch = ingest_documents(app, token, project_id, &[(filename, content)]).await;
     let succeeded = batch["succeeded"]
         .as_array()
         .expect("succeeded should be array");
@@ -541,27 +541,37 @@ pub async fn ingest_document(
 }
 
 /// Ingest multiple files and return the full BatchIngestResponse.
-pub async fn ingest_documents(app: &axum::Router, files: &[(&str, &[u8])]) -> serde_json::Value {
-    post_documents(app, files).await.1
+pub async fn ingest_documents(
+    app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
+    files: &[(&str, &[u8])],
+) -> serde_json::Value {
+    post_documents(app, token, project_id, files).await.1
 }
 
 /// Ingest files and also return the HTTP status code.
 pub async fn ingest_documents_with_status(
     app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
     files: &[(&str, &[u8])],
 ) -> (axum::http::StatusCode, serde_json::Value) {
-    post_documents(app, files).await
+    post_documents(app, token, project_id, files).await
 }
 
 async fn post_documents(
     app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
     files: &[(&str, &[u8])],
 ) -> (axum::http::StatusCode, serde_json::Value) {
     let (boundary, body) = build_multipart_body(files);
 
     let req = Request::builder()
         .method("POST")
-        .uri("/documents")
+        .uri(format!("/projects/{project_id}/documents"))
+        .header("authorization", format!("Bearer {token}"))
         .header(
             "content-type",
             format!("multipart/form-data; boundary={boundary}"),
@@ -572,13 +582,22 @@ async fn post_documents(
     let resp = app.clone().oneshot(req).await.unwrap();
     let status = resp.status();
     let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    (status, serde_json::from_slice(&bytes).unwrap())
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+    )
 }
 
-pub async fn purge_document(app: &axum::Router, id: &str) -> axum::http::StatusCode {
+pub async fn purge_document(
+    app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
+    id: &str,
+) -> axum::http::StatusCode {
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/documents/{id}"))
+        .uri(format!("/projects/{project_id}/documents/{id}"))
+        .header("authorization", format!("Bearer {token}"))
         .body(Body::empty())
         .unwrap();
 
@@ -587,12 +606,15 @@ pub async fn purge_document(app: &axum::Router, id: &str) -> axum::http::StatusC
 
 pub async fn bulk_purge_documents(
     app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
     ids: &[&str],
 ) -> (axum::http::StatusCode, serde_json::Value) {
     let payload = serde_json::json!({ "ids": ids });
     let req = Request::builder()
         .method("DELETE")
-        .uri("/documents")
+        .uri(format!("/projects/{project_id}/documents"))
+        .header("authorization", format!("Bearer {token}"))
         .header("content-type", "application/json")
         .body(Body::from(serde_json::to_vec(&payload).unwrap()))
         .unwrap();
@@ -608,11 +630,14 @@ pub async fn bulk_purge_documents(
 
 pub async fn get_document(
     app: &axum::Router,
+    token: &str,
+    project_id: uuid::Uuid,
     id: &str,
 ) -> (axum::http::StatusCode, serde_json::Value) {
     let req = Request::builder()
         .method("GET")
-        .uri(format!("/documents/{id}"))
+        .uri(format!("/projects/{project_id}/documents/{id}"))
+        .header("authorization", format!("Bearer {token}"))
         .body(Body::empty())
         .unwrap();
 

--- a/backend/tests/dirent_test.rs
+++ b/backend/tests/dirent_test.rs
@@ -15,10 +15,9 @@ use tower::ServiceExt;
 async fn make_state_with_dir() -> (Arc<AppState>, TempDir) {
     let tmp = TempDir::new().unwrap();
     let repo = common::make_repo().await;
-    let store = common::make_test_store();
+    let _ = common::make_test_store();
     let state = Arc::new(AppState::new(
         repo,
-        store,
         common::test_jwt_config(),
         tmp.path().to_path_buf(),
     ));
@@ -28,14 +27,9 @@ async fn make_state_with_dir() -> (Arc<AppState>, TempDir) {
 async fn make_state_with_dir_and_max_bytes(max_bytes: usize) -> (Arc<AppState>, TempDir) {
     let tmp = TempDir::new().unwrap();
     let repo = common::make_repo().await;
-    let store = common::make_test_store();
+    let _ = common::make_test_store();
     // Build AppState directly with a custom max_upload_bytes to avoid env var races.
-    let mut state = AppState::new(
-        repo,
-        store,
-        common::test_jwt_config(),
-        tmp.path().to_path_buf(),
-    );
+    let mut state = AppState::new(repo, common::test_jwt_config(), tmp.path().to_path_buf());
     // Patch the field via a builder approach — we expose the field publicly,
     // so just overwrite it after construction.
     state.max_upload_bytes = max_bytes;

--- a/backend/tests/document_test.rs
+++ b/backend/tests/document_test.rs
@@ -1,50 +1,70 @@
+//! Project-scoped document tests. The /documents endpoints moved under
+//! /projects/{project_id}/documents in commit 4 — every test now signs up a
+//! user, picks up their personal project, and operates on that project's
+//! Store via the project-scoped routes.
+
 #[path = "common/mod.rs"]
 mod common;
 
 use axum::http::StatusCode;
 use common::{
-    bulk_purge_documents, get_document, ingest_document, ingest_documents_with_status,
-    list_documents, make_app_with_repo, make_repo, purge_document,
+    bulk_purge_documents, get_document, get_personal_project, ingest_document,
+    ingest_documents_with_status, list_documents, login, make_app_with_repo, make_repo,
+    purge_document, signup,
 };
 use http_body_util::BodyExt;
 use tower::ServiceExt;
+use uuid::Uuid;
+
+/// Sign up a fresh user, log in, and resolve their personal project. Returns
+/// `(app, token, project_id)` ready to be passed to the document helpers.
+async fn fresh_app() -> (axum::Router, String, Uuid) {
+    let repo = make_repo().await;
+    let app = make_app_with_repo(repo);
+    let username = format!("doc_user_{}", Uuid::new_v4().simple());
+    let _ = signup(&app, &username, "test-password-123").await;
+    let token = login(&app, &username, "test-password-123").await;
+    let project = get_personal_project(&app, &token).await;
+    let project_id: Uuid = project["id"]
+        .as_str()
+        .expect("project.id")
+        .parse()
+        .expect("uuid");
+    (app, token, project_id)
+}
 
 #[tokio::test]
 async fn list_documents_empty_initially() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
-
-    let docs = list_documents(&app).await;
+    let (app, token, project_id) = fresh_app().await;
+    let docs = list_documents(&app, &token, project_id).await;
     assert!(docs.is_empty());
 }
 
 #[tokio::test]
 async fn ingest_and_list_document() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let content = b"# Test Document\n\nThis is test content for indexing.";
-    let doc = ingest_document(&app, "test.md", content).await;
+    let doc = ingest_document(&app, &token, project_id, "test.md", content).await;
 
     assert!(doc.get("id").is_some(), "response should contain id");
     assert!(doc.get("title").is_some(), "response should contain title");
     assert!(doc.get("len").is_some(), "response should contain len");
 
-    let docs = list_documents(&app).await;
+    let docs = list_documents(&app, &token, project_id).await;
     assert_eq!(docs.len(), 1);
     assert_eq!(docs[0]["id"], doc["id"]);
 }
 
 #[tokio::test]
 async fn get_document_by_id() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let content = b"# Getting by ID\n\nSome content here.";
-    let created = ingest_document(&app, "get-test.md", content).await;
+    let created = ingest_document(&app, &token, project_id, "get-test.md", content).await;
     let id = created["id"].as_str().unwrap();
 
-    let (status, fetched) = get_document(&app, id).await;
+    let (status, fetched) = get_document(&app, &token, project_id, id).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(fetched["id"].as_str().unwrap(), id);
     assert_eq!(fetched["title"].as_str(), created["title"].as_str());
@@ -52,51 +72,45 @@ async fn get_document_by_id() {
 
 #[tokio::test]
 async fn get_nonexistent_document_returns_404() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
-
-    let fake_id = uuid::Uuid::new_v4();
-    let (status, _) = get_document(&app, &fake_id.to_string()).await;
+    let (app, token, project_id) = fresh_app().await;
+    let fake_id = Uuid::new_v4();
+    let (status, _) = get_document(&app, &token, project_id, &fake_id.to_string()).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn purge_document_removes_it() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let content = b"# To Be Purged\n\nThis document will be deleted.";
-    let doc = ingest_document(&app, "purge-me.md", content).await;
+    let doc = ingest_document(&app, &token, project_id, "purge-me.md", content).await;
     let id = doc["id"].as_str().unwrap();
 
-    let status = purge_document(&app, id).await;
+    let status = purge_document(&app, &token, project_id, id).await;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
-    let docs = list_documents(&app).await;
+    let docs = list_documents(&app, &token, project_id).await;
     assert!(docs.is_empty(), "document list should be empty after purge");
 
-    let (status, _) = get_document(&app, id).await;
+    let (status, _) = get_document(&app, &token, project_id, id).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn purge_nonexistent_returns_404() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
-
-    let fake_id = uuid::Uuid::new_v4();
-    let status = purge_document(&app, &fake_id.to_string()).await;
+    let (app, token, project_id) = fresh_app().await;
+    let fake_id = Uuid::new_v4();
+    let status = purge_document(&app, &token, project_id, &fake_id.to_string()).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn ingest_duplicate_returns_same_id() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let content = b"# Duplicate Test\n\nSame content, same ID.";
-    let doc1 = ingest_document(&app, "dup1.md", content).await;
-    let doc2 = ingest_document(&app, "dup2.md", content).await;
+    let doc1 = ingest_document(&app, &token, project_id, "dup1.md", content).await;
+    let doc2 = ingest_document(&app, &token, project_id, "dup2.md", content).await;
 
     assert_eq!(
         doc1["id"].as_str().unwrap(),
@@ -104,7 +118,7 @@ async fn ingest_duplicate_returns_same_id() {
         "same content should produce same UUID (UUIDv5)"
     );
 
-    let docs = list_documents(&app).await;
+    let docs = list_documents(&app, &token, project_id).await;
     assert_eq!(
         docs.len(),
         1,
@@ -116,29 +130,27 @@ async fn ingest_duplicate_returns_same_id() {
 
 #[tokio::test]
 async fn ingest_multiple_documents() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let files: &[(&str, &[u8])] = &[
         ("doc1.md", b"# Document One\n\nFirst document."),
         ("doc2.txt", b"# Document Two\n\nSecond document."),
     ];
 
-    let (status, batch) = ingest_documents_with_status(&app, files).await;
+    let (status, batch) = ingest_documents_with_status(&app, &token, project_id, files).await;
     assert_eq!(status, StatusCode::CREATED);
 
     let succeeded = batch["succeeded"].as_array().unwrap();
     assert_eq!(succeeded.len(), 2);
     assert!(batch["failed"].as_array().unwrap().is_empty());
 
-    let docs = list_documents(&app).await;
+    let docs = list_documents(&app, &token, project_id).await;
     assert_eq!(docs.len(), 2);
 }
 
 #[tokio::test]
 async fn ingest_partial_failure_mixed_filetypes() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let files: &[(&str, &[u8])] = &[
         ("good.md", b"# Good Document\n\nValid markdown."),
@@ -146,7 +158,7 @@ async fn ingest_partial_failure_mixed_filetypes() {
         ("also-good.txt", b"# Another Good\n\nAlso valid."),
     ];
 
-    let (status, batch) = ingest_documents_with_status(&app, files).await;
+    let (status, batch) = ingest_documents_with_status(&app, &token, project_id, files).await;
     assert_eq!(status, StatusCode::OK, "partial success should return 200");
 
     let succeeded = batch["succeeded"].as_array().unwrap();
@@ -158,12 +170,11 @@ async fn ingest_partial_failure_mixed_filetypes() {
 
 #[tokio::test]
 async fn ingest_all_unsupported_returns_empty_succeeded() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let files: &[(&str, &[u8])] = &[("data.csv", b"a,b,c")];
 
-    let (status, batch) = ingest_documents_with_status(&app, files).await;
+    let (status, batch) = ingest_documents_with_status(&app, &token, project_id, files).await;
     assert_eq!(status, StatusCode::OK);
 
     let succeeded = batch["succeeded"].as_array().unwrap();
@@ -174,15 +185,15 @@ async fn ingest_all_unsupported_returns_empty_succeeded() {
 
 #[tokio::test]
 async fn ingest_no_file_field_returns_400() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let boundary = "----testboundary";
     let body = format!("--{boundary}--\r\n");
 
     let req = axum::http::Request::builder()
         .method("POST")
-        .uri("/documents")
+        .uri(format!("/projects/{project_id}/documents"))
+        .header("authorization", format!("Bearer {token}"))
         .header(
             "content-type",
             format!("multipart/form-data; boundary={boundary}"),
@@ -196,8 +207,7 @@ async fn ingest_no_file_field_returns_400() {
 
 #[tokio::test]
 async fn ingest_malformed_multipart_after_valid_file_returns_400() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
     let boundary = "----testboundary";
     let body = format!(
@@ -213,7 +223,8 @@ async fn ingest_malformed_multipart_after_valid_file_returns_400() {
 
     let req = axum::http::Request::builder()
         .method("POST")
-        .uri("/documents")
+        .uri(format!("/projects/{project_id}/documents"))
+        .header("authorization", format!("Bearer {token}"))
         .header(
             "content-type",
             format!("multipart/form-data; boundary={boundary}"),
@@ -238,35 +249,33 @@ async fn ingest_malformed_multipart_after_valid_file_returns_400() {
 
 #[tokio::test]
 async fn bulk_purge_multiple_documents() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
-    let doc1 = ingest_document(&app, "a.md", b"# Doc A\n\nContent A.").await;
-    let doc2 = ingest_document(&app, "b.md", b"# Doc B\n\nContent B.").await;
+    let doc1 = ingest_document(&app, &token, project_id, "a.md", b"# Doc A\n\nContent A.").await;
+    let doc2 = ingest_document(&app, &token, project_id, "b.md", b"# Doc B\n\nContent B.").await;
     let id1 = doc1["id"].as_str().unwrap();
     let id2 = doc2["id"].as_str().unwrap();
 
-    let (status, resp) = bulk_purge_documents(&app, &[id1, id2]).await;
+    let (status, resp) = bulk_purge_documents(&app, &token, project_id, &[id1, id2]).await;
     assert_eq!(status, StatusCode::OK);
 
     let purged = resp["purged"].as_array().unwrap();
     assert_eq!(purged.len(), 2);
     assert!(resp["failed"].as_array().unwrap().is_empty());
 
-    let docs = list_documents(&app).await;
+    let docs = list_documents(&app, &token, project_id).await;
     assert!(docs.is_empty());
 }
 
 #[tokio::test]
 async fn bulk_purge_partial_failure() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
-    let doc = ingest_document(&app, "c.md", b"# Doc C\n\nContent C.").await;
+    let doc = ingest_document(&app, &token, project_id, "c.md", b"# Doc C\n\nContent C.").await;
     let real_id = doc["id"].as_str().unwrap();
-    let fake_id = uuid::Uuid::new_v4().to_string();
+    let fake_id = Uuid::new_v4().to_string();
 
-    let (status, resp) = bulk_purge_documents(&app, &[real_id, &fake_id]).await;
+    let (status, resp) = bulk_purge_documents(&app, &token, project_id, &[real_id, &fake_id]).await;
     assert_eq!(status, StatusCode::OK);
 
     let purged = resp["purged"].as_array().unwrap();
@@ -278,14 +287,15 @@ async fn bulk_purge_partial_failure() {
 
 #[tokio::test]
 async fn bulk_purge_invalid_id_is_item_failure() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
-    let doc = ingest_document(&app, "valid.md", b"# Valid\n\nContent.").await;
+    let doc =
+        ingest_document(&app, &token, project_id, "valid.md", b"# Valid\n\nContent.").await;
     let real_id = doc["id"].as_str().unwrap();
     let invalid_id = "not-a-uuid";
 
-    let (status, resp) = bulk_purge_documents(&app, &[real_id, invalid_id]).await;
+    let (status, resp) =
+        bulk_purge_documents(&app, &token, project_id, &[real_id, invalid_id]).await;
     assert_eq!(status, StatusCode::OK);
 
     let purged = resp["purged"].as_array().unwrap();
@@ -304,9 +314,8 @@ async fn bulk_purge_invalid_id_is_item_failure() {
 
 #[tokio::test]
 async fn bulk_purge_empty_ids_returns_400() {
-    let repo = make_repo().await;
-    let app = make_app_with_repo(repo);
+    let (app, token, project_id) = fresh_app().await;
 
-    let (status, _) = bulk_purge_documents(&app, &[]).await;
+    let (status, _) = bulk_purge_documents(&app, &token, project_id, &[]).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }

--- a/backend/tests/e2e_test.rs
+++ b/backend/tests/e2e_test.rs
@@ -3,7 +3,6 @@ mod common;
 
 use std::sync::Arc;
 
-use agent_k::{agents::build_tools, knowledge_base::Store};
 use agent_k_backend::{repository, router::get_router, state::AppState};
 use aide::openapi::OpenApi;
 use ailoy::{agent::default_provider_mut, lang_model::LangModelProvider};
@@ -12,18 +11,17 @@ use common::{
     bulk_purge_documents, extract_text, get_personal_project, ingest_documents, list_documents,
     login, post_session_authed, send_message, signup, test_jwt_config,
 };
-use tokio::sync::RwLock;
 
 #[tokio::test]
 #[ignore = "requires OPENAI_API_KEY"]
 async fn test_ingest_message_purge_cycle() {
     dotenvy::dotenv().ok();
 
-    let store_path = std::env::temp_dir().join(format!("agent-k-e2e-{}", uuid::Uuid::new_v4()));
-    let store = Arc::new(RwLock::new(
-        Store::new(store_path).expect("test store init"),
-    ));
-
+    // Pre-multi-tenancy: this test predates per-project Stores and the
+    // build_agent-owned provider. Models are still registered against the
+    // default LangModelProvider so `build_agent` can resolve them; tools are
+    // built per-call inside `build_agent` from `AppState::get_store(...)`, so
+    // we no longer prime `default_provider_mut().tools`.
     {
         let mut provider = default_provider_mut();
         if let Ok(key) = std::env::var("OPENAI_API_KEY") {
@@ -31,19 +29,29 @@ async fn test_ingest_message_purge_cycle() {
                 .models
                 .insert("openai/*".into(), LangModelProvider::openai(key));
         }
-        provider.tools = build_tools(store.clone());
     }
 
     let repo = repository::create_repository("sqlite::memory:")
         .await
         .expect("test repo init");
     let data_root = std::env::temp_dir().join(format!("agent-k-e2e-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(repo, store, test_jwt_config(), data_root));
+    let state = Arc::new(AppState::new(repo, test_jwt_config(), data_root));
     let app = get_router(state).finish_api(&mut OpenApi::default());
 
-    // ── Ingest two documents via multipart ───────────────────────────────────
+    // ── Create user, project, session ────────────────────────────────────────
+    let username = format!("user_{}", uuid::Uuid::new_v4().simple());
+    signup(&app, &username, "Password123!").await;
+    let token = login(&app, &username, "Password123!").await;
+    let project = get_personal_project(&app, &token).await;
+    let project_id_str = project["id"].as_str().unwrap();
+    let project_id: uuid::Uuid = project_id_str.parse().expect("project id is a Uuid");
+    let session_id = post_session_authed(&app, &token, project_id_str).await;
+
+    // ── Ingest two documents into this project's Store ──────────────────────
     let batch = ingest_documents(
         &app,
+        &token,
+        project_id,
         &[
             (
                 "freedonia.md",
@@ -62,14 +70,6 @@ async fn test_ingest_message_purge_cycle() {
         .iter()
         .map(|d| d["id"].as_str().unwrap())
         .collect();
-
-    // ── Create user and session ──────────────────────────────────────────────
-    let username = format!("user_{}", uuid::Uuid::new_v4().simple());
-    signup(&app, &username, "Password123!").await;
-    let token = login(&app, &username, "Password123!").await;
-    let project = get_personal_project(&app, &token).await;
-    let project_id = project["id"].as_str().unwrap();
-    let session_id = post_session_authed(&app, &token, project_id).await;
 
     // ── Question about document 1 (Freedonia) ────────────────────────────────
     let outputs = send_message(
@@ -100,13 +100,14 @@ async fn test_ingest_message_purge_cycle() {
     );
 
     // ── Bulk purge both documents ─────────────────────────────────────────────
-    let (purge_status, purge_resp) = bulk_purge_documents(&app, &doc_ids).await;
+    let (purge_status, purge_resp) =
+        bulk_purge_documents(&app, &token, project_id, &doc_ids).await;
     assert_eq!(purge_status, StatusCode::OK);
     let purged = purge_resp["purged"].as_array().unwrap();
     assert_eq!(purged.len(), 2, "both documents should be purged");
 
     // ── Verify documents are gone ────────────────────────────────────────────
-    let docs = list_documents(&app).await;
+    let docs = list_documents(&app, &token, project_id).await;
     assert!(docs.is_empty(), "document list should be empty after purge");
 
     // ── Post-purge question (agent should still respond, just without KB) ────

--- a/backend/tests/multi_tenancy_test.rs
+++ b/backend/tests/multi_tenancy_test.rs
@@ -1,0 +1,218 @@
+//! Multi-tenancy unit tests for the per-project Speedwagon store and the
+//! ingest_jobs / project_documents repository tables.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::sync::Arc;
+
+use agent_k_backend::{model::IngestStatus, state::AppState};
+use chrono::Utc;
+use uuid::Uuid;
+
+fn temp_data_root() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("agent-k-mt-{}", Uuid::new_v4()))
+}
+
+#[tokio::test]
+async fn get_store_returns_same_instance_for_same_project() {
+    let repo = common::make_repo().await;
+    let state = Arc::new(AppState::new(repo, common::test_jwt_config(), temp_data_root()));
+    let project_id = Uuid::new_v4();
+
+    let s1 = state.get_store(project_id).await;
+    let s2 = state.get_store(project_id).await;
+    assert!(
+        Arc::ptr_eq(&s1, &s2),
+        "second call should hand out the cached Arc"
+    );
+}
+
+#[tokio::test]
+async fn get_store_returns_distinct_instances_per_project() {
+    let repo = common::make_repo().await;
+    let state = Arc::new(AppState::new(repo, common::test_jwt_config(), temp_data_root()));
+    let s1 = state.get_store(Uuid::new_v4()).await;
+    let s2 = state.get_store(Uuid::new_v4()).await;
+    assert!(
+        !Arc::ptr_eq(&s1, &s2),
+        "different project ids must yield different stores"
+    );
+}
+
+#[tokio::test]
+async fn enqueue_creates_queued_job() {
+    let repo = common::make_repo().await;
+    let project_id = seed_project(&repo).await;
+
+    let job = repo
+        .enqueue_ingest_job(project_id, "alpha.pdf")
+        .await
+        .expect("enqueue");
+    assert_eq!(job.project_id, project_id);
+    assert_eq!(job.source_path, "alpha.pdf");
+    assert_eq!(job.status, IngestStatus::Queued);
+    assert_eq!(job.attempts, 0);
+}
+
+#[tokio::test]
+async fn enqueue_is_idempotent_per_path() {
+    let repo = common::make_repo().await;
+    let project_id = seed_project(&repo).await;
+
+    let a = repo
+        .enqueue_ingest_job(project_id, "doc.md")
+        .await
+        .expect("first enqueue");
+    let b = repo
+        .enqueue_ingest_job(project_id, "doc.md")
+        .await
+        .expect("second enqueue");
+    assert_eq!(a.id, b.id, "re-enqueue must update the same row");
+
+    let jobs = repo
+        .list_ingest_jobs_for_project(project_id)
+        .await
+        .expect("list");
+    assert_eq!(jobs.len(), 1, "no duplicate row should be created");
+}
+
+#[tokio::test]
+async fn claim_then_finalize_done_writes_project_document() {
+    let repo = common::make_repo().await;
+    let project_id = seed_project(&repo).await;
+
+    let _enqueued = repo
+        .enqueue_ingest_job(project_id, "report.pdf")
+        .await
+        .expect("enqueue");
+
+    let claimed = repo
+        .claim_ingest_job(Utc::now() + chrono::Duration::minutes(5))
+        .await
+        .expect("claim")
+        .expect("a job should be available");
+    assert_eq!(claimed.status, IngestStatus::Running);
+    assert_eq!(claimed.attempts, 1);
+
+    let document_id = Uuid::new_v4().to_string();
+    let ok = repo
+        .finalize_ingest_done(claimed.id, project_id, "report.pdf", &document_id)
+        .await
+        .expect("finalize");
+    assert!(ok, "running row should transition to done");
+
+    let pd = repo
+        .get_project_document(project_id, "report.pdf")
+        .await
+        .expect("get_project_document")
+        .expect("mapping must exist after finalize");
+    assert_eq!(pd.document_id, document_id);
+    assert_eq!(pd.project_id, project_id);
+}
+
+#[tokio::test]
+async fn delete_project_document_returns_document_id_and_clears_rows() {
+    let repo = common::make_repo().await;
+    let project_id = seed_project(&repo).await;
+
+    repo.enqueue_ingest_job(project_id, "x.txt")
+        .await
+        .expect("enqueue");
+    let job = repo
+        .claim_ingest_job(Utc::now() + chrono::Duration::minutes(5))
+        .await
+        .expect("claim")
+        .expect("a job");
+    let doc_id = Uuid::new_v4().to_string();
+    repo.finalize_ingest_done(job.id, project_id, "x.txt", &doc_id)
+        .await
+        .expect("finalize");
+
+    let returned = repo
+        .delete_project_document(project_id, "x.txt")
+        .await
+        .expect("delete");
+    assert_eq!(returned.as_deref(), Some(doc_id.as_str()));
+
+    let missing = repo
+        .get_project_document(project_id, "x.txt")
+        .await
+        .expect("get");
+    assert!(missing.is_none(), "mapping should be gone");
+
+    let jobs = repo
+        .list_ingest_jobs_for_project(project_id)
+        .await
+        .expect("list");
+    assert!(jobs.is_empty(), "ingest_jobs row should be cleared too");
+}
+
+#[tokio::test]
+async fn reap_requeues_expired_lease() {
+    let repo = common::make_repo().await;
+    let project_id = seed_project(&repo).await;
+
+    repo.enqueue_ingest_job(project_id, "y.md")
+        .await
+        .expect("enqueue");
+    let past = Utc::now() - chrono::Duration::minutes(10);
+    let claimed = repo
+        .claim_ingest_job(past)
+        .await
+        .expect("claim")
+        .expect("a job");
+    assert_eq!(claimed.status, IngestStatus::Running);
+
+    let count = repo
+        .reap_expired_ingest_jobs(Utc::now())
+        .await
+        .expect("reap");
+    assert_eq!(count, 1, "the expired-lease row should be reaped");
+
+    let jobs = repo
+        .list_ingest_jobs_for_project(project_id)
+        .await
+        .expect("list");
+    assert_eq!(jobs[0].status, IngestStatus::Queued);
+    assert!(jobs[0].lease_until.is_none());
+}
+
+#[tokio::test]
+async fn is_ingestable_filename_matches_supported_extensions() {
+    use agent_k_backend::model::is_ingestable_filename;
+    assert!(is_ingestable_filename("a.pdf"));
+    assert!(is_ingestable_filename("a.PDF"));
+    assert!(is_ingestable_filename("notes.md"));
+    assert!(is_ingestable_filename("doc.markdown"));
+    assert!(is_ingestable_filename("plain.txt"));
+    assert!(!is_ingestable_filename("data.csv"));
+    assert!(!is_ingestable_filename("photo.png"));
+    assert!(!is_ingestable_filename("noext"));
+}
+
+/// Seed a minimal user + project so that ingest_jobs FK constraints hold.
+async fn seed_project(repo: &agent_k_backend::repository::AppRepository) -> Uuid {
+    use agent_k_backend::{auth::Role, repository::NewUser};
+
+    let user_id = Uuid::new_v4();
+    let username = format!("tester_{}", Uuid::new_v4().simple());
+    let user = repo
+        .create_user(NewUser {
+            id: user_id,
+            username,
+            password_hash: "test-bcrypt-hash-placeholder".into(),
+            role: Role::User,
+            display_name: None,
+            is_active: true,
+        })
+        .await
+        .expect("create_user");
+
+    let project = repo
+        .create_project(format!("proj-{}", Uuid::new_v4().simple()), None, user.id)
+        .await
+        .expect("create_project");
+
+    project.id
+}

--- a/backend/tests/session_messages_test.rs
+++ b/backend/tests/session_messages_test.rs
@@ -115,7 +115,8 @@ async fn get_messages_returns_empty_for_new_session() {
     let repo = make_repo().await;
     let data_root =
         std::env::temp_dir().join(format!("agent-k-msg-persist-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(repo, store, test_jwt_config(), data_root));
+    let _ = store;
+    let state = Arc::new(AppState::new(repo, test_jwt_config(), data_root));
     let app = make_app_with_state(state.clone());
 
     let username = format!("user_{}", uuid::Uuid::new_v4().simple());
@@ -167,7 +168,8 @@ async fn get_messages_returns_persisted_messages_in_order() {
     let repo = make_repo().await;
     let data_root =
         std::env::temp_dir().join(format!("agent-k-msg-persist-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(repo, store, test_jwt_config(), data_root));
+    let _ = store;
+    let state = Arc::new(AppState::new(repo, test_jwt_config(), data_root));
     let app = make_app_with_state(state.clone());
 
     let username = format!("user_{}", uuid::Uuid::new_v4().simple());
@@ -235,7 +237,8 @@ async fn clear_messages_removes_persisted_messages() {
     let repo = make_repo().await;
     let data_root =
         std::env::temp_dir().join(format!("agent-k-msg-persist-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(repo, store, test_jwt_config(), data_root));
+    let _ = store;
+    let state = Arc::new(AppState::new(repo, test_jwt_config(), data_root));
     let app = make_app_with_state(state.clone());
 
     let username = format!("user_{}", uuid::Uuid::new_v4().simple());
@@ -289,7 +292,8 @@ async fn clear_messages_does_not_delete_session() {
     let repo = make_repo().await;
     let data_root =
         std::env::temp_dir().join(format!("agent-k-msg-persist-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(repo, store, test_jwt_config(), data_root));
+    let _ = store;
+    let state = Arc::new(AppState::new(repo, test_jwt_config(), data_root));
     let app = make_app_with_state(state.clone());
 
     let username = format!("user_{}", uuid::Uuid::new_v4().simple());
@@ -333,7 +337,8 @@ async fn can_append_messages_after_clear() {
     let repo = make_repo().await;
     let data_root =
         std::env::temp_dir().join(format!("agent-k-msg-persist-{}", uuid::Uuid::new_v4()));
-    let state = Arc::new(AppState::new(repo, store, test_jwt_config(), data_root));
+    let _ = store;
+    let state = Arc::new(AppState::new(repo, test_jwt_config(), data_root));
     let app = make_app_with_state(state.clone());
 
     let username = format!("user_{}", uuid::Uuid::new_v4().simple());
@@ -385,12 +390,11 @@ async fn get_messages_response_includes_correct_sender_field() {
     use agent_k_backend::repository::{DbSenderKind, NewSessionMessage};
     use ailoy::message::{Message, Part, Role};
 
-    let store = common::make_test_store();
+    let _ = common::make_test_store();
     let repo = common::make_repo().await;
     let data_root = std::env::temp_dir().join(format!("agent-k-sender-{}", Uuid::new_v4()));
     let state = std::sync::Arc::new(agent_k_backend::state::AppState::new(
         repo.clone(),
-        store,
         common::test_jwt_config(),
         data_root,
     ));

--- a/backend/tests/session_metadata_test.rs
+++ b/backend/tests/session_metadata_test.rs
@@ -23,9 +23,9 @@ async fn new_session_has_null_last_message_at_and_title() {
     let (status, body) = common::authed(
         &app,
         "POST",
-        &format!("/projects/{project_id}/sessions"),
+        "/sessions",
         &token,
-        Some(serde_json::json!({})),
+        Some(serde_json::json!({ "project_id": project_id })),
     )
     .await;
     assert_eq!(status, StatusCode::CREATED, "create session failed: {body}");
@@ -264,7 +264,7 @@ async fn list_sessions_includes_metadata() {
     let (status, body) = common::authed(
         &app,
         "GET",
-        &format!("/projects/{project_id_str}/sessions"),
+        &format!("/sessions?project_id={project_id_str}"),
         &alice_token,
         None,
     )

--- a/backend/tests/session_sandbox_test.rs
+++ b/backend/tests/session_sandbox_test.rs
@@ -19,14 +19,9 @@ use common::{
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 async fn make_state() -> Arc<AppState> {
-    let store = make_test_store();
+    let _ = make_test_store();
     let data_root = std::env::temp_dir().join(format!("agent-k-sandbox-{}", uuid::Uuid::new_v4()));
-    Arc::new(AppState::new(
-        make_repo().await,
-        store,
-        test_jwt_config(),
-        data_root,
-    ))
+    Arc::new(AppState::new(make_repo().await, test_jwt_config(), data_root))
 }
 
 // ── sandbox isolation ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a `speedwagon` agent that answers questions about each project's uploaded documents, with `web_search` as a fallback when the corpus does not cover the question. Speedwagon is a first-class agent: it runs **standalone** via `get_speedwagon_agent(...)` (mirroring `get_coworker_agent` — Agent + Local RunEnv + per-call provider), and it is wired as a **subagent** inside `build_agent` so coworker can delegate corpus Q&A to it. Backend now owns the upload→ingest pipeline and isolates corpora per project.

## What changed

- `agent-k/src/agents/speedwagon/agent.rs`: new `SpeedwagonSpec::with_web_search()` builder; new standalone `get_speedwagon_agent(name, model, store)` helper mirroring the `get_coworker_agent` shape (Agent + Local RunEnv + per-call provider). `SYSTEM_PROMPT` teaches the model to search the corpus first and fall back to `web_search` only when the corpus is empty/off-topic, with distinct citation rules (`filepath:line` for docs, URL for web). The same `SpeedwagonSpec` is consumed both by the standalone helper and by `build_agent` when attaching speedwagon as a subagent — one source of truth for the agent's tools, prompt, and model.
- `backend/src/state.rs`: `AppState.store: SharedStore` becomes `stores: DashMap<Uuid, SharedStore>` with a `get_store(project_id)` accessor that lazily creates `data_root/projects/{id}/.speedwagon`. No process-wide store anymore.
- `backend/src/handlers/session.rs`: `build_agent(state, project_id, runenv)` now constructs a per-call `AgentProvider` (ailoy default for built-in tools + `build_tools(store)` for the project's corpus tools), passes it via `AgentBuilder::provider(...)`, and registers `speedwagon` as a subagent alongside `math`. Subagents inherit the parent's provider, so corpus tools resolve correctly for the speedwagon subagent.
- `backend/src/handlers/session.rs`: new `build_runenv` wrapper. When `AGENT_K_DISABLE_SANDBOX=1` it returns `RunEnv::local()` instead of booting a microsandbox; default behavior is unchanged.
- `backend/src/main.rs`: removes the boot-time `default_provider_mut().tools.insert_func(...)` block. Tools are wired per call from the project's store; ailoy's default `ToolProvider` continues to supply built-ins (bash, python, web_search, ...).
- `backend/migrations/0007_ingest_jobs.sql`: two new tables. `ingest_jobs` queues uploaded files for the background worker (status / attempts / lease_until / document_id, unique on (project_id, source_path)). `project_documents` maps (project_id, source_path) to the resulting agent-k Store document id, populated on success, dropped on delete.
- `backend/src/model/ingest.rs`, `backend/src/repository/ingest.rs`: `IngestStatus` enum, `DbIngestJob` / `DbProjectDocument`, plus enqueue / claim / heartbeat / finalize_done / finalize_failed / reap / list / delete operations. The same lease pattern as `automation_runs` from `worker.rs`.
- `backend/src/handlers/dirent.rs`: `upload` enqueues PDF/MD/TXT files via `enqueue_ingest_job` after the file is on disk (best effort, logs on failure). `delete_path` for single files now drops the `project_documents` row and purges the document from the project's Store inside the handler.
- `backend/src/ingest_worker.rs`: new background worker. Polls for queued jobs, runs `Store::ingest`, finalizes with the document id, and renews the lease via a child task. Housekeeper reaps expired leases. Spawned from `main.rs` when `mode.runs_worker()` is true.
- `backend/src/handlers/document.rs` + `backend/src/router.rs`: `/documents` endpoints move under `/projects/{project_id}/documents` and pull the store via `AppState::get_store(project_id)`. The flat `/documents` routes are removed.
- Tests: SpeedwagonSpec unit tests (default tool set, with_web_search, prompt content), new `multi_tenancy_test` (per-project store isolation + ingest repo CRUD + reaper). Existing `document_test` rewritten to sign up a user and operate on their personal project. Helpers in `common/mod.rs` (`list_documents` / `ingest_document` / `purge_document` / `bulk_purge_documents` / `get_document`) gain `token` + `project_id` parameters. `session_metadata_test` URL/payload corrected to match the actual `POST /sessions` shape.

## Two modes of running speedwagon

- **Standalone (`get_speedwagon_agent`)**: useful for CLI-style invocations or scripts that want to ask a project's corpus a single question without booting the coworker / sandbox stack. Pass a `SharedStore`, get back an `Agent` ready to `run(...)`.
- **Subagent (inside `build_agent`)**: the normal session path. Coworker remains the top-level agent (with bash, python, web_search, math); when a question is about the project's uploaded documents, coworker delegates to the speedwagon subagent. Subagent inherits the parent's `AgentProvider`, so the project-scoped corpus tools resolve transparently.

The same `SpeedwagonSpec::new().with_web_search().card(...).into_spec()` builds the spec in both modes — changes to the prompt or tool set propagate to both without duplication.

## Why

Before this PR, `build_agent` produced a single coworker agent (+ math subagent) that saw uploaded files only as host-mounted paths under `/workspace/.uploads/`. Asking the model a content question over those files relied on bash/grep inside the sandbox — no indexed search, no relevance ranking, no citations. The agent also had no path to fall back to the public web when the question was outside the uploaded corpus. This PR adds an indexed corpus per project, a `speedwagon` agent that searches it with `search_document` / `find_in_document` / `read_document`, and a `web_search` fallback for off-corpus questions. Each project's store is isolated under `data_root/projects/{id}/.speedwagon` so corpora cannot leak across projects.

## Test

- `cargo test -p agent-k` and `cargo test -p agent-k-backend`: all pass locally (161 tests). Ignored: 1 in `e2e_test` (`requires OPENAI_API_KEY`, pre-existing), 3 in `agent_k::knowledge_base` (`#[ignore]` integration tests, pre-existing).
- The new SpeedwagonSpec unit tests check that the corpus tool set + web_search fallback shape is preserved by the builder.
- The new `multi_tenancy_test` covers per-project Store isolation, idempotent enqueue, claim→done lifecycle, reaper requeue on expired lease, and `delete_project_document` cleanup.
- **End-to-end smoke verified locally** with `ANTHROPIC_API_KEY` and real microsandbox boot:
  1. `POST /projects/{id}/dirents` uploaded a small markdown file with a unique fact.
  2. The ingest worker picked up the job within ~2 s and produced a Store document (`tantivy` index visible under `data_root/projects/{id}/.speedwagon/`).
  3. A session was created (microsandbox booted), then `POST /sessions/{id}/messages` with a corpus question — coworker called the `subagent_speedwagon` tool, which ran `search_document` followed by `read_document` and returned the answer with the correct quote and line numbers; coworker then surfaced the citation to the user.
  4. An off-corpus question was answered by coworker calling `web_search` directly. A second prompt that explicitly asked for corpus-then-web showed the same delegate→search→empty→hand-back flow, after which coworker fell back to `web_search`. The corpus path, the citation path, and the web fallback all worked end-to-end.

## Notes from the E2E run

- When the corpus returns nothing, speedwagon currently hands control back to the parent rather than calling `web_search` itself. The `SYSTEM_PROMPT` advertises the fallback, the `web_search` ToolDesc is on the subagent's spec, and ailoy's default `ToolProvider` supplies the runtime — but the model's policy under Anthropic's haiku weighting prefers escalation when a parent agent is also web-capable. The desired behavior (speedwagon calls `web_search` itself) is one prompt strengthening away; left as a follow-up so this PR keeps a clean architectural seam.

## Out of scope

- Directory-level dirent delete does not currently walk and purge per-file `project_documents` rows. Files under a removed directory become orphan rows. A follow-up can add a sweep step.
- The legacy admin-style `/documents` routes are gone, not aliased. Any external caller that depended on them must move to `/projects/{id}/documents`.