### PR TITLE
Session fork UI

### DIFF
--- a/app/scripts/seed_automation_demo.py
+++ b/app/scripts/seed_automation_demo.py
@@ -72,6 +72,12 @@ def main() -> None:
             .replace("+00:00", "Z")
         )
 
+    def title_ts(offset_sec: int) -> str:
+        # Match the backend's deterministic format in
+        # `backend/src/repository/automation.rs::automation_session_title`:
+        # "{automation_name} · {kind_label} · %Y-%m-%d %H:%M".
+        return (base + timedelta(seconds=offset_sec)).strftime("%Y-%m-%d %H:%M")
+
     conn = sqlite3.connect(db)
     conn.execute("PRAGMA foreign_keys = ON")
 
@@ -157,18 +163,28 @@ def main() -> None:
     )
 
     # ── Sessions (one per run; origin='automation') ───────────────────────
+    # Session titles mirror the backend's deterministic format for
+    # automation-created sessions:
+    #   "{automation_name} · {kind_label} · {scheduled_for as %Y-%m-%d %H:%M}"
+    # kind_label maps 'cron' → 'recurring'; 'webhook' / 'manual' stay verbatim.
     sessions = [
-        (SESS_A1_1, PROJECT_KLIENT, OLIVE_ID, "private", "Daily summary 진행 중",
+        (SESS_A1_1, PROJECT_KLIENT, OLIVE_ID, "private",
+         f"Daily summary · recurring · {title_ts(100)}",
          None, None, ts(100), ts(110), "automation"),
-        (SESS_A1_2, PROJECT_KLIENT, OLIVE_ID, "private", "Daily summary (예정)",
+        (SESS_A1_2, PROJECT_KLIENT, OLIVE_ID, "private",
+         f"Daily summary · recurring · {title_ts(90)}",
          None, None, ts(120), ts(120), "automation"),
-        (SESS_A1_3, PROJECT_KLIENT, OLIVE_ID, "private", "Daily summary (어제)",
+        (SESS_A1_3, PROJECT_KLIENT, OLIVE_ID, "private",
+         f"Daily summary · recurring · {title_ts(80)}",
          None, None, ts(80), ts(95), "automation"),
-        (SESS_A2_1, PROJECT_KLIENT, OLIVE_ID, "private", "Weekly digest (지난주)",
+        (SESS_A2_1, PROJECT_KLIENT, OLIVE_ID, "private",
+         f"Weekly digest · recurring · {title_ts(50)}",
          None, None, ts(50), ts(75), "automation"),
-        (SESS_A3_1, PROJECT_KLIENT, OLIVE_ID, "private", "On-call ping INC-4471",
+        (SESS_A3_1, PROJECT_KLIENT, OLIVE_ID, "private",
+         f"On-call ping · webhook · {title_ts(40)}",
          None, None, ts(40), ts(60), "automation"),
-        (SESS_A4_1, PROJECT_KLIENT, OLIVE_ID, "private", "Backfill ledger 5/15-19",
+        (SESS_A4_1, PROJECT_KLIENT, OLIVE_ID, "private",
+         f"Backfill ledger · manual · {title_ts(30)}",
          None, None, ts(30), ts(48), "automation"),
     ]
     conn.executemany(

--- a/app/src/api/sessions.ts
+++ b/app/src/api/sessions.ts
@@ -32,3 +32,13 @@ export async function updateSessionShareMode(sessionId: string, shareMode: Share
 export async function deleteSession(sessionId: string): Promise<void> {
   await request(`/sessions/${sessionId}`, { method: 'DELETE' });
 }
+
+// User-facing label is "Duplicate" (the action clones the entire session
+// — messages + sandbox); the backend endpoint is still `/fork` since that
+// is the internal mechanism name.
+export async function duplicateSession(sessionId: string): Promise<Session> {
+  const raw = await request<BackendSession>(`/sessions/${sessionId}/fork`, {
+    method: 'POST',
+  });
+  return toSession(raw);
+}

--- a/app/src/api/transformers.ts
+++ b/app/src/api/transformers.ts
@@ -1,5 +1,5 @@
 // Map raw backend payloads to the app-live domain types used in views.
-// Default values for missing metadata (intent, references, etc.) are filled here.
+// Default values for missing metadata (references, etc.) are filled here.
 
 import type {
   Automation,
@@ -110,7 +110,6 @@ export function toSession(backend: BackendSession): Session {
     creatorId: backend.creator_id,
     shareMode: backend.share_mode,
     origin: backend.origin,
-    intent: 'general',
     updatedAt: compactDate(backend.updated_at),
     lastMessageAt: backend.last_message_at,
     lastMessageSnippet: backend.last_message_snippet,

--- a/app/src/components/ArtifactsPanel.tsx
+++ b/app/src/components/ArtifactsPanel.tsx
@@ -34,7 +34,7 @@ export function ArtifactsPanel({ projectId, sessionId, onCopyToShared }: Artifac
   const { data: rawEntries = [], isLoading } = useQuery({
     queryKey: ['dirents', 'artifacts', projectId, sessionId],
     queryFn: () => listDirentsRaw(scope, true),
-    enabled: Boolean(sessionId),
+    enabled: Boolean(projectId && sessionId),
   });
 
   // Show files only, strip scope prefix for display

--- a/app/src/components/Icon.tsx
+++ b/app/src/components/Icon.tsx
@@ -4,14 +4,14 @@ export type IconName =
   | 'home' | 'folder' | 'folder-open' | 'users' | 'settings' | 'lock' | 'eye'
   | 'message-square' | 'file-text' | 'file' | 'sheet' | 'image' | 'search' | 'plus'
   | 'send' | 'sparkles' | 'check' | 'chevron' | 'zap' | 'calendar' | 'circle-play' | 'rocket' | 'artifact'
-  | 'shield' | 'x' | 'arrow-left' | 'analysis' | 'brainstorm' | 'writing'
-  | 'recap' | 'general' | 'more' | 'upload' | 'trash' | 'download' | 'copy'
+  | 'shield' | 'x' | 'arrow-left' | 'writing' | 'recap'
+  | 'more' | 'upload' | 'trash' | 'download' | 'copy'
   | 'list' | 'grid' | 'chevron-right' | 'chevron-left' | 'rotate-ccw' | 'corner-down-left' | 'paperclip'
   | 'file-pdf' | 'file-code' | 'file-archive' | 'file-video' | 'file-audio';
 
 type PreviewIconName =
-  | 'lock' | 'eye' | 'message-square' | 'messages-square' | 'clipboard-list'
-  | 'lightbulb' | 'pencil' | 'home' | 'folder' | 'folder-open' | 'users'
+  | 'lock' | 'eye' | 'message-square' | 'messages-square'
+  | 'pencil' | 'home' | 'folder' | 'folder-open' | 'users'
   | 'settings' | 'plus' | 'chevron-down' | 'chevron-right' | 'chevron-left' | 'more-horizontal' | 'check'
   | 'x' | 'arrow-left' | 'send' | 'search' | 'file-text' | 'file-spreadsheet'
   | 'file' | 'image' | 'sparkles' | 'shield-check' | 'zap' | 'calendar' | 'circle-play' | 'rocket'
@@ -23,8 +23,6 @@ const previewIconPath: Record<PreviewIconName, string> = {
   eye: '<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/>',
   'message-square': '<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>',
   'messages-square': '<path d="M14 9a2 2 0 0 1-2 2H6l-4 4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2z"/><path d="M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1"/>',
-  'clipboard-list': '<rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11h4"/><path d="M12 16h4"/><path d="M8 11h.01"/><path d="M8 16h.01"/>',
-  lightbulb: '<path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/>',
   pencil: '<path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/>',
   home: '<path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>',
   folder: '<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>',
@@ -93,11 +91,8 @@ const iconAlias: Record<IconName, PreviewIconName> = {
   shield: 'shield-check',
   x: 'x',
   'arrow-left': 'arrow-left',
-  analysis: 'clipboard-list',
-  brainstorm: 'lightbulb',
   writing: 'pencil',
   recap: 'messages-square',
-  general: 'message-square',
   more: 'more-horizontal',
   upload: 'plus',
   trash: 'trash-2',

--- a/app/src/components/Icon.tsx
+++ b/app/src/components/Icon.tsx
@@ -7,7 +7,8 @@ export type IconName =
   | 'shield' | 'x' | 'arrow-left' | 'writing' | 'recap'
   | 'more' | 'upload' | 'trash' | 'download' | 'copy'
   | 'list' | 'grid' | 'chevron-right' | 'chevron-left' | 'rotate-ccw' | 'corner-down-left' | 'paperclip'
-  | 'file-pdf' | 'file-code' | 'file-archive' | 'file-video' | 'file-audio';
+  | 'file-pdf' | 'file-code' | 'file-archive' | 'file-video' | 'file-audio'
+  | 'sticky-notes';
 
 type PreviewIconName =
   | 'lock' | 'eye' | 'message-square' | 'messages-square'
@@ -16,7 +17,8 @@ type PreviewIconName =
   | 'x' | 'arrow-left' | 'send' | 'search' | 'file-text' | 'file-spreadsheet'
   | 'file' | 'image' | 'sparkles' | 'shield-check' | 'zap' | 'calendar' | 'circle-play' | 'rocket'
   | 'trash-2' | 'download' | 'copy' | 'list' | 'grid-3x3' | 'rotate-ccw' | 'corner-down-left' | 'paperclip'
-  | 'file-code' | 'file-archive' | 'file-video' | 'file-audio';
+  | 'file-code' | 'file-archive' | 'file-video' | 'file-audio'
+  | 'sticky-notes';
 
 const previewIconPath: Record<PreviewIconName, string> = {
   lock: '<rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>',
@@ -62,6 +64,7 @@ const previewIconPath: Record<PreviewIconName, string> = {
   'file-video': '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="m10 11 5 3-5 3z"/>',
   'file-audio': '<path d="M17.5 22h.5a2 2 0 0 0 2-2V7l-5-5H6a2 2 0 0 0-2 2v3"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M2 17v-3a4 4 0 0 1 8 0v3"/><circle cx="9" cy="17" r="1"/><circle cx="3" cy="17" r="1"/>',
   paperclip: '<path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/>',
+  'sticky-notes': '<path d="M10 8a2.4 2.4 0 0 1 1.706.706l3.588 3.588A2.4 2.4 0 0 1 16 14v6a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z"/><path d="M10 8v5a1 1 0 0 0 1 1h5"/><path d="M8 4a2 2 0 0 1 2-2h6a2.4 2.4 0 0 1 1.706.706l3.588 3.588A2.4 2.4 0 0 1 22 8v6a2 2 0 0 1-2 2"/><path d="M16 2v5a1 1 0 0 0 1 1h5"/>',
 };
 
 const iconAlias: Record<IconName, PreviewIconName> = {
@@ -112,6 +115,7 @@ const iconAlias: Record<IconName, PreviewIconName> = {
   'file-video': 'file-video',
   'file-audio': 'file-audio',
   paperclip: 'paperclip',
+  'sticky-notes': 'sticky-notes',
 };
 
 export function Icon({ name, size = 16, className = '', strokeWidth = 2, style, ...props }: SVGProps<SVGSVGElement> & { name: IconName; size?: number }) {

--- a/app/src/components/InviteDialog.tsx
+++ b/app/src/components/InviteDialog.tsx
@@ -10,11 +10,11 @@ import { Icon } from '@/components/Icon';
 import { ApiError } from '@/api/client';
 
 interface InviteDialogProps {
-  projectId: string;
+  projectRef: string;
   onClose: () => void;
 }
 
-export function InviteDialog({ projectId, onClose }: InviteDialogProps) {
+export function InviteDialog({ projectRef, onClose }: InviteDialogProps) {
   const queryClient = useQueryClient();
   const [username, setUsername] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -27,9 +27,9 @@ export function InviteDialog({ projectId, onClose }: InviteDialogProps) {
   }, [onClose]);
 
   const mutation = useMutation({
-    mutationFn: (name: string) => addMember(projectId, name),
+    mutationFn: (name: string) => addMember(projectRef, name),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['members', projectId] });
+      await queryClient.invalidateQueries({ queryKey: ['members', projectRef] });
       onClose();
     },
     onError: (err) => {
@@ -61,7 +61,7 @@ export function InviteDialog({ projectId, onClose }: InviteDialogProps) {
           초대할 사용자의 username을 입력하세요. 가입된 사용자만 추가할 수 있습니다.
         </p>
         <p style={{ color: 'var(--cw-ink-4)', margin: '0 0 14px', fontSize: 11, fontFamily: 'var(--cw-font-mono)' }}>
-          POST /projects/{projectId.slice(0, 8)}…/members
+          POST /projects/{projectRef}/members
         </p>
         <form onSubmit={submit}>
           <div className="cw-field">

--- a/app/src/components/SessionCardMenu.tsx
+++ b/app/src/components/SessionCardMenu.tsx
@@ -9,12 +9,13 @@ import { Icon } from './Icon';
 
 interface SessionCardMenuProps {
   onDuplicate?: () => void;
+  duplicateDisabled?: boolean;
   onDelete?: () => void;
 }
 
 interface MenuRect { top: number; left: number; }
 
-export function SessionCardMenu({ onDuplicate, onDelete }: SessionCardMenuProps) {
+export function SessionCardMenu({ onDuplicate, duplicateDisabled, onDelete }: SessionCardMenuProps) {
   if (!onDuplicate && !onDelete) return null;
   const [open, setOpen] = useState(false);
   const [rect, setRect] = useState<MenuRect | null>(null);
@@ -106,7 +107,13 @@ export function SessionCardMenu({ onDuplicate, onDelete }: SessionCardMenuProps)
             <button
               type="button"
               role="menuitem"
-              onClick={(e) => { e.stopPropagation(); setOpen(false); onDuplicate(); }}
+              disabled={duplicateDisabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (duplicateDisabled) return;
+                setOpen(false);
+                onDuplicate();
+              }}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -116,12 +123,16 @@ export function SessionCardMenu({ onDuplicate, onDelete }: SessionCardMenuProps)
                 padding: '7px 10px',
                 border: 0,
                 background: 'transparent',
-                color: 'var(--cw-ink-1)',
+                color: duplicateDisabled ? 'var(--cw-ink-4)' : 'var(--cw-ink-1)',
                 fontSize: 12.5,
                 borderRadius: 'var(--cw-radius-sm)',
-                cursor: 'pointer',
+                cursor: duplicateDisabled ? 'not-allowed' : 'pointer',
+                opacity: duplicateDisabled ? 0.6 : 1,
               }}
-              onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--cw-paper-3)'; }}
+              onMouseEnter={(e) => {
+                if (duplicateDisabled) return;
+                (e.currentTarget as HTMLButtonElement).style.background = 'var(--cw-paper-3)';
+              }}
               onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
             >
               <Icon name="sticky-notes" size={13} />

--- a/app/src/components/SessionCardMenu.tsx
+++ b/app/src/components/SessionCardMenu.tsx
@@ -16,7 +16,7 @@ interface SessionCardMenuProps {
 interface MenuRect { top: number; left: number; }
 
 export function SessionCardMenu({ onDuplicate, duplicateDisabled, onDelete }: SessionCardMenuProps) {
-  if (!onDuplicate && !onDelete) return null;
+  const hasActions = Boolean(onDuplicate || onDelete);
   const [open, setOpen] = useState(false);
   const [rect, setRect] = useState<MenuRect | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -60,6 +60,8 @@ export function SessionCardMenu({ onDuplicate, duplicateDisabled, onDelete }: Se
       document.removeEventListener('keydown', onKey);
     };
   }, [open]);
+
+  if (!hasActions) return null;
 
   return (
     <>

--- a/app/src/components/SessionCardMenu.tsx
+++ b/app/src/components/SessionCardMenu.tsx
@@ -8,12 +8,14 @@ import { createPortal } from 'react-dom';
 import { Icon } from './Icon';
 
 interface SessionCardMenuProps {
-  onDelete: () => void;
+  onDuplicate?: () => void;
+  onDelete?: () => void;
 }
 
 interface MenuRect { top: number; left: number; }
 
-export function SessionCardMenu({ onDelete }: SessionCardMenuProps) {
+export function SessionCardMenu({ onDuplicate, onDelete }: SessionCardMenuProps) {
+  if (!onDuplicate && !onDelete) return null;
   const [open, setOpen] = useState(false);
   const [rect, setRect] = useState<MenuRect | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -100,27 +102,58 @@ export function SessionCardMenu({ onDelete }: SessionCardMenuProps) {
             zIndex: 100,
           }}
         >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={(e) => { e.stopPropagation(); setOpen(false); onDelete(); }}
-            style={{
-              display: 'block',
-              width: '100%',
-              textAlign: 'left',
-              padding: '7px 10px',
-              border: 0,
-              background: 'transparent',
-              color: 'var(--cw-destructive)',
-              fontSize: 12.5,
-              borderRadius: 'var(--cw-radius-sm)',
-              cursor: 'pointer',
-            }}
-            onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--cw-paper-3)'; }}
-            onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
-          >
-            세션 삭제
-          </button>
+          {onDuplicate && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={(e) => { e.stopPropagation(); setOpen(false); onDuplicate(); }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                width: '100%',
+                textAlign: 'left',
+                padding: '7px 10px',
+                border: 0,
+                background: 'transparent',
+                color: 'var(--cw-ink-1)',
+                fontSize: 12.5,
+                borderRadius: 'var(--cw-radius-sm)',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--cw-paper-3)'; }}
+              onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+            >
+              <Icon name="sticky-notes" size={13} />
+              세션 복제
+            </button>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={(e) => { e.stopPropagation(); setOpen(false); onDelete(); }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                width: '100%',
+                textAlign: 'left',
+                padding: '7px 10px',
+                border: 0,
+                background: 'transparent',
+                color: 'var(--cw-destructive)',
+                fontSize: 12.5,
+                borderRadius: 'var(--cw-radius-sm)',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--cw-paper-3)'; }}
+              onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+            >
+              <Icon name="trash" size={13} />
+              세션 삭제
+            </button>
+          )}
         </div>,
         document.body,
       )}

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -222,8 +222,8 @@ export function Sidebar() {
 
   const sessionsQuery = useQuery({
     queryKey: ['sessions', activeProjectSlug],
-    queryFn: () => listSessions(activeProject!.id),
-    enabled: Boolean(activeProjectSlug) && Boolean(activeProject),
+    queryFn: () => listSessions(activeProjectSlug!),
+    enabled: Boolean(activeProjectSlug),
   });
 
   const activeSessionId = useActiveSessionId();
@@ -281,7 +281,7 @@ export function Sidebar() {
     },
   });
 
-  const duplicateMutation = useDuplicateSession({ navigateOnSuccess: true });
+  const duplicateMutation = useDuplicateSession();
 
   function openProject(slug: string) {
     navigate({ to: '/projects/$projectSlug', params: { projectSlug: slug } });
@@ -496,7 +496,13 @@ export function Sidebar() {
           confirmLabel="복제"
           pending={duplicateMutation.isPending}
           onConfirm={() => {
-            duplicateMutation.mutate(pendingDuplicate.id);
+            duplicateMutation.mutate(pendingDuplicate.id, {
+              onSuccess: (newSession) => {
+                if (activeProject) {
+                  openSession(activeProject.slug, shortSessionId(newSession.id));
+                }
+              },
+            });
             setPendingDuplicate(null);
           }}
           onClose={() => setPendingDuplicate(null)}

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -25,6 +25,7 @@ import { useNewProjectDialog } from '@/components/NewProjectDialog';
 import { SessionCardMenu } from '@/components/SessionCardMenu';
 import { canAdministerSession } from '@/lib/permissions';
 import { shortSessionId } from '@/lib/sessionId';
+import { useDuplicateSession } from '@/lib/useDuplicateSession';
 import { ApiError } from '@/api/client';
 import { SessionTitleText } from '@/components/SessionTitleText';
 import type { Session } from '@/domain/types';
@@ -254,6 +255,7 @@ export function Sidebar() {
   });
 
   const [pendingDelete, setPendingDelete] = useState<Session | null>(null);
+  const [pendingDuplicate, setPendingDuplicate] = useState<Session | null>(null);
   const projectCreator = useNewProjectDialog();
   const deleteMutation = useMutation({
     mutationFn: (sessionId: string) => deleteSession(sessionId),
@@ -278,6 +280,8 @@ export function Sidebar() {
       showToast(`세션 삭제 실패: ${msg}`);
     },
   });
+
+  const duplicateMutation = useDuplicateSession();
 
   function openProject(slug: string) {
     navigate({ to: '/projects/$projectSlug', params: { projectSlug: slug } });
@@ -439,11 +443,12 @@ export function Sidebar() {
                     )}
                     <SessionTitleText title={session.title} />
                     {session.isAutoAppend && <span className="auto-dot">●</span>}
-                    {canDelete && (
-                      <span className="cw-session-menu-wrap">
-                        <SessionCardMenu onDelete={() => setPendingDelete(session)} />
-                      </span>
-                    )}
+                    <span className="cw-session-menu-wrap">
+                      <SessionCardMenu
+                        onDuplicate={() => setPendingDuplicate(session)}
+                        onDelete={canDelete ? () => setPendingDelete(session) : undefined}
+                      />
+                    </span>
                   </div>
                 );
               })}
@@ -481,6 +486,20 @@ export function Sidebar() {
           pending={deleteMutation.isPending}
           onConfirm={() => deleteMutation.mutate(pendingDelete.id)}
           onClose={() => setPendingDelete(null)}
+        />
+      )}
+
+      {pendingDuplicate && (
+        <ConfirmDialog
+          title="세션을 복제하시겠어요?"
+          body={`"${pendingDuplicate.title}"의 메시지와 sandbox 상태를 새 세션으로 복제합니다.`}
+          confirmLabel="복제"
+          pending={duplicateMutation.isPending}
+          onConfirm={() => {
+            duplicateMutation.mutate(pendingDuplicate.id);
+            setPendingDuplicate(null);
+          }}
+          onClose={() => setPendingDuplicate(null)}
         />
       )}
 

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -445,7 +445,8 @@ export function Sidebar() {
                     {session.isAutoAppend && <span className="auto-dot">●</span>}
                     <span className="cw-session-menu-wrap">
                       <SessionCardMenu
-                        onDuplicate={session.lastMessageAt ? () => setPendingDuplicate(session) : undefined}
+                        onDuplicate={() => setPendingDuplicate(session)}
+                        duplicateDisabled={!session.lastMessageAt}
                         onDelete={canDelete ? () => setPendingDelete(session) : undefined}
                       />
                     </span>

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -445,7 +445,7 @@ export function Sidebar() {
                     {session.isAutoAppend && <span className="auto-dot">●</span>}
                     <span className="cw-session-menu-wrap">
                       <SessionCardMenu
-                        onDuplicate={() => setPendingDuplicate(session)}
+                        onDuplicate={session.lastMessageAt ? () => setPendingDuplicate(session) : undefined}
                         onDelete={canDelete ? () => setPendingDelete(session) : undefined}
                       />
                     </span>
@@ -492,20 +492,23 @@ export function Sidebar() {
       {pendingDuplicate && (
         <ConfirmDialog
           title="세션을 복제하시겠어요?"
-          body={`"${pendingDuplicate.title}"의 메시지와 sandbox 상태를 새 세션으로 복제합니다.`}
+          body={`"${pendingDuplicate.title}"의 메시지와 sandbox 상태를 새 세션으로 복제합니다. 세션이 사용 중이면 복제에 실패할 수 있습니다.`}
           confirmLabel="복제"
           pending={duplicateMutation.isPending}
           onConfirm={() => {
             duplicateMutation.mutate(pendingDuplicate.id, {
               onSuccess: (newSession) => {
+                setPendingDuplicate(null);
                 if (activeProject) {
                   openSession(activeProject.slug, shortSessionId(newSession.id));
                 }
               },
+              onError: () => setPendingDuplicate(null),
             });
-            setPendingDuplicate(null);
           }}
-          onClose={() => setPendingDuplicate(null)}
+          onClose={() => {
+            if (!duplicateMutation.isPending) setPendingDuplicate(null);
+          }}
         />
       )}
 

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -237,7 +237,7 @@ export function Sidebar() {
   }, [activeProjectSlug, activeSessionId, activeRoute, sidebarMode]);
 
   const createSessionMutation = useMutation({
-    mutationFn: (projectId: string) => createSession(projectId),
+    mutationFn: (projectRef: string) => createSession(projectRef),
     onSuccess: async (session) => {
       await queryClient.invalidateQueries({ queryKey: ['sessions', activeProjectSlug] });
       showToast('새 세션이 만들어졌습니다');
@@ -414,7 +414,7 @@ export function Sidebar() {
               label="Sessions"
               expanded={sessionsExpanded}
               onToggle={toggleSessions}
-              onAdd={() => createSessionMutation.mutate(activeProject.id)}
+              onAdd={() => createSessionMutation.mutate(activeProject.slug)}
               addLabel={createSessionMutation.isPending ? '세션 생성 중…' : '새 Session'}
               addDisabled={createSessionMutation.isPending}
             />

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -281,7 +281,7 @@ export function Sidebar() {
     },
   });
 
-  const duplicateMutation = useDuplicateSession();
+  const duplicateMutation = useDuplicateSession(activeProjectSlug ?? '');
 
   function openProject(slug: string) {
     navigate({ to: '/projects/$projectSlug', params: { projectSlug: slug } });

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -281,7 +281,7 @@ export function Sidebar() {
     },
   });
 
-  const duplicateMutation = useDuplicateSession();
+  const duplicateMutation = useDuplicateSession({ navigateOnSuccess: true });
 
   function openProject(slug: string) {
     navigate({ to: '/projects/$projectSlug', params: { projectSlug: slug } });

--- a/app/src/components/uiPrimitives.tsx
+++ b/app/src/components/uiPrimitives.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { Icon, type IconName } from './Icon';
-import { intentMeta, shareMeta } from '../domain/metadata';
-import type { SessionIntent, ShareMode, User } from '../domain/types';
+import { shareMeta } from '../domain/metadata';
+import type { ShareMode, User } from '../domain/types';
 
 export function EmptyState({
   title,
@@ -35,11 +35,6 @@ export function SectionLabel({ children }: { children: ReactNode }) {
   return <div className="cw-section-label-app">{children}</div>;
 }
 
-export function IntentIcon({ intent, force = false }: { intent: SessionIntent; force?: boolean }) {
-  if (intent === 'general' && !force) return <span className="cw-intent-dot" />;
-  return <span className={`cw-pocket cw-intent-${intent}`}><Icon name={intentMeta[intent].icon} size={14} /></span>;
-}
-
 export function Avatar({ user, small = false }: { user: User; small?: boolean }) {
   return <span className={`cw-avatar-app ${small ? 'small' : ''}`} style={{ background: user.color }}>{user.avatar}</span>;
 }
@@ -69,8 +64,6 @@ export function byId<T extends { id: string }>(items: T[], id: string): T {
 export function InfoRow({ icon, title, meta, children }: { icon: IconName; title: string; meta: string; children: ReactNode }) { return <article className="cw-info-row"><IconPocket tone="neutral" icon={icon} /><div><b>{title}</b><p>{children}</p></div><span>{meta}</span></article>; }
 
 export function ActivityRow({ title, date, children }: { title: string; date: string; children: ReactNode }) { return <article className="cw-activity-row"><span><Icon name="recap" /></span><div><b>{title}</b><p>{children}</p></div><time>{date}</time></article>; }
-
-export function IntentBadge({ intent }: { intent: SessionIntent }) { return <span className="cw-intent-badge"><IntentIcon intent={intent} force />{intentMeta[intent].label}</span>; }
 
 export function SharePill({ mode, compact = false }: { mode: ShareMode; compact?: boolean }) { return <span className={`cw-share-pill ${shareMeta[mode].className}`}><Icon name={shareMeta[mode].icon} size={compact ? 11 : 12} />{compact ? shareMeta[mode].shortLabel : shareMeta[mode].label}</span>; }
 

--- a/app/src/components/uiPrimitives.tsx
+++ b/app/src/components/uiPrimitives.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Icon, type IconName } from './Icon';
 import { shareMeta } from '../domain/metadata';
 import type { ShareMode, User } from '../domain/types';
@@ -68,3 +68,75 @@ export function ActivityRow({ title, date, children }: { title: string; date: st
 export function SharePill({ mode, compact = false }: { mode: ShareMode; compact?: boolean }) { return <span className={`cw-share-pill ${shareMeta[mode].className}`}><Icon name={shareMeta[mode].icon} size={compact ? 11 : 12} />{compact ? shareMeta[mode].shortLabel : shareMeta[mode].label}</span>; }
 
 export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mode: ShareMode) => void }) { return <label className={`cw-share-select ${shareMeta[mode].className}`}><Icon name={shareMeta[mode].icon} /><select value={mode} onChange={(event) => onChange(event.target.value as ShareMode)}>{(Object.keys(shareMeta) as ShareMode[]).map((key) => <option key={key} value={key}>{shareMeta[key].label}</option>)}</select></label>; }
+
+/// Ghost icon-only button. Base style ships in `.cw-icon-button` (globals.css);
+/// pass `className` to layer modifier classes (e.g. `cw-rail-action` adds
+/// row-hover gating and smaller sizing). `label` is the aria-label (required
+/// for accessibility); `title` overrides the hover tooltip when it should
+/// differ from the label.
+/// `stopPropagation` is for buttons sitting inside a clickable parent row.
+/// Pass `expandedText` to turn the button into a 30×30 square that grows on
+/// hover to reveal that text — opt-in is implicit (presence of the prop).
+/// `confirmText` makes the button two-click: first click arms (and shows
+/// this text), second click fires `onClick`. Mousing off the armed button
+/// disarms it.
+export function IconButton({
+  icon,
+  label,
+  title,
+  onClick,
+  disabled = false,
+  className,
+  iconSize = 15,
+  stopPropagation = false,
+  expandedText,
+  confirmText,
+}: {
+  icon: IconName;
+  label: string;
+  title?: string;
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+  iconSize?: number;
+  stopPropagation?: boolean;
+  expandedText?: string;
+  confirmText?: string;
+}) {
+  const [armed, setArmed] = useState(false);
+  const useConfirm = Boolean(confirmText) && !disabled;
+  // Expandable layout when either the consumer opted in (via expandedText) or
+  // the button is currently armed (so the confirmation text has room to show).
+  const expandable = Boolean(expandedText) || armed;
+  const visibleText = armed ? confirmText : (expandedText ?? label);
+  const cls = `cw-icon-button${expandable ? ' is-expandable' : ''}${armed ? ' is-armed' : ''}${className ? ` ${className}` : ''}`;
+  return (
+    <button
+      type="button"
+      aria-label={armed && confirmText ? confirmText : label}
+      title={armed && confirmText ? confirmText : (title ?? label)}
+      onClick={(e) => {
+        if (stopPropagation) e.stopPropagation();
+        if (disabled) return;
+        if (useConfirm && !armed) {
+          setArmed(true);
+          return;
+        }
+        setArmed(false);
+        onClick();
+      }}
+      onMouseLeave={armed ? () => setArmed(false) : undefined}
+      disabled={disabled}
+      className={cls}
+    >
+      {expandable ? (
+        <>
+          <span className="cw-icon-button-icon"><Icon name={icon} size={iconSize} /></span>
+          <span className="cw-icon-button-label">{visibleText}</span>
+        </>
+      ) : (
+        <Icon name={icon} size={iconSize} />
+      )}
+    </button>
+  );
+}

--- a/app/src/domain/metadata.ts
+++ b/app/src/domain/metadata.ts
@@ -1,13 +1,5 @@
 import type { IconName } from '../components/Icon';
-import type { SessionIntent, ShareMode } from './types';
-
-export const intentMeta: Record<SessionIntent, { label: string; icon: IconName; note: string }> = {
-  general: { label: '일반', icon: 'general', note: '자유롭게 시작' },
-  analysis: { label: '분석', icon: 'analysis', note: '자료 기반 판단' },
-  brainstorm: { label: '브레인스토밍', icon: 'brainstorm', note: '옵션 탐색' },
-  writing: { label: '작성', icon: 'writing', note: '초안 생성' },
-  recap: { label: '정리', icon: 'recap', note: '결정/요약' },
-};
+import type { ShareMode } from './types';
 
 export const shareMeta: Record<ShareMode, { label: string; shortLabel: string; icon: IconName; className: string; desc: string }> = {
   private: { label: '비공개', shortLabel: '비공개', icon: 'lock', className: 'private', desc: '나만 봐요' },

--- a/app/src/domain/types.ts
+++ b/app/src/domain/types.ts
@@ -2,7 +2,6 @@ export type UserId = string;
 export type ProjectId = string;
 export type SessionId = string;
 export type ShareMode = 'private' | 'shared_readonly' | 'shared_chat';
-export type SessionIntent = 'general' | 'analysis' | 'brainstorm' | 'writing' | 'recap';
 export type RouteKey = 'projects' | 'project' | 'session' | 'files' | 'skills' | 'schedule' | 'members' | 'settings' | 'auth' | 'demo';
 
 export interface User {
@@ -32,7 +31,6 @@ export interface Session {
   creatorId: UserId;
   shareMode: ShareMode;
   origin: SessionOrigin;
-  intent: SessionIntent;
   updatedAt: string;
   lastMessageAt: string | null;
   lastMessageSnippet: string | null;
@@ -102,7 +100,6 @@ export interface SkillPreview {
   updatedAt: string;
   promptTemplate?: string;
   toolBindings?: string[];
-  defaultIntent?: SessionIntent;
   sourceSessionId?: SessionId;
   sourceMessageRange?: { startTurn: number; endTurn: number };
 }

--- a/app/src/lib/useDuplicateSession.ts
+++ b/app/src/lib/useDuplicateSession.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { duplicateSession } from '@/api/sessions';
+import { useToastStore } from '@/components/Toast';
+import type { Session } from '@/domain/types';
+
+type UseDuplicateSessionOptions = {
+  navigateOnSuccess?: boolean;
+};
+
+export function useDuplicateSession({ navigateOnSuccess = false }: UseDuplicateSessionOptions = {}) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const showToast = useToastStore((s) => s.show);
+
+  return useMutation({
+    mutationFn: (sessionId: string) => duplicateSession(sessionId),
+    onSuccess: async (session: Session) => {
+      await queryClient.invalidateQueries({ queryKey: ['sessions', session.projectId] });
+      showToast('세션이 복제되었습니다');
+      if (navigateOnSuccess) {
+        navigate({
+          to: '/projects/$projectId/sessions/$sessionId',
+          params: { projectId: session.projectId, sessionId: session.id },
+        });
+      }
+    },
+    onError: (err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      showToast(`세션 복제 실패: ${msg}`);
+    },
+  });
+}

--- a/app/src/lib/useDuplicateSession.ts
+++ b/app/src/lib/useDuplicateSession.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { duplicateSession } from '@/api/sessions';
+import { ApiError } from '@/api/client';
 import { useToastStore } from '@/components/Toast';
 import type { Session } from '@/domain/types';
 
@@ -14,6 +15,12 @@ export function useDuplicateSession() {
       showToast('세션이 복제되었습니다');
     },
     onError: (err) => {
+      // 423: agent lock held — typically the worker hasn't released after a
+      // cancel yet (heartbeat-driven, up to ~30s). Tell the user to retry.
+      if (err instanceof ApiError && err.status === 423) {
+        showToast('세션이 사용 중입니다. 잠시 후 다시 시도해주세요.');
+        return;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       showToast(`세션 복제 실패: ${msg}`);
     },

--- a/app/src/lib/useDuplicateSession.ts
+++ b/app/src/lib/useDuplicateSession.ts
@@ -1,16 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import { duplicateSession } from '@/api/sessions';
 import { useToastStore } from '@/components/Toast';
 import type { Session } from '@/domain/types';
 
-type UseDuplicateSessionOptions = {
-  navigateOnSuccess?: boolean;
-};
-
-export function useDuplicateSession({ navigateOnSuccess = false }: UseDuplicateSessionOptions = {}) {
+export function useDuplicateSession() {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const showToast = useToastStore((s) => s.show);
 
   return useMutation({
@@ -18,12 +12,6 @@ export function useDuplicateSession({ navigateOnSuccess = false }: UseDuplicateS
     onSuccess: async (session: Session) => {
       await queryClient.invalidateQueries({ queryKey: ['sessions', session.projectId] });
       showToast('세션이 복제되었습니다');
-      if (navigateOnSuccess) {
-        navigate({
-          to: '/projects/$projectId/sessions/$sessionId',
-          params: { projectId: session.projectId, sessionId: session.id },
-        });
-      }
     },
     onError: (err) => {
       const msg = err instanceof Error ? err.message : String(err);

--- a/app/src/lib/useDuplicateSession.ts
+++ b/app/src/lib/useDuplicateSession.ts
@@ -2,16 +2,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { duplicateSession } from '@/api/sessions';
 import { ApiError } from '@/api/client';
 import { useToastStore } from '@/components/Toast';
-import type { Session } from '@/domain/types';
 
-export function useDuplicateSession() {
+export function useDuplicateSession(projectSlug: string) {
   const queryClient = useQueryClient();
   const showToast = useToastStore((s) => s.show);
 
   return useMutation({
     mutationFn: (sessionId: string) => duplicateSession(sessionId),
-    onSuccess: async (session: Session) => {
-      await queryClient.invalidateQueries({ queryKey: ['sessions', session.projectId] });
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['sessions', projectSlug] });
       showToast('세션이 복제되었습니다');
     },
     onError: (err) => {

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import type { MouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '@/components/Icon';
+import { IconButton } from '@/components/uiPrimitives';
 import { MarkdownRenderer } from '@/components/chat/MarkdownRenderer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { summarizeCron } from '@/components/SchedulePicker';
@@ -794,22 +794,16 @@ function RailAction({
   onClick: () => void;
   disabled?: boolean;
 }) {
-  const handle = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    if (disabled) return;
-    onClick();
-  };
   return (
-    <button
-      type="button"
-      className="cw-rail-action"
-      title={label}
-      aria-label={label}
+    <IconButton
+      icon={icon}
+      label={label}
+      onClick={onClick}
       disabled={disabled}
-      onClick={handle}
-    >
-      <Icon name={icon} size={13} />
-    </button>
+      className="cw-rail-action"
+      iconSize={13}
+      stopPropagation
+    />
   );
 }
 

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -10,6 +10,7 @@ import { summarizeCron } from '@/components/SchedulePicker';
 import { cancelRun as cancelRunApi, createRun, listAutomations, listRunEvents, listRuns, listTriggers } from '@/api/automations';
 import { listMessages } from '@/api/messages';
 import { formatMessageTime } from '@/lib/formatMessageTime';
+import { useDuplicateSession } from '@/lib/useDuplicateSession';
 import type { Automation, Message, Run, Trigger } from '@/domain/types';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/automation/')({
@@ -321,6 +322,7 @@ function AutomationsPage() {
       void queryClient.invalidateQueries({ queryKey: ['runs', automationId] });
     },
   });
+  const duplicateMutation = useDuplicateSession({ navigateOnSuccess: true });
   const [pendingManualRun, setPendingManualRun] = useState<Automation | null>(null);
   const triggerManualRun = (automationId: string) => {
     if (manualRunMutation.isPending) return;
@@ -345,26 +347,20 @@ function AutomationsPage() {
     return (
     <>
       <header className="cw-run-drawer-head">
-        <div>
-          <div className="cw-run-drawer-title">
-            <StatusDot status={status} />
-            <strong>{automationById[run.automationId]?.name}</strong>
-            <span className="cw-run-attempt">#{shortRunId(run)}</span>
-          </div>
-          <div className="cw-run-drawer-meta">
-            <TriggerBadge trigger={trigger} placement="below-start" />
-            <span>{STATUS_LABEL[status]}</span>
-            <span>·</span>
-            <span>{formatRunWhen(run)}</span>
-            <span>·</span>
-            {status === 'queued' ? (
-              <span>scheduled {formatScheduledAt(run.scheduledFor)}</span>
-            ) : (
-              <span>duration {formatRunDuration(run)}</span>
-            )}
-          </div>
+        <div className="cw-run-drawer-title">
+          <StatusDot status={status} />
+          <strong>{automationById[run.automationId]?.name}</strong>
+          <span className="cw-run-attempt">#{shortRunId(run)}</span>
         </div>
         <div className="cw-run-drawer-actions">
+          <IconButton
+            icon="sticky-notes"
+            label="이 run의 세션 복제"
+            title="이 run의 세션을 복제"
+            expandedText="세션으로 복제"
+            confirmText="한 번 더 눌러 복제"
+            onClick={() => duplicateMutation.mutate(run.sessionId)}
+          />
           {cancellable && (
             <button
               type="button"
@@ -383,6 +379,18 @@ function AutomationsPage() {
           >
             <Icon name="x" size={16} />
           </button>
+        </div>
+        <div className="cw-run-drawer-meta">
+          <TriggerBadge trigger={trigger} placement="below-start" />
+          <span>{STATUS_LABEL[status]}</span>
+          <span>·</span>
+          <span>{formatRunWhen(run)}</span>
+          <span>·</span>
+          {status === 'queued' ? (
+            <span>scheduled {formatScheduledAt(run.scheduledFor)}</span>
+          ) : (
+            <span>duration {formatRunDuration(run)}</span>
+          )}
         </div>
       </header>
 

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -11,6 +11,7 @@ import { cancelRun as cancelRunApi, createRun, listAutomations, listRunEvents, l
 import { listMessages } from '@/api/messages';
 import { formatMessageTime } from '@/lib/formatMessageTime';
 import { useDuplicateSession } from '@/lib/useDuplicateSession';
+import { shortSessionId } from '@/lib/sessionId';
 import type { Automation, Message, Run, Trigger } from '@/domain/types';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/automation/')({
@@ -322,7 +323,7 @@ function AutomationsPage() {
       void queryClient.invalidateQueries({ queryKey: ['runs', automationId] });
     },
   });
-  const duplicateMutation = useDuplicateSession({ navigateOnSuccess: true });
+  const duplicateMutation = useDuplicateSession();
   const [pendingManualRun, setPendingManualRun] = useState<Automation | null>(null);
   const triggerManualRun = (automationId: string) => {
     if (manualRunMutation.isPending) return;
@@ -359,7 +360,14 @@ function AutomationsPage() {
             title="이 run의 세션을 복제"
             expandedText="세션으로 복제"
             confirmText="한 번 더 눌러 복제"
-            onClick={() => duplicateMutation.mutate(run.sessionId)}
+            onClick={() => duplicateMutation.mutate(run.sessionId, {
+              onSuccess: (newSession) => {
+                navigate({
+                  to: '/projects/$projectSlug/sessions/$sessionPrefix',
+                  params: { projectSlug, sessionPrefix: shortSessionId(newSession.id) },
+                });
+              },
+            })}
           />
           {cancellable && (
             <button

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -323,7 +323,7 @@ function AutomationsPage() {
       void queryClient.invalidateQueries({ queryKey: ['runs', automationId] });
     },
   });
-  const duplicateMutation = useDuplicateSession();
+  const duplicateMutation = useDuplicateSession(projectSlug);
   const [pendingManualRun, setPendingManualRun] = useState<Automation | null>(null);
   const triggerManualRun = (automationId: string) => {
     if (manualRunMutation.isPending) return;

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -344,6 +344,7 @@ function AutomationsPage() {
   const renderRunDetail = (run: Run) => {
     const status = effectiveStatus(run);
     const cancellable = status === 'queued' || status === 'running';
+    const forkable = !cancellable;
     const trigger = run.triggerId ? triggerById[run.triggerId] ?? null : null;
     return (
     <>
@@ -357,9 +358,14 @@ function AutomationsPage() {
           <IconButton
             icon="sticky-notes"
             label="이 run의 세션 복제"
-            title="이 run의 세션을 복제"
-            expandedText="세션으로 복제"
+            title={
+              !forkable ? '완료된 run만 복제할 수 있습니다'
+              : duplicateMutation.isPending ? '복제 중...'
+              : '이 run의 세션을 복제'
+            }
+            expandedText={duplicateMutation.isPending ? '복제 중...' : '세션으로 복제'}
             confirmText="한 번 더 눌러 복제"
+            disabled={!forkable || duplicateMutation.isPending}
             onClick={() => duplicateMutation.mutate(run.sessionId, {
               onSuccess: (newSession) => {
                 navigate({

--- a/app/src/routes/_app.projects.$projectSlug.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.index.tsx
@@ -7,7 +7,7 @@ import { getProject, listMembers } from '@/api/projects';
 import { createSession, deleteSession, listSessions } from '@/api/sessions';
 import { listDirents } from '@/api/dirents';
 import { Icon } from '@/components/Icon';
-import { ActivityRow, AvatarStack, EmptyState, InfoRow, IntentIcon, SectionLabel, SharePill } from '@/components/uiPrimitives';
+import { ActivityRow, AvatarStack, EmptyState, InfoRow, SectionLabel, SharePill } from '@/components/uiPrimitives';
 import { timeAgo } from '@/lib/timeAgo';
 import { useToastStore } from '@/components/Toast';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -178,7 +178,6 @@ function SessionCard({
     >
       <div className="cw-session-card-head">
         <span className="cw-session-card-title">
-          <IntentIcon intent={session.intent} force />
           <SessionTitleText title={session.title} />
         </span>
         <span className="cw-session-right">

--- a/app/src/routes/_app.projects.$projectSlug.members.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.members.tsx
@@ -199,7 +199,7 @@ function MembersPage() {
       )}
 
       {inviteOpen && (
-        <InviteDialog projectId={projectSlug} onClose={() => setInviteOpen(false)} />
+        <InviteDialog projectRef={projectSlug} onClose={() => setInviteOpen(false)} />
       )}
 
       {removeTarget && (

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -9,7 +9,7 @@ import { listMessages, streamMessage } from '@/api/messages';
 import { getProject, listMembers } from '@/api/projects';
 import { deleteDirent, downloadFile, uploadFiles, type DirentScope } from '@/api/dirents';
 import { Icon } from '@/components/Icon';
-import { Avatar, SharePill, ShareSelect } from '@/components/uiPrimitives';
+import { Avatar, IconButton, SharePill, ShareSelect } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
 import { useToastStore } from '@/components/Toast';
 import { shareMeta } from '@/domain/metadata';
@@ -25,6 +25,7 @@ import { AttachmentChip } from '@/components/AttachmentChip';
 import { AttachmentPreview } from '@/components/AttachmentPreview';
 import { FileTypeIcon } from '@/components/FileTypeIcon';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { useDuplicateSession } from '@/lib/useDuplicateSession';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sessionPrefix')({
   component: SessionPage,
@@ -219,6 +220,8 @@ function SessionPage() {
     }
   }, [composerText, streaming, sessionPrefix, projectSlug, projectId, sessionId, currentUser, queryClient, showToast, pendingAttachments]);
 
+  const duplicateMutation = useDuplicateSession({ navigateOnSuccess: true });
+
   const shareMutation = useMutation({
     mutationFn: (mode: ShareMode) => updateSessionShareMode(sessionPrefix, mode),
     onSuccess: async () => {
@@ -251,6 +254,16 @@ function SessionPage() {
             </p>
           </div>
           <div className="cw-session-head-actions">
+            {sess && (
+              <IconButton
+                icon="sticky-notes"
+                label="세션 복제"
+                title="Duplicate session"
+                expandedText="세션 복제"
+                confirmText="한 번 더 눌러 복제"
+                onClick={() => duplicateMutation.mutate(sessionId)}
+              />
+            )}
             {sess && (
               <ShareSelect mode={sess.shareMode} onChange={(mode) => shareMutation.mutate(mode)} />
             )}

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -222,7 +222,7 @@ function SessionPage() {
   }, [composerText, streaming, sessionPrefix, projectSlug, projectId, sessionId, currentUser, queryClient, showToast, pendingAttachments]);
 
   const navigate = useNavigate();
-  const duplicateMutation = useDuplicateSession();
+  const duplicateMutation = useDuplicateSession(projectSlug);
 
   const shareMutation = useMutation({
     mutationFn: (mode: ShareMode) => updateSessionShareMode(sessionPrefix, mode),

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -242,6 +242,7 @@ function SessionPage() {
   const creator = userList.find((u) => u.id === sess?.creatorId);
   const usersForRender: User[] = [...userList, AI_USER];
   const hasUploadingAttachments = pendingAttachments.some((a) => a.status === 'uploading');
+  const sessionForkable = !streaming && allMessages.length > 0;
 
   return (
     <div className="cw-session-layout cw-page-enter">
@@ -260,9 +261,15 @@ function SessionPage() {
               <IconButton
                 icon="sticky-notes"
                 label="세션 복제"
-                title="Duplicate session"
-                expandedText="세션 복제"
+                title={
+                  !sessionForkable
+                    ? (streaming ? '응답 생성이 끝난 뒤 복제할 수 있습니다' : '메시지가 있는 세션만 복제할 수 있습니다')
+                  : duplicateMutation.isPending ? '복제 중...'
+                  : 'Duplicate session'
+                }
+                expandedText={duplicateMutation.isPending ? '복제 중...' : '세션 복제'}
                 confirmText="한 번 더 눌러 복제"
+                disabled={!sessionForkable || duplicateMutation.isPending}
                 onClick={() => duplicateMutation.mutate(sessionId, {
                   onSuccess: (newSession) => {
                     navigate({

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -2,7 +2,7 @@
 // + composer) + right side (members, references, access, artifact).
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getSession, updateSessionShareMode } from '@/api/sessions';
 import { listMessages, streamMessage } from '@/api/messages';
@@ -26,6 +26,7 @@ import { AttachmentPreview } from '@/components/AttachmentPreview';
 import { FileTypeIcon } from '@/components/FileTypeIcon';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { useDuplicateSession } from '@/lib/useDuplicateSession';
+import { shortSessionId } from '@/lib/sessionId';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sessionPrefix')({
   component: SessionPage,
@@ -220,7 +221,8 @@ function SessionPage() {
     }
   }, [composerText, streaming, sessionPrefix, projectSlug, projectId, sessionId, currentUser, queryClient, showToast, pendingAttachments]);
 
-  const duplicateMutation = useDuplicateSession({ navigateOnSuccess: true });
+  const navigate = useNavigate();
+  const duplicateMutation = useDuplicateSession();
 
   const shareMutation = useMutation({
     mutationFn: (mode: ShareMode) => updateSessionShareMode(sessionPrefix, mode),
@@ -261,7 +263,14 @@ function SessionPage() {
                 title="Duplicate session"
                 expandedText="세션 복제"
                 confirmText="한 번 더 눌러 복제"
-                onClick={() => duplicateMutation.mutate(sessionId)}
+                onClick={() => duplicateMutation.mutate(sessionId, {
+                  onSuccess: (newSession) => {
+                    navigate({
+                      to: '/projects/$projectSlug/sessions/$sessionPrefix',
+                      params: { projectSlug, sessionPrefix: shortSessionId(newSession.id) },
+                    });
+                  },
+                })}
               />
             )}
             {sess && (

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -9,7 +9,7 @@ import { listMessages, streamMessage } from '@/api/messages';
 import { getProject, listMembers } from '@/api/projects';
 import { deleteDirent, downloadFile, uploadFiles, type DirentScope } from '@/api/dirents';
 import { Icon } from '@/components/Icon';
-import { Avatar, IntentBadge, SharePill, ShareSelect } from '@/components/uiPrimitives';
+import { Avatar, SharePill, ShareSelect } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
 import { useToastStore } from '@/components/Toast';
 import { shareMeta } from '@/domain/metadata';
@@ -251,7 +251,6 @@ function SessionPage() {
             </p>
           </div>
           <div className="cw-session-head-actions">
-            {sess && <IntentBadge intent={sess.intent} />}
             {sess && (
               <ShareSelect mode={sess.shareMode} onChange={(mode) => shareMutation.mutate(mode)} />
             )}

--- a/app/src/routes/_app.tsx
+++ b/app/src/routes/_app.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/stores/auth';
 import { useLayoutStore } from '@/stores/layout';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { appWs } from '@/api/ws';
-import type { Session } from '@/domain/types';
+import type { Project, Session } from '@/domain/types';
 
 export const Route = createFileRoute('/_app')({
   beforeLoad: () => {
@@ -42,7 +42,13 @@ function AppShell() {
           ['session', event.session_id],
           (old) => (old ? { ...old, title: event.title } : old),
         );
-        void queryClient.invalidateQueries({ queryKey: ['sessions', event.project_id] });
+        // Session lists are keyed by project slug; event carries only the UUID.
+        // Resolve via the projects cache; no-op if it isn't loaded yet.
+        const projects = queryClient.getQueryData<Project[]>(['projects']) ?? [];
+        const slug = projects.find((p) => p.id === event.project_id)?.slug;
+        if (slug) {
+          void queryClient.invalidateQueries({ queryKey: ['sessions', slug] });
+        }
       }
     });
     return () => {

--- a/app/src/styles/cowork-design-system.css
+++ b/app/src/styles/cowork-design-system.css
@@ -67,9 +67,7 @@
   --cw-icon-private:    var(--cw-cozy-clay);
   --cw-icon-readonly:   var(--cw-cozy-teal);
   --cw-icon-shared:     var(--cw-cozy-sage);
-  --cw-icon-general:    var(--cw-cozy-clay);
   --cw-icon-analysis:   var(--cw-cozy-teal);
-  --cw-icon-brainstorm: var(--cw-cozy-honey);
   --cw-icon-writing:    var(--cw-cozy-plum);
   --cw-icon-recap:      var(--cw-cozy-sage);
 

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -255,6 +255,23 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
 .cw-btn-primary:hover { background: var(--cw-primary-hover); }
 .cw-btn-secondary { background: var(--cw-bg); color: var(--cw-fg-1); border: 1px solid var(--cw-border); }
 .cw-btn-secondary:hover { border-color: var(--cw-border-hover); background: var(--cw-bg-muted); }
+
+/* Ghost icon-only button — base for IconButton primitive. Modifiers (e.g.
+   .cw-rail-action) layer on top to override size or add row-hover gating. */
+.cw-icon-button { width: 30px; height: 30px; display: inline-flex; align-items: center; justify-content: center; border: 0; background: transparent; color: var(--cw-ink-3); border-radius: 6px; padding: 0; cursor: pointer; transition: background 120ms, color 120ms; }
+.cw-icon-button:hover { background: var(--cw-paper-3); color: var(--cw-ink-1); }
+.cw-icon-button:disabled { opacity: 0.5; cursor: not-allowed; }
+/* Expandable variant: 30×30 square that grows on hover to reveal the label.
+   Label uses max-width transition so width animates smoothly with content. */
+.cw-icon-button.is-expandable { width: auto; min-width: 30px; justify-content: flex-start; }
+.cw-icon-button.is-expandable .cw-icon-button-icon { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; flex: 0 0 30px; }
+.cw-icon-button.is-expandable .cw-icon-button-label { max-width: 0; overflow: hidden; white-space: nowrap; font-size: 12px; font-weight: 500; padding: 0; transition: max-width 180ms ease, padding 180ms ease; }
+.cw-icon-button.is-expandable:hover .cw-icon-button-label,
+.cw-icon-button.is-expandable.is-armed .cw-icon-button-label { max-width: 200px; padding-right: 10px; }
+/* Armed (two-click confirm) state. Primary-tone bg to read as a CTA: "this
+   click executes". Disarms on mouse-leave (handled in JS). */
+.cw-icon-button.is-armed,
+.cw-icon-button.is-armed:hover { background: var(--cw-primary); color: var(--cw-fg-on-primary); }
 .wide { width: 100%; }
 
 .cw-project-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
@@ -1468,24 +1485,24 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 }
 .cw-rail-trigger-meta { color: var(--cw-ink-3); white-space: pre-line; line-height: 1.4; }
 .cw-rail-trigger-none { font-style: italic; color: var(--cw-ink-4); }
+/* Rail-action layers over .cw-icon-button: smaller (24×24), uses radius-sm,
+   hidden by default and revealed only when the parent row is hovered/active
+   (the visibility selectors below). The opacity transition is added on top
+   of the base button transition so reveal animates. */
 .cw-rail-action {
-  border: 0;
-  background: transparent;
-  color: var(--cw-ink-3);
   width: 24px;
   height: 24px;
   flex: 0 0 24px;
   border-radius: var(--cw-radius-sm);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
   opacity: 0;
   transition: opacity 120ms, background 120ms, color 120ms;
 }
-.cw-rail-row-automation:hover .cw-rail-action { opacity: 1; transition-delay: 300ms; }
-.cw-rail-row-automation:focus-within .cw-rail-action { opacity: 1; transition-delay: 0s; }
-.cw-rail-row-automation.is-active .cw-rail-action { opacity: 1; transition-delay: 0s; }
+/* 300ms delay applies ONLY to opacity so the action's own hover bg/color
+   respond immediately once it's visible. (Single transition-delay value
+   would cascade across all transitioned properties.) */
+.cw-rail-row-automation:hover .cw-rail-action { opacity: 1; transition-delay: 300ms, 0s, 0s; }
+.cw-rail-row-automation:focus-within .cw-rail-action { opacity: 1; transition-delay: 0s, 0s, 0s; }
+.cw-rail-row-automation.is-active .cw-rail-action { opacity: 1; transition-delay: 0s, 0s, 0s; }
 .cw-rail-action:hover { background: var(--cw-paper-4); color: var(--cw-ink); }
 
 /* Rail header: large "Automations" title + icon create button */

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1751,14 +1751,21 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   max-height: calc(100vh - 32px);
   overflow: auto;
 }
+/* Grid so title shares row 1 with actions while meta sits on its own row 2
+   spanning full width — the actions' hover-expand only competes with title
+   for row-1 space, never with meta. */
 .cw-run-drawer-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: 12px;
+  row-gap: 6px;
+  align-items: center;
   padding-bottom: 12px;
   border-bottom: 1px solid var(--cw-line-soft);
 }
+.cw-run-drawer-head > .cw-run-drawer-title { grid-column: 1; grid-row: 1; min-width: 0; }
+.cw-run-drawer-head > .cw-run-drawer-actions { grid-column: 2; grid-row: 1; }
+.cw-run-drawer-head > .cw-run-drawer-meta { grid-column: 1 / -1; grid-row: 2; }
 .cw-run-drawer-title { display: inline-flex; align-items: center; gap: 8px; }
 .cw-run-drawer-title strong { font-size: 14px; font-weight: 650; color: var(--cw-ink); }
 .cw-run-drawer-meta {
@@ -1766,7 +1773,6 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   align-items: center;
   gap: 6px;
   flex-wrap: wrap;
-  margin-top: 6px;
   font-size: 12px;
   color: var(--cw-ink-3);
 }

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -495,15 +495,12 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
 .cw-simple-page ol { line-height: 1.8; color: var(--cw-fg-2); }
 
 .cw-pocket { width: 22px; height: 22px; display: inline-grid; place-items: center; border-radius: var(--cw-radius-sm); border: 1px solid var(--cw-line-soft); background: var(--cw-bg); flex: 0 0 auto; }
-.cw-intent-analysis, .cw-file-pdf { background: oklch(0.96 0.018 210); color: var(--cw-icon-analysis); }
-.cw-intent-brainstorm { background: oklch(0.97 0.025 75); color: var(--cw-icon-brainstorm); }
-.cw-intent-writing, .cw-file-doc { background: oklch(0.965 0.018 340); color: var(--cw-icon-writing); }
-.cw-intent-recap, .cw-file-folder { background: oklch(0.96 0.018 150); color: var(--cw-icon-recap); }
-.cw-intent-general { background: oklch(0.965 0.020 25); color: var(--cw-icon-general); }
+.cw-file-pdf { background: oklch(0.96 0.018 210); color: var(--cw-icon-analysis); }
+.cw-file-doc { background: oklch(0.965 0.018 340); color: var(--cw-icon-writing); }
+.cw-file-folder { background: oklch(0.96 0.018 150); color: var(--cw-icon-recap); }
 .cw-file-sheet { background: oklch(0.96 0.018 150); color: var(--cw-cozy-sage); }
 .cw-file-image { background: oklch(0.965 0.018 45); color: var(--cw-cozy-clay); }
-.cw-intent-dot { width: 7px; height: 7px; border-radius: 2px; background: var(--cw-fg-3); }
-.cw-intent-badge, .cw-share-pill, .cw-share-select { display: inline-flex; align-items: center; gap: 6px; min-height: 30px; border-radius: var(--cw-radius-full); border: 1px solid var(--cw-border); background: var(--cw-bg); color: var(--cw-fg-2); padding: 4px 9px; font-size: 12px; }
+.cw-share-pill, .cw-share-select { display: inline-flex; align-items: center; gap: 6px; min-height: 30px; border-radius: var(--cw-radius-full); border: 1px solid var(--cw-border); background: var(--cw-bg); color: var(--cw-fg-2); padding: 4px 9px; font-size: 12px; }
 .cw-share-select select { border: 0; outline: 0; background: transparent; color: inherit; }
 .cw-share-pill.private, .cw-share-select.private { background: var(--cw-share-private-bg); border-color: var(--cw-share-private-border); color: var(--cw-share-private-fg); }
 .cw-share-pill.readonly, .cw-share-select.readonly { background: var(--cw-share-readonly-bg); border-color: var(--cw-share-readonly-border); color: var(--cw-share-readonly-fg); }
@@ -529,11 +526,6 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
 .cw-dialog .cw-field input:focus-visible { outline: 2px solid var(--cw-accent-line); outline-offset: 0; border-color: var(--cw-accent-line); }
 .cw-dialog .cw-field input[aria-invalid="true"] { border-color: color-mix(in oklch, var(--cw-destructive), transparent 40%); }
 .cw-dialog-warn { display: inline-flex; align-items: center; gap: 6px; margin-top: 8px; padding: 7px 12px; border-radius: var(--cw-radius-md); background: color-mix(in oklch, var(--cw-destructive), white 92%); border: 1px solid color-mix(in oklch, var(--cw-destructive), transparent 65%); color: oklch(0.42 0.14 25); font-size: 12.5px; line-height: 1.4; }
-.cw-intent-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin: 18px 0; }
-.cw-intent-grid button { display: grid; grid-template-columns: auto 1fr; gap: 4px 10px; align-items: center; text-align: left; border: 1px solid var(--cw-border); border-radius: var(--cw-radius-lg); background: var(--cw-bg-subtle); padding: 12px; }
-.cw-intent-grid button span:last-child { grid-column: 2; color: var(--cw-fg-3); font-size: 12px; }
-.cw-intent-grid button.is-active { border-color: var(--cw-accent-line); background: var(--cw-accent-soft); }
-
 @keyframes cw-enter { from { opacity: 0; } to { opacity: 1; } }
 @keyframes cw-rise { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes cw-ping { 50% { opacity: .25; } }
@@ -720,11 +712,6 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   background: var(--cw-paper-3);
   color: var(--cw-ink-3);
 }
-.cw-intent-general { background: color-mix(in oklch, var(--cw-cozy-clay) 14%, var(--cw-paper)); color: var(--cw-cozy-clay); }
-.cw-intent-analysis { background: color-mix(in oklch, var(--cw-cozy-teal) 14%, var(--cw-paper)); color: var(--cw-cozy-teal); }
-.cw-intent-brainstorm { background: color-mix(in oklch, var(--cw-cozy-honey) 18%, var(--cw-paper)); color: oklch(0.50 0.13 75); }
-.cw-intent-writing { background: color-mix(in oklch, var(--cw-cozy-plum) 14%, var(--cw-paper)); color: var(--cw-cozy-plum); }
-.cw-intent-recap { background: color-mix(in oklch, var(--cw-cozy-sage) 14%, var(--cw-paper)); color: var(--cw-cozy-sage); }
 .cw-share-pill,
 .cw-share-select {
   min-height: 20px;
@@ -734,7 +721,6 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   font-size: 10px;
   font-weight: 500;
 }
-.cw-intent-badge { min-height: 24px; padding: 3px 10px 3px 8px; font-size: 11px; }
 
 .cw-file-browser {
   border-radius: 12px;


### PR DESCRIPTION
## Ticket
resolves #106 

## Description
- **Session duplicate (fork)** — exposes `POST /sessions/{id}/fork` in three UI spots (**sidebar menu**, **session header**, **automation run detail**).
  - Inline buttons use two-click confirm; sidebar menu uses a confirm dialog.
  - Success navigates to the new session in all three.
- **`IconButton` primitive** — ghost icon-only button with `expandedText` (hover-expand) and `confirmText` (two-click confirm). `RailAction` is refactored to use it.
- Removes the unused `SessionIntent` feature (the transformer hard-coded every session to `general`, so the badges/icons carried no signal).

## Test plan
- [x] Sidebar menu → Duplicate → confirm dialog → lands on the new session
- [x] Session header Duplicate button: hover expands, two clicks fire
- [x] Automation run detail Duplicate (verify new session is `origin = user`)
- [x] Trigger row hover/focus reveal animation still works (RailAction)
- [x] No `IntentBadge`/`IntentIcon` rendered anywhere; session lists still load
### Added tests
- [x] No `GET /sessions//artifacts` 400 in network tab right after fork
- [x] Duplicate from sidebar menu / session header / automation run drawer all land on `/projects/{slug}/sessions/{prefix}` with a success toast
- [x] Automation run: button disabled for `queued`/`running`, enabled for terminal statuses
- [x] Session detail: button disabled while streaming and on a 0-message session, enabled otherwise
- [x] Pending: every Duplicate IconButton goes disabled + shows "복제 중..." until navigation
- [x] Sidebar menu: Duplicate item disabled on empty sessions; confirm dialog body mentions "in use may fail"; dialog stays open until success/error

## Screenshots
### Sidebar menu
<img width="256" height="127" alt="스크린샷 2026-05-28 오후 12 58 20" src="https://github.com/user-attachments/assets/2d8ec385-dcbe-4f3a-98a2-9ee2a3a52709" />
<img width="528" height="277" alt="image" src="https://github.com/user-attachments/assets/47730f61-8698-47dd-aa69-77547b514f0f" />
<img width="234" height="116" alt="image" src="https://github.com/user-attachments/assets/c1e49d05-4eae-4c54-a975-32b7d0350a16" />

### Session page header
basic / hover / click once(twice for confirm)
(you can see the features of `IconButton` component here.)
<img width="288" height="101" alt="스크린샷 2026-05-28 오후 12 58 42" src="https://github.com/user-attachments/assets/954ac350-6873-4477-8acc-275e885eb2f4" />
<img width="292" height="96" alt="스크린샷 2026-05-28 오후 12 58 48" src="https://github.com/user-attachments/assets/9fb80a06-2aed-48b7-ad25-7043ebc95931" />
<img width="294" height="90" alt="스크린샷 2026-05-28 오후 12 58 53" src="https://github.com/user-attachments/assets/75447d9e-ba87-40c2-89a0-0b44330ba62c" />
<img width="288" height="78" alt="image" src="https://github.com/user-attachments/assets/41f58c47-5c97-4928-89fc-75ca7460900b" />

### Automation run detail panel
basic / hover / click once(twice for confirm)
<img width="448" height="88" alt="스크린샷 2026-05-28 오후 12 59 02" src="https://github.com/user-attachments/assets/1176e549-ceb3-4b73-b95c-a11d4cf998c9" />
<img width="439" height="86" alt="스크린샷 2026-05-28 오후 1 04 05" src="https://github.com/user-attachments/assets/bcefe121-dfd7-4b11-9dbe-38ed45571fa1" />
<img width="443" height="89" alt="스크린샷 2026-05-28 오후 12 59 28" src="https://github.com/user-attachments/assets/714d5d44-5c85-497f-b0da-ecb134ca31b0" />
<img width="443" height="92" alt="image" src="https://github.com/user-attachments/assets/0840e0f9-b1f2-4842-a564-7f2422182a16" />
