### PR TITLE
feat(app): project home as a new-conversation composer surface

### DIFF
--- a/app/src/components/Icon.tsx
+++ b/app/src/components/Icon.tsx
@@ -99,6 +99,7 @@ const iconAlias: Record<IconName, PreviewIconName> = {
   grid: 'grid-3x3',
   'chevron-right': 'chevron-right',
   'chevron-left': 'chevron-left',
+  paperclip: 'paperclip',
   /* PDF doesn't have its own Lucide glyph — reuse file-text and let colour
      (cw-file-pdf rose tint) carry the type signal. */
   'file-pdf': 'file-text',
@@ -106,7 +107,6 @@ const iconAlias: Record<IconName, PreviewIconName> = {
   'file-archive': 'file-archive',
   'file-video': 'file-video',
   'file-audio': 'file-audio',
-  paperclip: 'paperclip',
 };
 
 export function Icon({ name, size = 16, className = '', strokeWidth = 2, style, ...props }: SVGProps<SVGSVGElement> & { name: IconName; size?: number }) {

--- a/app/src/components/SessionCard.tsx
+++ b/app/src/components/SessionCard.tsx
@@ -1,0 +1,55 @@
+// Session card — rich session preview (title, snippet, time, share, unread).
+// Shared by the project home (previously) and the "View all" sessions overlay.
+
+import { IntentIcon, SharePill } from '@/components/uiPrimitives';
+import { SessionCardMenu } from '@/components/SessionCardMenu';
+import { SessionTitleText } from '@/components/SessionTitleText';
+import { timeAgo } from '@/lib/timeAgo';
+import type { Session } from '@/domain/types';
+
+export function SessionCard({
+  session,
+  canDelete,
+  onOpen,
+  onRequestDelete,
+}: {
+  session: Session;
+  canDelete: boolean;
+  onOpen: () => void;
+  onRequestDelete: () => void;
+}) {
+  const isUnread = session.unreadCount > 0;
+  const timeLabel = session.lastMessageAt ? timeAgo(session.lastMessageAt) : null;
+
+  return (
+    <div
+      className={`cw-session-card${isUnread ? ' is-unread' : ''}`}
+      onClick={onOpen}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="cw-session-card-head">
+        <span className="cw-session-card-title">
+          <IntentIcon intent={session.intent} force />
+          <SessionTitleText title={session.title} />
+        </span>
+        <span className="cw-session-right">
+          {isUnread && (
+            <span className="cw-unread-badge" aria-label={`unread ${session.unreadCount}`}>
+              <span className="dot" />
+              <span className="n">{session.unreadCount}</span>
+            </span>
+          )}
+          <SharePill mode={session.shareMode} compact />
+          {canDelete && <SessionCardMenu onDelete={onRequestDelete} />}
+        </span>
+      </div>
+      {session.lastMessageSnippet && (
+        <p className="cw-session-last">{session.lastMessageSnippet}</p>
+      )}
+      <div className="cw-session-card-footer">
+        {timeLabel && <span className="cw-card-time">{timeLabel}</span>}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/SessionsOverlay.tsx
+++ b/app/src/components/SessionsOverlay.tsx
@@ -2,7 +2,7 @@
 // from the sidebar SESSIONS header. Shows every session of a project as a card
 // grid. Self-contained: takes only projectSlug and handles its own data + delete.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
@@ -25,6 +25,12 @@ export function SessionsOverlay({ projectSlug, onClose }: { projectSlug: string;
   const project = useQuery({ queryKey: ['project', projectSlug], queryFn: () => getProject(projectSlug) });
   const sessions = useQuery({ queryKey: ['sessions', projectSlug], queryFn: () => listSessions(projectSlug) });
 
+  // Move focus to the close button on mount so keyboard users can dismiss immediately.
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
   // Close on Escape.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
@@ -45,7 +51,7 @@ export function SessionsOverlay({ projectSlug, onClose }: { projectSlug: string;
       <div className="cw-sessions-overlay" role="dialog" aria-modal="true" aria-label="All sessions">
         <div className="cw-overlay-head">
           <h2>Sessions · {sessionList.length}</h2>
-          <button type="button" className="cw-overlay-close" onClick={onClose} aria-label="닫기">
+          <button ref={closeButtonRef} type="button" className="cw-overlay-close" onClick={onClose} aria-label="닫기">
             <Icon name="x" size={18} />
           </button>
         </div>

--- a/app/src/components/SessionsOverlay.tsx
+++ b/app/src/components/SessionsOverlay.tsx
@@ -1,0 +1,90 @@
+// "View all" sessions overlay — a wide modal floating over the main area, opened
+// from the sidebar SESSIONS header. Shows every session of a project as a card
+// grid. Self-contained: takes only projectSlug and handles its own data + delete.
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useNavigate } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { getProject } from '@/api/projects';
+import { listSessions } from '@/api/sessions';
+import { Icon } from '@/components/Icon';
+import { EmptyState } from '@/components/uiPrimitives';
+import { SessionCard } from '@/components/SessionCard';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { useAuthStore } from '@/stores/auth';
+import { canAdministerSession } from '@/lib/permissions';
+import { shortSessionId } from '@/lib/sessionId';
+import { useSessionDelete } from '@/lib/useSessionDelete';
+import type { Session } from '@/domain/types';
+
+export function SessionsOverlay({ projectSlug, onClose }: { projectSlug: string; onClose: () => void }) {
+  const navigate = useNavigate();
+  const currentUser = useAuthStore((s) => s.currentUser);
+
+  const project = useQuery({ queryKey: ['project', projectSlug], queryFn: () => getProject(projectSlug) });
+  const sessions = useQuery({ queryKey: ['sessions', projectSlug], queryFn: () => listSessions(projectSlug) });
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const [pendingDelete, setPendingDelete] = useState<Session | null>(null);
+  const deleteMutation = useSessionDelete(projectSlug, { onDeleted: () => setPendingDelete(null) });
+
+  const sessionList = (sessions.data ?? []).filter((s) => s.origin === 'user');
+
+  // Render via portal to document.body so `position: fixed` is relative to the
+  // viewport — not the sidebar (whose transform would otherwise trap it).
+  return createPortal(
+    <>
+      <div className="cw-overlay-backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="cw-sessions-overlay" role="dialog" aria-modal="true" aria-label="All sessions">
+        <div className="cw-overlay-head">
+          <h2>Sessions · {sessionList.length}</h2>
+          <button type="button" className="cw-overlay-close" onClick={onClose} aria-label="닫기">
+            <Icon name="x" size={18} />
+          </button>
+        </div>
+        <div className="cw-overlay-body cw-scroll-quiet">
+          {sessionList.length ? (
+            <div className="cw-session-grid">
+              {sessionList.map((session) => (
+                <SessionCard
+                  key={session.id}
+                  session={session}
+                  canDelete={canAdministerSession(session, project.data, currentUser)}
+                  onOpen={() => {
+                    navigate({
+                      to: '/projects/$projectSlug/sessions/$sessionPrefix',
+                      params: { projectSlug, sessionPrefix: shortSessionId(session.id) },
+                    });
+                    onClose();
+                  }}
+                  onRequestDelete={() => setPendingDelete(session)}
+                />
+              ))}
+            </div>
+          ) : (
+            <EmptyState title="No sessions yet" body="새 대화를 시작하면 여기에 쌓입니다." chip="+" />
+          )}
+        </div>
+      </div>
+      {pendingDelete && (
+        <ConfirmDialog
+          title="세션을 삭제하시겠어요?"
+          body={`"${pendingDelete.title}"의 모든 메시지와 sandbox 자원이 함께 정리됩니다. 이 작업은 되돌릴 수 없습니다.`}
+          confirmLabel="삭제"
+          destructive
+          pending={deleteMutation.isPending}
+          onConfirm={() => deleteMutation.mutate(pendingDelete.id)}
+          onClose={() => setPendingDelete(null)}
+        />
+      )}
+    </>,
+    document.body,
+  );
+}

--- a/app/src/components/chat/ComposerAgentPicker.tsx
+++ b/app/src/components/chat/ComposerAgentPicker.tsx
@@ -1,0 +1,92 @@
+// Agent / mode selector for the project-home composer, shown as a segmented tab
+// row above the input (Perplexity Search/Research style). This picks WHICH agent
+// surface drives the conversation — a different axis from the LLM model picker.
+//
+// Mock for now: the selection is not wired to create-session / dispatch yet
+// (the backend's CreateSessionRequest only takes project_id, with
+// deny_unknown_fields). The IDs below are the real intended agent surfaces so the
+// seam is concrete — a follow-up PR routes ComposerSubmission.agentHint here.
+
+import { Icon, type IconName } from '@/components/Icon';
+
+export type AgentId = 'coworker' | 'speedwagon' | 'deep-research' | 'buddy';
+
+interface AgentOption {
+  id: AgentId;
+  label: string;
+  icon: IconName;
+  // One-line role, shown as a subtitle under the active tab.
+  blurb: string;
+  // Composer placeholder when this agent is active, so the surface reacts to the choice.
+  placeholder: string;
+}
+
+export const AGENT_OPTIONS: readonly AgentOption[] = [
+  {
+    id: 'coworker',
+    label: 'Coworker',
+    icon: 'zap',
+    blurb: '작업 실행 에이전트',
+    placeholder: '실행할 작업을 적어줘…',
+  },
+  {
+    id: 'speedwagon',
+    label: 'Speedwagon',
+    icon: 'search',
+    blurb: '지식 기반 질의 응답',
+    placeholder: '무엇이 궁금해?',
+  },
+  {
+    id: 'deep-research',
+    label: 'Deep Research',
+    icon: 'analysis',
+    blurb: '심층 조사·리서치',
+    placeholder: '무엇을 조사할까?',
+  },
+  {
+    id: 'buddy',
+    label: 'Buddy',
+    icon: 'brainstorm',
+    blurb: '브레인스토밍·번역 등 채팅',
+    placeholder: '편하게 말 걸어줘…',
+  },
+] as const;
+
+export const DEFAULT_AGENT_ID: AgentId = 'coworker';
+
+export function getAgentOption(id: AgentId): AgentOption {
+  return AGENT_OPTIONS.find((a) => a.id === id) ?? AGENT_OPTIONS[0];
+}
+
+export function ComposerAgentPicker({
+  value,
+  onChange,
+}: {
+  value: AgentId;
+  onChange: (id: AgentId) => void;
+}) {
+  const active = getAgentOption(value);
+  return (
+    <div className="cw-agent-picker">
+      <div role="tablist" aria-label="에이전트 선택 (미리보기)" className="cw-agent-tabs">
+        {AGENT_OPTIONS.map((agent) => {
+          const isActive = agent.id === value;
+          return (
+            <button
+              key={agent.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              className={`cw-agent-tab${isActive ? ' is-active' : ''}`}
+              onClick={() => onChange(agent.id)}
+            >
+              <Icon name={agent.icon} size={15} />
+              <span>{agent.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <p className="cw-agent-blurb">{active.blurb}</p>
+    </div>
+  );
+}

--- a/app/src/components/chat/ComposerAgentPicker.tsx
+++ b/app/src/components/chat/ComposerAgentPicker.tsx
@@ -1,63 +1,18 @@
 // Agent / mode selector for the project-home composer, shown as a segmented tab
-// row above the input (Perplexity Search/Research style). This picks WHICH agent
-// surface drives the conversation — a different axis from the LLM model picker.
+// row attached to the top of the composer box. Picks WHICH agent surface drives
+// the conversation — a different axis from the LLM model picker.
 //
 // Mock for now: the selection is not wired to create-session / dispatch yet
 // (the backend's CreateSessionRequest only takes project_id, with
 // deny_unknown_fields). The IDs below are the real intended agent surfaces so the
-// seam is concrete — a follow-up PR routes ComposerSubmission.agentHint here.
+// seam is concrete — a follow-up PR routes the home-composer agent hint here.
 
-import { Icon, type IconName } from '@/components/Icon';
+import { useLayoutEffect, useRef, useState, type CSSProperties } from 'react';
+import { Icon } from '@/components/Icon';
+import { AGENT_SURFACES, type AgentId } from '@/domain/agentSurfaces';
 
-export type AgentId = 'coworker' | 'speedwagon' | 'deep-research' | 'buddy';
-
-interface AgentOption {
-  id: AgentId;
-  label: string;
-  icon: IconName;
-  // One-line role, shown as a subtitle under the active tab.
-  blurb: string;
-  // Composer placeholder when this agent is active, so the surface reacts to the choice.
-  placeholder: string;
-}
-
-export const AGENT_OPTIONS: readonly AgentOption[] = [
-  {
-    id: 'coworker',
-    label: 'Coworker',
-    icon: 'zap',
-    blurb: '작업 실행 에이전트',
-    placeholder: '실행할 작업을 적어줘…',
-  },
-  {
-    id: 'speedwagon',
-    label: 'Speedwagon',
-    icon: 'search',
-    blurb: '지식 기반 질의 응답',
-    placeholder: '무엇이 궁금해?',
-  },
-  {
-    id: 'deep-research',
-    label: 'Deep Research',
-    icon: 'analysis',
-    blurb: '심층 조사·리서치',
-    placeholder: '무엇을 조사할까?',
-  },
-  {
-    id: 'buddy',
-    label: 'Buddy',
-    icon: 'brainstorm',
-    blurb: '브레인스토밍·번역 등 채팅',
-    placeholder: '편하게 말 걸어줘…',
-  },
-] as const;
-
-export const DEFAULT_AGENT_ID: AgentId = 'coworker';
-
-export function getAgentOption(id: AgentId): AgentOption {
-  return AGENT_OPTIONS.find((a) => a.id === id) ?? AGENT_OPTIONS[0];
-}
-
+// Renders only the tab row — the wrapping container lives in the home route
+// so the picker and composer share one bordered box.
 export function ComposerAgentPicker({
   value,
   onChange,
@@ -65,28 +20,73 @@ export function ComposerAgentPicker({
   value: AgentId;
   onChange: (id: AgentId) => void;
 }) {
-  const active = getAgentOption(value);
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const [indicator, setIndicator] = useState({ left: 0, width: 0 });
+
+  useLayoutEffect(() => {
+    const tabs = tabsRef.current;
+    if (!tabs) return;
+
+    const activeTab = tabs.querySelector<HTMLButtonElement>(`button[data-agent="${value}"]`);
+    if (!activeTab) return;
+
+    const updateIndicator = () => {
+      const tabsRect = tabs.getBoundingClientRect();
+      const tabRect = activeTab.getBoundingClientRect();
+      setIndicator({
+        left: tabRect.left - tabsRect.left,
+        width: tabRect.width,
+      });
+    };
+
+    updateIndicator();
+
+    const resizeObserver = new ResizeObserver(updateIndicator);
+    resizeObserver.observe(tabs);
+    resizeObserver.observe(activeTab);
+    window.addEventListener('resize', updateIndicator);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateIndicator);
+    };
+  }, [value]);
+
+  const indicatorStyle = {
+    '--cw-agent-indicator-left': `${indicator.left}px`,
+    '--cw-agent-indicator-width': `${indicator.width}px`,
+  } as CSSProperties;
+
   return (
-    <div className="cw-agent-picker">
-      <div role="tablist" aria-label="에이전트 선택 (미리보기)" className="cw-agent-tabs">
-        {AGENT_OPTIONS.map((agent) => {
-          const isActive = agent.id === value;
-          return (
-            <button
-              key={agent.id}
-              type="button"
-              role="tab"
-              aria-selected={isActive}
-              className={`cw-agent-tab${isActive ? ' is-active' : ''}`}
-              onClick={() => onChange(agent.id)}
-            >
-              <Icon name={agent.icon} size={15} />
-              <span>{agent.label}</span>
-            </button>
-          );
-        })}
-      </div>
-      <p className="cw-agent-blurb">{active.blurb}</p>
+    <div
+      ref={tabsRef}
+      role="group"
+      aria-label="에이전트 선택"
+      className="cw-agent-tabs"
+    >
+      <span
+        key={value}
+        aria-hidden
+        className="cw-agent-tab-indicator"
+        data-agent={value}
+        style={indicatorStyle}
+      />
+      {AGENT_SURFACES.map((agent) => {
+        const isActive = agent.id === value;
+        return (
+          <button
+            key={agent.id}
+            type="button"
+            aria-pressed={isActive}
+            data-agent={agent.id}
+            className={`cw-agent-tab${isActive ? ' is-active' : ''}`}
+            onClick={() => onChange(agent.id)}
+          >
+            <Icon name={agent.icon} size={15} />
+            <span>{agent.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/app/src/components/chat/ComposerModelPicker.tsx
+++ b/app/src/components/chat/ComposerModelPicker.tsx
@@ -1,0 +1,64 @@
+// Provider model selector for the composer, in the ChatGPT/Claude style: pick the
+// underlying LLM (Claude / OpenAI / Gemini model) for the conversation. This is a
+// mock for now — the selection is not yet wired to the router/dispatcher — but the
+// labels are the real provider model names, grouped by provider.
+
+import { Icon } from '@/components/Icon';
+
+export type ModelId = string;
+
+interface ProviderGroup {
+  provider: string;
+  models: { id: ModelId; label: string }[];
+}
+
+export const PROVIDER_MODELS: readonly ProviderGroup[] = [
+  {
+    provider: 'Claude',
+    models: [
+      { id: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
+      { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+    ],
+  },
+  {
+    provider: 'OpenAI',
+    models: [
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+    ],
+  },
+  {
+    provider: 'Gemini',
+    models: [
+      { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+      { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+    ],
+  },
+] as const;
+
+export const DEFAULT_MODEL_ID: ModelId = 'claude-opus-4-7';
+
+export function ComposerModelPicker({
+  value,
+  onChange,
+}: {
+  value: ModelId;
+  onChange: (id: ModelId) => void;
+}) {
+  return (
+    <label className="cw-model-picker" title="모델 선택 (미리보기)">
+      <Icon name="sparkles" size={12} />
+      <select value={value} onChange={(event) => onChange(event.target.value)}>
+        {PROVIDER_MODELS.map((group) => (
+          <optgroup key={group.provider} label={group.provider}>
+            {group.models.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.label}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/app/src/components/chat/ComposerModelPicker.tsx
+++ b/app/src/components/chat/ComposerModelPicker.tsx
@@ -3,6 +3,7 @@
 // mock for now — the selection is not yet wired to the router/dispatcher — but the
 // labels are the real provider model names, grouped by provider.
 
+import { useId } from 'react';
 import { Icon } from '@/components/Icon';
 
 export type ModelId = string;
@@ -45,10 +46,12 @@ export function ComposerModelPicker({
   value: ModelId;
   onChange: (id: ModelId) => void;
 }) {
+  const selectId = useId();
   return (
-    <label className="cw-model-picker" title="모델 선택 (미리보기)">
+    <span className="cw-model-picker" title="모델 선택 (미리보기)">
       <Icon name="sparkles" size={12} />
-      <select value={value} onChange={(event) => onChange(event.target.value)}>
+      <label htmlFor={selectId} className="sr-only">모델 선택 (미리보기)</label>
+      <select id={selectId} value={value} onChange={(event) => onChange(event.target.value)}>
         {PROVIDER_MODELS.map((group) => (
           <optgroup key={group.provider} label={group.provider}>
             {group.models.map((model) => (
@@ -59,6 +62,6 @@ export function ComposerModelPicker({
           </optgroup>
         ))}
       </select>
-    </label>
+    </span>
   );
 }

--- a/app/src/components/chat/ProjectHomeComposer.tsx
+++ b/app/src/components/chat/ProjectHomeComposer.tsx
@@ -1,41 +1,28 @@
-// Shared chat composer. Extracted from the inline form that used to live in the
-// session page so the project home ("new conversation" surface) and the session
-// page render the exact same input. onSubmit takes an envelope object so future
-// dispatch metadata (agentHint / promptId from suggested-prompt chips) can be added
-// without touching every call site.
-//
-// Two sizes intentionally diverge:
-//   - 'pill'  (default, session page): a tight single-row rounded pill matching PR #114.
-//   - 'large' (home "new conversation"): a roomier box — textarea on top, a bottom
-//     toolbar row (model picker on the left, attach + send on the right) so the home
-//     surface doesn't feel cramped with the model picker crammed inline.
+// Project-home composer preview surface. Separate from the session composer because
+// this surface owns agent/model picker UI, suggested-prompt handoff, and a roomier
+// multiline textarea.
 
 import { useEffect, useRef, type KeyboardEvent, type ReactNode } from 'react';
 import { Icon } from '@/components/Icon';
 
-export interface ComposerSubmission {
+export interface ProjectHomeComposerSubmission {
   text: string;
   // future: agentHint?: string;
   // future: promptId?: string;
 }
 
-interface SessionComposerProps {
+interface ProjectHomeComposerProps {
   value: string;
   onChange: (next: string) => void;
-  onSubmit: (submission: ComposerSubmission) => void | Promise<void>;
+  onSubmit: (submission: ProjectHomeComposerSubmission) => void | Promise<void>;
   disabled?: boolean;
   // 전송 처리 중(세션 생성/스트림 시작 대기): send 버튼에 스피너를 띄워 "보내는 중"을 알림.
   pending?: boolean;
   placeholder?: string;
   // 파일 추가 진입점 (placeholder — PR #114 의 attachment tray 와 연결 예정).
   onAttachClick?: () => void;
-  footerHint?: ReactNode;
-  // composer 아래 suggested prompts 슬롯.
-  belowSlot?: ReactNode;
-  // model picker 슬롯. pill 에선 send 앞 inline, large 에선 하단 toolbar 좌측.
-  actionsSlot?: ReactNode;
-  // 'pill'(세션, 기본) | 'large'(home). 레이아웃과 textarea 기본 높이가 달라진다.
-  size?: 'pill' | 'large';
+  // Home-only model picker slot. Session composer owns its own compact controls.
+  modelPicker?: ReactNode;
   // focus 요청 신호. 값이 바뀔 때마다 input 에 focus (boolean 이 아니라 nonce 라
   // 같은 요청이 반복돼도 매번 focus 가 걸린다). 0/undefined 면 focus 안 함.
   focusSignal?: number;
@@ -45,7 +32,7 @@ const DEFAULT_PLACEHOLDER = 'Message Cowork and the team…';
 const DEFAULT_HINT = 'Enter to send · Shift+Enter for newline · Reference files with @filename';
 const MAX_TEXTAREA_HEIGHT = 200;
 
-export function SessionComposer({
+export function ProjectHomeComposer({
   value,
   onChange,
   onSubmit,
@@ -53,15 +40,11 @@ export function SessionComposer({
   pending = false,
   placeholder = DEFAULT_PLACEHOLDER,
   onAttachClick,
-  footerHint = DEFAULT_HINT,
-  belowSlot,
-  actionsSlot,
-  size = 'pill',
+  modelPicker,
   focusSignal,
-}: SessionComposerProps) {
+}: ProjectHomeComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const canSubmit = value.trim().length > 0 && !disabled;
-  const isLarge = size === 'large';
 
   useEffect(() => {
     if (focusSignal) textareaRef.current?.focus();
@@ -113,40 +96,31 @@ export function SessionComposer({
 
   return (
     <form
-      className={`cw-composer${isLarge ? ' cw-composer--large' : ''}`}
+      className="cw-home-composer"
       onSubmit={(event) => {
         event.preventDefault();
         submit();
       }}
     >
-      <div className={`cw-composer-box${isLarge ? ' cw-composer-box--large' : ''}`}>
+      <div className="cw-home-composer-box">
         <textarea
           ref={textareaRef}
-          className="cw-composer-input"
+          className="cw-home-composer-input"
           value={value}
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={disabled}
-          rows={1}
+          rows={3}
         />
-        {isLarge ? (
-          <div className="cw-composer-actions">
-            {actionsSlot}
-            <span className="cw-composer-actions-spacer" />
-            {attachButton}
-            {sendButton}
-          </div>
-        ) : (
-          <>
-            {actionsSlot}
-            {attachButton}
-            {sendButton}
-          </>
-        )}
+        <div className="cw-home-composer-actions">
+          {modelPicker}
+          <span className="cw-home-composer-actions-spacer" />
+          {attachButton}
+          {sendButton}
+        </div>
       </div>
-      {footerHint && <small>{footerHint}</small>}
-      {belowSlot}
+      <small>{DEFAULT_HINT}</small>
     </form>
   );
 }

--- a/app/src/components/chat/SessionComposer.tsx
+++ b/app/src/components/chat/SessionComposer.tsx
@@ -1,0 +1,152 @@
+// Shared chat composer. Extracted from the inline form that used to live in the
+// session page so the project home ("new conversation" surface) and the session
+// page render the exact same input. onSubmit takes an envelope object so future
+// dispatch metadata (agentHint / promptId from suggested-prompt chips) can be added
+// without touching every call site.
+//
+// Two sizes intentionally diverge:
+//   - 'pill'  (default, session page): a tight single-row rounded pill matching PR #114.
+//   - 'large' (home "new conversation"): a roomier box — textarea on top, a bottom
+//     toolbar row (model picker on the left, attach + send on the right) so the home
+//     surface doesn't feel cramped with the model picker crammed inline.
+
+import { useEffect, useRef, type KeyboardEvent, type ReactNode } from 'react';
+import { Icon } from '@/components/Icon';
+
+export interface ComposerSubmission {
+  text: string;
+  // future: agentHint?: string;
+  // future: promptId?: string;
+}
+
+interface SessionComposerProps {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit: (submission: ComposerSubmission) => void | Promise<void>;
+  disabled?: boolean;
+  // 전송 처리 중(세션 생성/스트림 시작 대기): send 버튼에 스피너를 띄워 "보내는 중"을 알림.
+  pending?: boolean;
+  placeholder?: string;
+  // 파일 추가 진입점 (placeholder — PR #114 의 attachment tray 와 연결 예정).
+  onAttachClick?: () => void;
+  footerHint?: ReactNode;
+  // composer 아래 suggested prompts 슬롯.
+  belowSlot?: ReactNode;
+  // model picker 슬롯. pill 에선 send 앞 inline, large 에선 하단 toolbar 좌측.
+  actionsSlot?: ReactNode;
+  // 'pill'(세션, 기본) | 'large'(home). 레이아웃과 textarea 기본 높이가 달라진다.
+  size?: 'pill' | 'large';
+  // focus 요청 신호. 값이 바뀔 때마다 input 에 focus (boolean 이 아니라 nonce 라
+  // 같은 요청이 반복돼도 매번 focus 가 걸린다). 0/undefined 면 focus 안 함.
+  focusSignal?: number;
+}
+
+const DEFAULT_PLACEHOLDER = 'Message Cowork and the team…';
+const DEFAULT_HINT = 'Enter to send · Shift+Enter for newline · Reference files with @filename';
+const MAX_TEXTAREA_HEIGHT = 200;
+
+export function SessionComposer({
+  value,
+  onChange,
+  onSubmit,
+  disabled = false,
+  pending = false,
+  placeholder = DEFAULT_PLACEHOLDER,
+  onAttachClick,
+  footerHint = DEFAULT_HINT,
+  belowSlot,
+  actionsSlot,
+  size = 'pill',
+  focusSignal,
+}: SessionComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const canSubmit = value.trim().length > 0 && !disabled;
+  const isLarge = size === 'large';
+
+  useEffect(() => {
+    if (focusSignal) textareaRef.current?.focus();
+  }, [focusSignal]);
+
+  // Auto-grow: reset to auto first so removing lines also shrinks the box. Keep
+  // overflow hidden until we actually hit the cap — otherwise a sub-pixel rounding
+  // of scrollHeight vs clientHeight makes `overflow-y: auto` flash a phantom scrollbar.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = 'auto';
+    const next = Math.min(ta.scrollHeight, MAX_TEXTAREA_HEIGHT);
+    ta.style.height = `${next}px`;
+    ta.style.overflowY = ta.scrollHeight > MAX_TEXTAREA_HEIGHT ? 'auto' : 'hidden';
+  }, [value]);
+
+  const submit = () => {
+    if (canSubmit) void onSubmit({ text: value.trim() });
+  };
+
+  // Enter sends; Shift+Enter inserts a newline. isComposing guards Korean/IME
+  // composition so confirming a character with Enter doesn't fire a send.
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  const attachButton = onAttachClick && (
+    <button
+      type="button"
+      className="cw-attach-button"
+      onClick={onAttachClick}
+      disabled={disabled}
+      aria-label="파일 추가"
+      title="파일 추가"
+    >
+      <Icon name="paperclip" size={17} />
+    </button>
+  );
+
+  const sendButton = (
+    <button type="submit" className="cw-send-button" aria-label="Send" disabled={!canSubmit || pending}>
+      {pending ? <span className="cw-send-spinner" aria-hidden /> : <Icon name="send" size={12} />}
+    </button>
+  );
+
+  return (
+    <form
+      className={`cw-composer${isLarge ? ' cw-composer--large' : ''}`}
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <div className={`cw-composer-box${isLarge ? ' cw-composer-box--large' : ''}`}>
+        <textarea
+          ref={textareaRef}
+          className="cw-composer-input"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+        />
+        {isLarge ? (
+          <div className="cw-composer-actions">
+            {actionsSlot}
+            <span className="cw-composer-actions-spacer" />
+            {attachButton}
+            {sendButton}
+          </div>
+        ) : (
+          <>
+            {actionsSlot}
+            {attachButton}
+            {sendButton}
+          </>
+        )}
+      </div>
+      {footerHint && <small>{footerHint}</small>}
+      {belowSlot}
+    </form>
+  );
+}

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -6,10 +6,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import logoMark from '@/assets/logo-mark.svg';
 import { listProjects } from '@/api/projects';
-import { createSession, deleteSession, listSessions } from '@/api/sessions';
+import { listSessions } from '@/api/sessions';
 import { Icon } from '@/components/Icon';
 import { Avatar, IconPocket } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
@@ -19,13 +19,13 @@ import {
   useLayoutStore,
   SIDEBAR_MOBILE_BREAKPOINT,
 } from '@/stores/layout';
-import { useToastStore } from '@/components/Toast';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { useNewProjectDialog } from '@/components/NewProjectDialog';
 import { SessionCardMenu } from '@/components/SessionCardMenu';
+import { SessionsOverlay } from '@/components/SessionsOverlay';
 import { canAdministerSession } from '@/lib/permissions';
 import { shortSessionId } from '@/lib/sessionId';
-import { ApiError } from '@/api/client';
+import { useSessionDelete } from '@/lib/useSessionDelete';
 import { SessionTitleText } from '@/components/SessionTitleText';
 import type { Session } from '@/domain/types';
 
@@ -102,6 +102,7 @@ function SectionHeader({
   onAdd,
   addLabel,
   addDisabled,
+  onViewAll,
 }: {
   label: string;
   expanded: boolean;
@@ -109,6 +110,7 @@ function SectionHeader({
   onAdd?: () => void;
   addLabel?: string;
   addDisabled?: boolean;
+  onViewAll?: () => void;
 }) {
   return (
     <div className="cw-section-header">
@@ -126,6 +128,15 @@ function SectionHeader({
         />
         <span>{label}</span>
       </button>
+      {onViewAll && (
+        <button
+          type="button"
+          className="cw-section-viewall"
+          onClick={(e) => { e.stopPropagation(); onViewAll(); }}
+        >
+          View all ›
+        </button>
+      )}
       {onAdd && (
         <button
           type="button"
@@ -144,8 +155,6 @@ function SectionHeader({
 
 export function Sidebar() {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const showToast = useToastStore((s) => s.show);
   const currentUser = useAuthStore((s) => s.currentUser);
   const sidebarMode = useLayoutStore((s) => s.sidebarMode);
   const setSidebarMode = useLayoutStore((s) => s.setSidebarMode);
@@ -235,47 +244,27 @@ export function Sidebar() {
     if (isMobile || sidebarMode !== 'hidden') setRevealed(false);
   }, [activeProjectSlug, activeSessionId, activeRoute, sidebarMode]);
 
-  const createSessionMutation = useMutation({
-    mutationFn: (projectId: string) => createSession(projectId),
-    onSuccess: async (session) => {
-      await queryClient.invalidateQueries({ queryKey: ['sessions', activeProjectSlug] });
-      showToast('새 세션이 만들어졌습니다');
-      if (activeProject) {
-        navigate({
-          to: '/projects/$projectSlug/sessions/$sessionPrefix',
-          params: { projectSlug: activeProject.slug, sessionPrefix: shortSessionId(session.id) },
-        });
-      }
-    },
-    onError: (err) => {
-      const msg = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'create failed';
-      showToast(`세션 생성 실패: ${msg}`);
-    },
-  });
+  // New session starts on the project home composer ("new conversation" surface)
+  // so the user states intent before dispatch — not via an empty session here.
+  const startNewSession = useCallback(() => {
+    if (!activeProject) return;
+    navigate({
+      to: '/projects/$projectSlug',
+      params: { projectSlug: activeProject.slug },
+      state: { focusComposer: true },
+    });
+  }, [activeProject, navigate]);
 
+  const [sessionsOverlayOpen, setSessionsOverlayOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Session | null>(null);
   const projectCreator = useNewProjectDialog();
-  const deleteMutation = useMutation({
-    mutationFn: (sessionId: string) => deleteSession(sessionId),
-    onSuccess: async (_, deletedId) => {
-      if (activeProjectSlug) {
-        await queryClient.invalidateQueries({ queryKey: ['sessions', activeProjectSlug] });
-      }
-      // deletedId is the full UUID; invalidate both full-UUID and prefix-based keys.
-      await queryClient.invalidateQueries({ queryKey: ['session', deletedId] });
-      await queryClient.invalidateQueries({ queryKey: ['session', shortSessionId(deletedId)] });
-      // activeSessionId is now a 12-char prefix — compare against the prefix of the deleted id.
+  const deleteMutation = useSessionDelete(activeProjectSlug ?? '', {
+    onDeleted: (deletedId) => {
+      // If the deleted session was the one being viewed, leave it for the project home.
       if (activeSessionId === shortSessionId(deletedId) && activeProject) {
         navigate({ to: '/projects/$projectSlug', params: { projectSlug: activeProject.slug } });
       }
-      showToast('세션이 삭제되었습니다');
       setPendingDelete(null);
-    },
-    onError: (err) => {
-      const msg = err instanceof ApiError
-        ? (err.status === 403 ? '삭제 권한이 없습니다 (creator 또는 project owner만 가능)' : err.message)
-        : err instanceof Error ? err.message : 'delete failed';
-      showToast(`세션 삭제 실패: ${msg}`);
     },
   });
 
@@ -410,9 +399,9 @@ export function Sidebar() {
               label="Sessions"
               expanded={sessionsExpanded}
               onToggle={toggleSessions}
-              onAdd={() => createSessionMutation.mutate(activeProject.id)}
-              addLabel={createSessionMutation.isPending ? '세션 생성 중…' : '새 Session'}
-              addDisabled={createSessionMutation.isPending}
+              onAdd={startNewSession}
+              addLabel="새 Session"
+              onViewAll={() => setSessionsOverlayOpen(true)}
             />
             <div className="cw-sessions-list" data-expanded={sessionsExpanded ? 'true' : 'false'}>
               {(sessionsQuery.data ?? []).filter((s) => s.origin === 'user').map((session) => {
@@ -485,6 +474,13 @@ export function Sidebar() {
       )}
 
       {projectCreator.dialog}
+
+      {sessionsOverlayOpen && activeProject && (
+        <SessionsOverlay
+          projectSlug={activeProject.slug}
+          onClose={() => setSessionsOverlayOpen(false)}
+        />
+      )}
       </aside>
     </>
   );

--- a/app/src/domain/agentSurfaces.test.ts
+++ b/app/src/domain/agentSurfaces.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_SURFACES, DEFAULT_AGENT_ID, getAgentSurface } from './agentSurfaces';
+
+describe('agent surface preview registry', () => {
+  it('keeps the default agent as the first configured surface', () => {
+    expect(DEFAULT_AGENT_ID).toBe('coworker');
+    expect(AGENT_SURFACES[0].id).toBe(DEFAULT_AGENT_ID);
+  });
+
+  it('falls back to the default surface for an unknown transient id', () => {
+    expect(getAgentSurface('not-real')).toBe(AGENT_SURFACES[0]);
+  });
+
+  it('keeps each preview surface complete enough for home and session UI', () => {
+    for (const surface of AGENT_SURFACES) {
+      expect(surface.label).toBeTruthy();
+      expect(surface.icon).toBeTruthy();
+      expect(surface.placeholder).toBeTruthy();
+      expect(surface.greeting).toBeTruthy();
+      expect(surface.prompts).toHaveLength(3);
+    }
+  });
+});

--- a/app/src/domain/agentSurfaces.ts
+++ b/app/src/domain/agentSurfaces.ts
@@ -1,0 +1,77 @@
+export type AgentId = 'coworker' | 'speedwagon' | 'deep-research' | 'buddy';
+
+export type AgentSurfaceIcon = 'zap' | 'search' | 'analysis' | 'brainstorm';
+
+export interface SuggestedPrompt {
+  label: string;
+  seedText: string;
+}
+
+export interface AgentSurface {
+  id: AgentId;
+  label: string;
+  icon: AgentSurfaceIcon;
+  // Composer placeholder when this agent is active.
+  placeholder: string;
+  // Dynamic greeting shown on the home surface.
+  greeting: string;
+  // Agent-specific suggested prompts (3 per agent).
+  prompts: SuggestedPrompt[];
+}
+
+export const AGENT_SURFACES: readonly AgentSurface[] = [
+  {
+    id: 'coworker',
+    label: 'Coworker',
+    icon: 'zap',
+    placeholder: '실행할 작업을 적어줘…',
+    greeting: 'Coworker가 실행을 도와줘요',
+    prompts: [
+      { label: '이번 주 진행 요약', seedText: '이번 주 진행 상황을 정리해서 보고서 초안 만들어줘' },
+      { label: '회의 메모 정리', seedText: '오늘 회의록을 액션 아이템 중심으로 정리해줘' },
+      { label: '이메일 초안', seedText: '이번 결정을 팀에 공유할 이메일 초안 써줘' },
+    ],
+  },
+  {
+    id: 'speedwagon',
+    label: 'Speedwagon',
+    icon: 'search',
+    placeholder: '무엇이 궁금해?',
+    greeting: 'Speedwagon이 파일에서 답을 찾아줘요',
+    prompts: [
+      { label: '프로젝트 파일 요약', seedText: '프로젝트 파일들의 핵심 내용을 요약해줘' },
+      { label: '특정 사실 찾기', seedText: '문서들에서 매출 관련 수치를 모두 찾아줘' },
+      { label: '문서 비교', seedText: '최근 두 보고서의 차이를 비교해줘' },
+    ],
+  },
+  {
+    id: 'deep-research',
+    label: 'Deep Research',
+    icon: 'analysis',
+    placeholder: '무엇을 조사할까?',
+    greeting: 'Deep Research가 깊이 파고들어요',
+    prompts: [
+      { label: '시장 동향 조사', seedText: 'KlientCo가 있는 시장의 최근 동향을 조사해줘' },
+      { label: '경쟁사 분석', seedText: '주요 경쟁사 3곳의 전략을 비교 분석해줘' },
+      { label: '선행 연구 정리', seedText: '관련 분야 선행 연구를 정리해줘' },
+    ],
+  },
+  {
+    id: 'buddy',
+    label: 'Buddy',
+    icon: 'brainstorm',
+    placeholder: '편하게 말 걸어줘…',
+    greeting: 'Buddy와 자유롭게 대화해요',
+    prompts: [
+      { label: '아이디어 발산', seedText: 'Q3 캠페인 아이디어 10개만 빠르게 던져줘' },
+      { label: '용어 풀이', seedText: '이 도메인 용어들을 쉽게 설명해줘' },
+      { label: '번역', seedText: '이 문장을 자연스러운 한국어로 번역해줘' },
+    ],
+  },
+] as const;
+
+export const DEFAULT_AGENT_ID: AgentId = AGENT_SURFACES[0].id;
+
+export function getAgentSurface(id: string | undefined): AgentSurface {
+  return AGENT_SURFACES.find((agent) => agent.id === id) ?? AGENT_SURFACES[0];
+}

--- a/app/src/lib/useSessionDelete.ts
+++ b/app/src/lib/useSessionDelete.ts
@@ -1,0 +1,35 @@
+// Shared session-delete mutation: delete + cache invalidation + the 403 copy, in
+// one place. Callers pass onDeleted for their own follow-up (close a dialog,
+// navigate away if the deleted session was the active one, etc).
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteSession } from '@/api/sessions';
+import { useToastStore } from '@/components/Toast';
+import { shortSessionId } from '@/lib/sessionId';
+import { ApiError } from '@/api/client';
+
+export function useSessionDelete(
+  projectRef: string,
+  opts?: { onDeleted?: (deletedId: string) => void },
+) {
+  const queryClient = useQueryClient();
+  const showToast = useToastStore((s) => s.show);
+
+  return useMutation({
+    mutationFn: (sessionId: string) => deleteSession(sessionId),
+    onSuccess: async (_, deletedId) => {
+      await queryClient.invalidateQueries({ queryKey: ['sessions', projectRef] });
+      // deletedId is the full UUID; invalidate both full-UUID and prefix-based keys.
+      await queryClient.invalidateQueries({ queryKey: ['session', deletedId] });
+      await queryClient.invalidateQueries({ queryKey: ['session', shortSessionId(deletedId)] });
+      showToast('세션이 삭제되었습니다');
+      opts?.onDeleted?.(deletedId);
+    },
+    onError: (err) => {
+      const msg = err instanceof ApiError
+        ? (err.status === 403 ? '삭제 권한이 없습니다 (creator 또는 project owner만 가능)' : err.message)
+        : err instanceof Error ? err.message : 'delete failed';
+      showToast(`세션 삭제 실패: ${msg}`);
+    },
+  });
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -31,7 +31,8 @@ declare module '@tanstack/react-router' {
   interface HistoryState {
     initialMessage?: string;
     focusComposer?: boolean;
-    // future: agentHint?: string;
+    // Agent selected in the home composer, carried to the session header chip.
+    initialAgentId?: import('@/domain/agentSurfaces').AgentId;
   }
 }
 

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -25,6 +25,14 @@ declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;
   }
+  // Transient navigation payloads handed off between routes via router state.
+  // initialMessage: home composer 가 만든 첫 발화를 세션 페이지가 받아 자동 전송.
+  // focusComposer: sidebar '+' 가 home 진입 시 composer 모드 + input focus 를 요청.
+  interface HistoryState {
+    initialMessage?: string;
+    focusComposer?: boolean;
+    // future: agentHint?: string;
+  }
 }
 
 const root = document.getElementById('root');

--- a/app/src/routes/_app.projects.$projectSlug.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.index.tsx
@@ -1,53 +1,78 @@
-// Project Home — markup mirrors app-live ProjectHome.
+// Project Home — a "new conversation" surface. Browsing past sessions lives in the
+// sidebar SESSIONS list + its "View all" overlay, not here.
 
-import { useState } from 'react';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { createFileRoute, useLocation, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getProject, listMembers } from '@/api/projects';
-import { createSession, deleteSession, listSessions } from '@/api/sessions';
-import { listDirents } from '@/api/dirents';
-import { Icon } from '@/components/Icon';
-import { ActivityRow, AvatarStack, EmptyState, InfoRow, IntentIcon, SectionLabel, SharePill } from '@/components/uiPrimitives';
-import { timeAgo } from '@/lib/timeAgo';
+import { createSession } from '@/api/sessions';
+import { AvatarStack } from '@/components/uiPrimitives';
+import { SessionComposer, type ComposerSubmission } from '@/components/chat/SessionComposer';
+import { ComposerModelPicker, DEFAULT_MODEL_ID, type ModelId } from '@/components/chat/ComposerModelPicker';
 import { useToastStore } from '@/components/Toast';
-import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { SessionCardMenu } from '@/components/SessionCardMenu';
-import { useAuthStore } from '@/stores/auth';
-import { canAdministerSession } from '@/lib/permissions';
 import { shortSessionId } from '@/lib/sessionId';
 import { ApiError } from '@/api/client';
-import { SessionTitleText } from '@/components/SessionTitleText';
-import type { Session } from '@/domain/types';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/')({
   component: ProjectHome,
 });
 
+// Placeholder suggested prompts. `label` is the short chip text; `seedText` is what
+// gets prefilled into the composer. In a follow-up PR each chip will also carry an
+// `agentHint` (which agent suits the task) and submit via the ComposerSubmission
+// envelope — defining the shape now keeps that seam real, not just a comment.
+interface SuggestedPrompt {
+  label: string;
+  seedText: string;
+  // future: agentHint?: string;
+}
+
+const SUGGESTED_PROMPTS: SuggestedPrompt[] = [
+  { label: '프로젝트 파일 요약', seedText: '프로젝트 파일들을 요약해줘' },
+  { label: '진행 상황 정리', seedText: '이번 주 진행 상황을 정리해줘' },
+  { label: '리스크 찾기', seedText: '리스크와 블로커를 찾아줘' },
+];
+
 function ProjectHome() {
   const { projectSlug } = Route.useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const showToast = useToastStore((s) => s.show);
-  const currentUser = useAuthStore((s) => s.currentUser);
 
   const project = useQuery({ queryKey: ['project', projectSlug], queryFn: () => getProject(projectSlug) });
-  const sessions = useQuery({ queryKey: ['sessions', projectSlug], queryFn: () => listSessions(projectSlug) });
   const members = useQuery({ queryKey: ['members', projectSlug], queryFn: () => listMembers(projectSlug) });
-  // Dirents are scope-based and keyed by the resolved project UUID (not the slug).
-  const resolvedProjectId = project.data?.id;
-  const files = useQuery({
-    queryKey: ['dirents', 'shared', resolvedProjectId, project.data?.name ?? ''],
-    queryFn: () =>
-      listDirents({ kind: 'shared', projectId: resolvedProjectId! }, project.data?.name ?? 'project'),
-    enabled: Boolean(project.data),
-  });
 
-  const newSessionMutation = useMutation({
-    mutationFn: () => createSession(projectSlug),
-    onSuccess: async (session) => {
+  const [composerText, setComposerText] = useState('');
+  const [selectedModelId, setSelectedModelId] = useState<ModelId>(DEFAULT_MODEL_ID);
+  const [focusNonce, setFocusNonce] = useState(0);
+
+  // Sidebar '+' navigates here with focusComposer: bump the focus nonce (so the
+  // composer focuses even on a repeat '+'), then consume the signal so a refresh
+  // doesn't re-focus.
+  useEffect(() => {
+    if (!location.state.focusComposer) return;
+    setFocusNonce((n) => n + 1);
+    void navigate({ replace: true, state: (prev) => ({ ...prev, focusComposer: undefined }) });
+  }, [location.state.focusComposer, navigate]);
+
+  // Submit creates a session and hands the first message to the session page via
+  // router state, where it auto-streams on entry.
+  const startSessionMutation = useMutation({
+    mutationFn: async (firstMessage: string) => {
+      const session = await createSession(projectSlug);
+      return { session, firstMessage };
+    },
+    onSuccess: async ({ session, firstMessage }) => {
       await queryClient.invalidateQueries({ queryKey: ['sessions', projectSlug] });
-      showToast('새 세션이 만들어졌습니다');
-      navigate({ to: '/projects/$projectSlug/sessions/$sessionPrefix', params: { projectSlug, sessionPrefix: shortSessionId(session.id) } });
+      setComposerText('');
+      navigate({
+        to: '/projects/$projectSlug/sessions/$sessionPrefix',
+        params: { projectSlug, sessionPrefix: shortSessionId(session.id) },
+        state: firstMessage ? { initialMessage: firstMessage } : undefined,
+        // Morph the composer to its session position/shape (shared view-transition-name).
+        viewTransition: true,
+      });
     },
     onError: (err) => {
       const msg = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'create failed';
@@ -55,149 +80,54 @@ function ProjectHome() {
     },
   });
 
-  const [pendingDelete, setPendingDelete] = useState<Session | null>(null);
-  const deleteMutation = useMutation({
-    mutationFn: (sessionId: string) => deleteSession(sessionId),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ['sessions', projectSlug] });
-      await queryClient.invalidateQueries({ queryKey: ['session', pendingDelete?.id] });
-      showToast(`세션이 삭제되었습니다`);
-      setPendingDelete(null);
-    },
-    onError: (err) => {
-      const msg = err instanceof ApiError
-        ? (err.status === 403 ? '삭제 권한이 없습니다 (creator 또는 project owner만 가능)' : err.message)
-        : err instanceof Error ? err.message : 'delete failed';
-      showToast(`세션 삭제 실패: ${msg}`);
-    },
-  });
+  const handleSubmit = ({ text }: ComposerSubmission) => {
+    if (startSessionMutation.isPending) return;
+    startSessionMutation.mutate(text);
+  };
 
   const memberList = members.data ?? [];
-  const fileList = (files.data ?? []).filter((f) => f.type !== 'folder');
-  const sessionList = (sessions.data ?? []).filter((s) => s.origin === 'user');
 
   return (
     <section className="cw-page cw-page-enter">
-      <div className="cw-project-hero">
+      <div className="cw-project-hero is-slim">
         <div>
           <h1>{project.data?.name ?? '...'}</h1>
-          <p>{project.data?.description || '세션을 시작해 에이전트와 대화하세요.'}</p>
         </div>
         <div className="cw-hero-actions">
           <AvatarStack users={memberList} />
-          <button className="cw-btn-primary" onClick={() => newSessionMutation.mutate()} disabled={newSessionMutation.isPending}>
-            <Icon name="plus" /> {newSessionMutation.isPending ? '생성 중…' : 'New session'}
-          </button>
         </div>
       </div>
 
-      <div className="cw-project-summary">
-        <InfoRow icon="folder-open" title={`${fileList.length} files`} meta="ground truth">
-          Project Files can be selected, pinned, and cited in sessions.
-        </InfoRow>
-        <InfoRow icon="users" title={`${memberList.length} members`} meta="access">
-          Shared sessions show who can talk with Cowork.
-        </InfoRow>
-      </div>
-
-      <div className="cw-section-title">
-        <SectionLabel>Sessions · {sessionList.length} visible to you</SectionLabel>
-        <button onClick={() => navigate({ to: '/projects/$projectSlug/schedule', params: { projectSlug } })}>
-          schedule 자동 발화
-        </button>
-      </div>
-
-      {sessionList.length ? (
-        <div className="cw-session-grid">
-          {sessionList.map((session) => (
-            <SessionCard
-              key={session.id}
-              session={session}
-              canDelete={canAdministerSession(session, project.data, currentUser)}
-              onOpen={() => navigate({
-                to: '/projects/$projectSlug/sessions/$sessionPrefix',
-                params: { projectSlug, sessionPrefix: shortSessionId(session.id) },
-              })}
-              onRequestDelete={() => setPendingDelete(session)}
-            />
-          ))}
-        </div>
-      ) : (
-        <EmptyState
-          title="No sessions yet"
-          body="Start a session to make this project self-serve."
-          action="New session"
-          onAction={() => newSessionMutation.mutate()}
-          chip="+"
+      <div className="cw-home-blank">
+        <p className="cw-home-greeting">
+          Start a new conversation in {project.data?.name ?? 'this project'}
+        </p>
+        <SessionComposer
+          value={composerText}
+          onChange={setComposerText}
+          onSubmit={handleSubmit}
+          disabled={startSessionMutation.isPending}
+          pending={startSessionMutation.isPending}
+          size="large"
+          focusSignal={focusNonce}
+          onAttachClick={() => showToast('파일 추가 기능은 곧 추가됩니다.')}
+          actionsSlot={<ComposerModelPicker value={selectedModelId} onChange={setSelectedModelId} />}
+          belowSlot={
+            <div className="cw-suggested-prompts" aria-label="추천 프롬프트 (미리보기)">
+              {SUGGESTED_PROMPTS.map((prompt) => (
+                <button
+                  key={prompt.label}
+                  type="button"
+                  className="cw-suggested-chip"
+                  onClick={() => setComposerText(prompt.seedText)}
+                >
+                  {prompt.label}
+                </button>
+              ))}
+            </div>
+          }
         />
-      )}
-
-      <SectionLabel>Activity</SectionLabel>
-      <div className="cw-activity-list">
-        <ActivityRow title="프로젝트 동기화됨" date="방금 전">
-          세션과 파일이 실시간으로 동기화되어 표시됩니다.
-        </ActivityRow>
       </div>
-
-      {pendingDelete && (
-        <ConfirmDialog
-          title="세션을 삭제하시겠어요?"
-          body={`"${pendingDelete.title}"의 모든 메시지와 sandbox 자원이 함께 정리됩니다. 이 작업은 되돌릴 수 없습니다.`}
-          confirmLabel="삭제"
-          destructive
-          pending={deleteMutation.isPending}
-          onConfirm={() => deleteMutation.mutate(pendingDelete.id)}
-          onClose={() => setPendingDelete(null)}
-        />
-      )}
     </section>
-  );
-}
-
-function SessionCard({
-  session,
-  canDelete,
-  onOpen,
-  onRequestDelete,
-}: {
-  session: Session;
-  canDelete: boolean;
-  onOpen: () => void;
-  onRequestDelete: () => void;
-}) {
-  const isUnread = session.unreadCount > 0;
-  const timeLabel = session.lastMessageAt ? timeAgo(session.lastMessageAt) : null;
-
-  return (
-    <div
-      className={`cw-session-card${isUnread ? ' is-unread' : ''}`}
-      onClick={onOpen}
-      role="button"
-      tabIndex={0}
-      style={{ cursor: 'pointer' }}
-    >
-      <div className="cw-session-card-head">
-        <span className="cw-session-card-title">
-          <IntentIcon intent={session.intent} force />
-          <SessionTitleText title={session.title} />
-        </span>
-        <span className="cw-session-right">
-          {isUnread && (
-            <span className="cw-unread-badge" aria-label={`unread ${session.unreadCount}`}>
-              <span className="dot" />
-              <span className="n">{session.unreadCount}</span>
-            </span>
-          )}
-          <SharePill mode={session.shareMode} compact />
-          {canDelete && <SessionCardMenu onDelete={onRequestDelete} />}
-        </span>
-      </div>
-      {session.lastMessageSnippet && (
-        <p className="cw-session-last">{session.lastMessageSnippet}</p>
-      )}
-      <div className="cw-session-card-footer">
-        {timeLabel && <span className="cw-card-time">{timeLabel}</span>}
-      </div>
-    </div>
   );
 }

--- a/app/src/routes/_app.projects.$projectSlug.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.index.tsx
@@ -7,9 +7,10 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getProject, listMembers } from '@/api/projects';
 import { createSession } from '@/api/sessions';
 import { AvatarStack } from '@/components/uiPrimitives';
-import { SessionComposer, type ComposerSubmission } from '@/components/chat/SessionComposer';
+import { ProjectHomeComposer, type ProjectHomeComposerSubmission } from '@/components/chat/ProjectHomeComposer';
 import { ComposerModelPicker, DEFAULT_MODEL_ID, type ModelId } from '@/components/chat/ComposerModelPicker';
-import { ComposerAgentPicker, DEFAULT_AGENT_ID, getAgentOption, type AgentId } from '@/components/chat/ComposerAgentPicker';
+import { ComposerAgentPicker } from '@/components/chat/ComposerAgentPicker';
+import { DEFAULT_AGENT_ID, getAgentSurface, type AgentId } from '@/domain/agentSurfaces';
 import { useToastStore } from '@/components/Toast';
 import { shortSessionId } from '@/lib/sessionId';
 import { ApiError } from '@/api/client';
@@ -17,22 +18,6 @@ import { ApiError } from '@/api/client';
 export const Route = createFileRoute('/_app/projects/$projectSlug/')({
   component: ProjectHome,
 });
-
-// Placeholder suggested prompts. `label` is the short chip text; `seedText` is what
-// gets prefilled into the composer. In a follow-up PR each chip will also carry an
-// `agentHint` (which agent suits the task) and submit via the ComposerSubmission
-// envelope — defining the shape now keeps that seam real, not just a comment.
-interface SuggestedPrompt {
-  label: string;
-  seedText: string;
-  // future: agentHint?: string;
-}
-
-const SUGGESTED_PROMPTS: SuggestedPrompt[] = [
-  { label: '프로젝트 파일 요약', seedText: '프로젝트 파일들을 요약해줘' },
-  { label: '진행 상황 정리', seedText: '이번 주 진행 상황을 정리해줘' },
-  { label: '리스크 찾기', seedText: '리스크와 블로커를 찾아줘' },
-];
 
 function ProjectHome() {
   const { projectSlug } = Route.useParams();
@@ -49,7 +34,7 @@ function ProjectHome() {
   const [selectedAgentId, setSelectedAgentId] = useState<AgentId>(DEFAULT_AGENT_ID);
   const [focusNonce, setFocusNonce] = useState(0);
 
-  const activeAgent = getAgentOption(selectedAgentId);
+  const activeAgent = getAgentSurface(selectedAgentId);
 
   // Sidebar '+' navigates here with focusComposer: bump the focus nonce (so the
   // composer focuses even on a repeat '+'), then consume the signal so a refresh
@@ -60,8 +45,8 @@ function ProjectHome() {
     void navigate({ replace: true, state: (prev) => ({ ...prev, focusComposer: undefined }) });
   }, [location.state.focusComposer, navigate]);
 
-  // Submit creates a session and hands the first message to the session page via
-  // router state, where it auto-streams on entry.
+  // Submit creates a session and hands the first message + selected agent to the
+  // session page via router state, where it auto-streams on entry.
   const startSessionMutation = useMutation({
     mutationFn: async (firstMessage: string) => {
       const session = await createSession(projectSlug);
@@ -73,7 +58,9 @@ function ProjectHome() {
       navigate({
         to: '/projects/$projectSlug/sessions/$sessionPrefix',
         params: { projectSlug, sessionPrefix: shortSessionId(session.id) },
-        state: firstMessage ? { initialMessage: firstMessage } : undefined,
+        state: firstMessage
+          ? { initialMessage: firstMessage, initialAgentId: selectedAgentId }
+          : { initialAgentId: selectedAgentId },
         // Morph the composer to its session position/shape (shared view-transition-name).
         viewTransition: true,
       });
@@ -84,7 +71,7 @@ function ProjectHome() {
     },
   });
 
-  const handleSubmit = ({ text }: ComposerSubmission) => {
+  const handleSubmit = ({ text }: ProjectHomeComposerSubmission) => {
     if (startSessionMutation.isPending) return;
     startSessionMutation.mutate(text);
   };
@@ -104,35 +91,49 @@ function ProjectHome() {
 
       <div className="cw-home-blank">
         <p className="cw-home-greeting">
-          Start a new conversation in {project.data?.name ?? 'this project'}
+          {activeAgent.greeting}
         </p>
-        <ComposerAgentPicker value={selectedAgentId} onChange={setSelectedAgentId} />
-        <SessionComposer
-          value={composerText}
-          onChange={setComposerText}
-          onSubmit={handleSubmit}
-          disabled={startSessionMutation.isPending}
-          pending={startSessionMutation.isPending}
-          size="large"
-          placeholder={activeAgent.placeholder}
-          focusSignal={focusNonce}
-          onAttachClick={() => showToast('파일 추가 기능은 곧 추가됩니다.')}
-          actionsSlot={<ComposerModelPicker value={selectedModelId} onChange={setSelectedModelId} />}
-          belowSlot={
-            <div className="cw-suggested-prompts" aria-label="추천 프롬프트 (미리보기)">
-              {SUGGESTED_PROMPTS.map((prompt) => (
-                <button
-                  key={prompt.label}
-                  type="button"
-                  className="cw-suggested-chip"
-                  onClick={() => setComposerText(prompt.seedText)}
-                >
-                  {prompt.label}
-                </button>
-              ))}
-            </div>
-          }
-        />
+
+        <div
+          className="cw-agent-composer-wrap"
+          data-agent={selectedAgentId}
+        >
+          <div className="cw-agent-tabs-area">
+            <ComposerAgentPicker value={selectedAgentId} onChange={setSelectedAgentId} />
+            <span className="cw-preview-pill" aria-label="미리보기: 아직 서버에 전달되지 않습니다">Preview</span>
+          </div>
+          <ProjectHomeComposer
+            value={composerText}
+            onChange={setComposerText}
+            onSubmit={handleSubmit}
+            disabled={startSessionMutation.isPending}
+            pending={startSessionMutation.isPending}
+            placeholder={activeAgent.placeholder}
+            focusSignal={focusNonce}
+            onAttachClick={() => showToast('파일 추가 기능은 곧 추가됩니다.')}
+            modelPicker={<ComposerModelPicker value={selectedModelId} onChange={setSelectedModelId} />}
+          />
+        </div>
+
+        <div
+          key={selectedAgentId}
+          className="cw-suggested-prompts"
+          aria-label="추천 프롬프트 (미리보기)"
+        >
+          {activeAgent.prompts.map((prompt) => (
+            <button
+              key={prompt.label}
+              type="button"
+              className="cw-suggested-chip"
+              onClick={() => {
+                setComposerText(prompt.seedText);
+                setFocusNonce((n) => n + 1);
+              }}
+            >
+              {prompt.label}
+            </button>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/app/src/routes/_app.projects.$projectSlug.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.index.tsx
@@ -9,6 +9,7 @@ import { createSession } from '@/api/sessions';
 import { AvatarStack } from '@/components/uiPrimitives';
 import { SessionComposer, type ComposerSubmission } from '@/components/chat/SessionComposer';
 import { ComposerModelPicker, DEFAULT_MODEL_ID, type ModelId } from '@/components/chat/ComposerModelPicker';
+import { ComposerAgentPicker, DEFAULT_AGENT_ID, getAgentOption, type AgentId } from '@/components/chat/ComposerAgentPicker';
 import { useToastStore } from '@/components/Toast';
 import { shortSessionId } from '@/lib/sessionId';
 import { ApiError } from '@/api/client';
@@ -45,7 +46,10 @@ function ProjectHome() {
 
   const [composerText, setComposerText] = useState('');
   const [selectedModelId, setSelectedModelId] = useState<ModelId>(DEFAULT_MODEL_ID);
+  const [selectedAgentId, setSelectedAgentId] = useState<AgentId>(DEFAULT_AGENT_ID);
   const [focusNonce, setFocusNonce] = useState(0);
+
+  const activeAgent = getAgentOption(selectedAgentId);
 
   // Sidebar '+' navigates here with focusComposer: bump the focus nonce (so the
   // composer focuses even on a repeat '+'), then consume the signal so a refresh
@@ -102,6 +106,7 @@ function ProjectHome() {
         <p className="cw-home-greeting">
           Start a new conversation in {project.data?.name ?? 'this project'}
         </p>
+        <ComposerAgentPicker value={selectedAgentId} onChange={setSelectedAgentId} />
         <SessionComposer
           value={composerText}
           onChange={setComposerText}
@@ -109,6 +114,7 @@ function ProjectHome() {
           disabled={startSessionMutation.isPending}
           pending={startSessionMutation.isPending}
           size="large"
+          placeholder={activeAgent.placeholder}
           focusSignal={focusNonce}
           onAttachClick={() => showToast('파일 추가 기능은 곧 추가됩니다.')}
           actionsSlot={<ComposerModelPicker value={selectedModelId} onChange={setSelectedModelId} />}

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -1,7 +1,7 @@
 // Session — markup mirrors app-live SessionPage. Chat surface (head + messages
 // + composer) + right side (members, references, access, artifact).
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createFileRoute, useLocation, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getSession, updateSessionShareMode } from '@/api/sessions';
@@ -10,6 +10,7 @@ import { getProject, listMembers } from '@/api/projects';
 import { deleteDirent, downloadFile, uploadFiles, type DirentScope } from '@/api/dirents';
 import { Icon } from '@/components/Icon';
 import { Avatar, IntentBadge, SharePill, ShareSelect } from '@/components/uiPrimitives';
+import { getAgentSurface, type AgentId } from '@/domain/agentSurfaces';
 import { useAuthStore } from '@/stores/auth';
 import { useToastStore } from '@/components/Toast';
 import { shareMeta } from '@/domain/metadata';
@@ -29,11 +30,6 @@ import { ConfirmDialog } from '@/components/ConfirmDialog';
 export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sessionPrefix')({
   component: SessionPage,
 });
-
-// Tracks sessions whose home-composer first message has already been sent, so the
-// initial-send effect fires exactly once per session even under StrictMode's
-// double-invoked effects. Module-level so it survives StrictMode's remount cycle.
-const sentInitialMessageFor = new Set<string>();
 
 function stripSubagentPrefix(name: string): string {
   return name.startsWith(SUBAGENT_PREFIX) ? name.slice(SUBAGENT_PREFIX.length) : name;
@@ -64,6 +60,24 @@ function SessionPage() {
     queryFn: () => listMessages(sessionId),
     enabled: Boolean(session.data && currentUser),
   });
+
+  // Agent chip — transient preview state from home. Persist it after router state
+  // is cleared, but reset it when this route instance moves to another session.
+  const [agentPreview, setAgentPreview] = useState<{ sessionPrefix: string; agentId?: AgentId }>(() => ({
+    sessionPrefix,
+    agentId: location.state.initialAgentId,
+  }));
+  if (agentPreview.sessionPrefix !== sessionPrefix) {
+    setAgentPreview({ sessionPrefix, agentId: location.state.initialAgentId });
+  } else if (location.state.initialAgentId && agentPreview.agentId !== location.state.initialAgentId) {
+    setAgentPreview({ sessionPrefix, agentId: location.state.initialAgentId });
+  }
+  const activeAgent = agentPreview.agentId ? getAgentSurface(agentPreview.agentId) : undefined;
+
+  // Auto-send initial message refs — useRef instead of module-level Set so each
+  // component instance tracks its own state (StrictMode-safe, no cross-session leak).
+  const initialMessageRef = useRef<string | null>(location.state.initialMessage ?? null);
+  const consumedInitialMessageRef = useRef(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -223,8 +237,11 @@ function SessionPage() {
       showToast(`전송 실패: ${msg}`);
     } finally {
       setStreaming(false);
-      // Refetch and wait for new history data before clearing live messages to avoid flash.
-      await queryClient.refetchQueries({ queryKey: ['messages', sessionId] });
+      // Guard against empty sessionId (race where session hasn't resolved yet).
+      if (sessionId) {
+        // Refetch and wait for new history data before clearing live messages to avoid flash.
+        await queryClient.refetchQueries({ queryKey: ['messages', sessionId] });
+      }
       setLiveMessages([]);
       void queryClient.invalidateQueries({ queryKey: ['session', sessionPrefix] });
       void queryClient.invalidateQueries({ queryKey: ['sessions', projectSlug] });
@@ -233,15 +250,20 @@ function SessionPage() {
   }, [composerText, streaming, sessionPrefix, projectSlug, projectId, sessionId, currentUser, queryClient, showToast, pendingAttachments]);
 
   // Auto-send the first message handed over from the home composer via router state.
-  // Guarded by the module-level Set so it fires exactly once per session (StrictMode-safe),
-  // then the router state is cleared so a refresh doesn't resend.
-  useLayoutEffect(() => {
-    const initial = location.state.initialMessage;
-    if (!initial || sentInitialMessageFor.has(sessionPrefix)) return;
-    sentInitialMessageFor.add(sessionPrefix);
+  // Deferred until session.data resolves so `sessionId` is non-empty when the
+  // finally-block refetch runs. useRef guards ensure exactly one send per mount
+  // (StrictMode-safe — refs survive the double-invoke cycle).
+  useEffect(() => {
+    if (consumedInitialMessageRef.current) return;
+    if (!session.data) return;                        // wait for session UUID to resolve
+    if (!initialMessageRef.current) return;
+    consumedInitialMessageRef.current = true;
+    const msg = initialMessageRef.current;
+    initialMessageRef.current = null;
+    // Clear router state so a hard refresh doesn't resend, but don't block send on it.
     void navigate({ replace: true, state: (prev) => ({ ...prev, initialMessage: undefined }) });
-    void send(initial);
-  }, [location.state.initialMessage, sessionPrefix, navigate, send]);
+    void send(msg);
+  }, [session.data, send, navigate]);
 
   const shareMutation = useMutation({
     mutationFn: (mode: ShareMode) => updateSessionShareMode(sessionPrefix, mode),
@@ -275,6 +297,17 @@ function SessionPage() {
             </p>
           </div>
           <div className="cw-session-head-actions">
+            {activeAgent && (
+              <span
+                className="cw-session-agent-chip"
+                data-agent={activeAgent.id}
+                title="이 세션에서 선택된 에이전트 (미리보기)"
+              >
+                <Icon name={activeAgent.icon} size={13} />
+                <span>{activeAgent.label}</span>
+                <span className="cw-preview-pill cw-preview-pill--micro">Preview</span>
+              </span>
+            )}
             {sess && <IntentBadge intent={sess.intent} />}
             {sess && (
               <ShareSelect mode={sess.shareMode} onChange={(mode) => shareMutation.mutate(mode)} />

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -1,8 +1,8 @@
 // Session — markup mirrors app-live SessionPage. Chat surface (head + messages
 // + composer) + right side (members, references, access, artifact).
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createFileRoute } from '@tanstack/react-router';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createFileRoute, useLocation, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getSession, updateSessionShareMode } from '@/api/sessions';
 import { listMessages, streamMessage } from '@/api/messages';
@@ -30,12 +30,19 @@ export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sess
   component: SessionPage,
 });
 
+// Tracks sessions whose home-composer first message has already been sent, so the
+// initial-send effect fires exactly once per session even under StrictMode's
+// double-invoked effects. Module-level so it survives StrictMode's remount cycle.
+const sentInitialMessageFor = new Set<string>();
+
 function stripSubagentPrefix(name: string): string {
   return name.startsWith(SUBAGENT_PREFIX) ? name.slice(SUBAGENT_PREFIX.length) : name;
 }
 
 function SessionPage() {
   const { projectSlug, sessionPrefix } = Route.useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const showToast = useToastStore((s) => s.show);
   const currentUser = useAuthStore((s) => s.currentUser);
@@ -75,11 +82,17 @@ function SessionPage() {
   };
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
 
-  useEffect(() => {
+  // Reset when switching sessions — done during render (not in an effect) so React
+  // StrictMode's double-invoked effects can't wipe the optimistic user/ai bubbles
+  // the initial-send effect adds on entry (React's "adjust state on prop change").
+  const [trackedPrefix, setTrackedPrefix] = useState(sessionPrefix);
+  if (trackedPrefix !== sessionPrefix) {
+    setTrackedPrefix(sessionPrefix);
     setLiveMessages([]);
     setComposerText('');
     setStreaming(false);
-  }, [sessionPrefix]);
+    setPendingAttachments([]);
+  }
 
   // After messages load, mark-read side effect has run on the backend — sync badge in session list.
   useEffect(() => {
@@ -128,8 +141,8 @@ function SessionPage() {
     }
   }, [projectId, sessionId]);
 
-  const send = useCallback(async () => {
-    const text = composerText.trim();
+  const send = useCallback(async (overrideText?: string) => {
+    const text = (overrideText ?? composerText).trim();
     if (!text || streaming || hasUploadingAttachments) return;
 
     const attachmentPaths = pendingAttachments
@@ -218,6 +231,17 @@ function SessionPage() {
       void queryClient.invalidateQueries({ queryKey: ['dirents', 'artifacts', projectId, sessionId] });
     }
   }, [composerText, streaming, sessionPrefix, projectSlug, projectId, sessionId, currentUser, queryClient, showToast, pendingAttachments]);
+
+  // Auto-send the first message handed over from the home composer via router state.
+  // Guarded by the module-level Set so it fires exactly once per session (StrictMode-safe),
+  // then the router state is cleared so a refresh doesn't resend.
+  useLayoutEffect(() => {
+    const initial = location.state.initialMessage;
+    if (!initial || sentInitialMessageFor.has(sessionPrefix)) return;
+    sentInitialMessageFor.add(sessionPrefix);
+    void navigate({ replace: true, state: (prev) => ({ ...prev, initialMessage: undefined }) });
+    void send(initial);
+  }, [location.state.initialMessage, sessionPrefix, navigate, send]);
 
   const shareMutation = useMutation({
     mutationFn: (mode: ShareMode) => updateSessionShareMode(sessionPrefix, mode),

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -943,19 +943,19 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 .cw-composer {
   position: sticky;
   bottom: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 14px clamp(20px, 5vw, 56px) 16px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 14px clamp(24px, 6vw, 72px) 16px;
   border-top: 1px solid var(--cw-border);
   background: var(--cw-bg);
   width: 100%;
-  max-width: 860px;
+  max-width: 920px;
   margin: 0 auto;
 }
-/* Rounded single-row pill (PR #114 base): textarea grows in place, attach + send
-   sit on the right. The optional actionsSlot (home's model picker) tucks in before
-   them. Auto-grow makes it taller for multiline while staying rounded. */
+/* Rounded single-row pill (PR #114 base): the session composer keeps its compact
+   pill controls here. Project home uses the separate .cw-home-composer selectors. */
 .cw-composer-box {
   display: flex;
   flex-direction: row;
@@ -973,22 +973,7 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   border-color: var(--cw-border-hover);
   box-shadow: 0 0 0 3px color-mix(in oklch, var(--cw-accent), transparent 86%);
 }
-/* Home "new conversation": roomier column layout — textarea on top, a bottom
-   toolbar row holding the model picker (left) and attach + send (right). */
-.cw-composer-box--large {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 10px;
-  padding: 14px 16px 12px;
-  border-radius: 20px;
-}
-.cw-composer-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.cw-composer-actions-spacer { flex: 1; }
-.cw-composer-input {
+.cw-composer input {
   flex: 1;
   min-width: 0;
   min-height: 24px;
@@ -1004,14 +989,62 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   line-height: 1.5;
   color: var(--cw-fg-1);
 }
-/* In the column layout, let the textarea keep its JS auto-grow height instead of
-   flex-growing to fill the box (flex-grow on the column axis would override the
-   inline height and pin it to one line). align-items: stretch handles full width. */
-.cw-composer-box--large .cw-composer-input { flex: 0 0 auto; min-height: 24px; padding: 4px 0; }
+.cw-home-composer {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 100%;
+  margin-top: -1px;
+  border-top: 0;
+  background: transparent;
+  padding: 0;
+  z-index: 2;
+}
+.cw-home-composer-box {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 16px 12px;
+  border: 1px solid var(--cw-agent-accent);
+  border-radius: 20px;
+  background: var(--cw-paper);
+  position: relative;
+  z-index: 0;
+  transition: box-shadow 120ms;
+}
+.cw-home-composer-box:focus-within {
+  box-shadow: 0 0 0 2.5px color-mix(in oklch, var(--cw-agent-accent), transparent 90%);
+}
+.cw-home-composer-input {
+  flex: 0 0 auto;
+  min-width: 0;
+  min-height: calc(4.5em + 8px);
+  max-height: 200px;
+  border: 0;
+  background: transparent;
+  padding: 4px 0;
+  outline: 0;
+  resize: none;
+  overflow-y: hidden;
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--cw-fg-1);
+}
+.cw-home-composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.cw-home-composer-actions-spacer { flex: 1; }
 
 /* home -> session composer morph (route navigate with viewTransition: true).
-   The shared `cw-composer` name lets the browser tween the box from the home
-   center to the bottom-of-session pill; we just tune timing + cross-fade. */
+   Home assigns `cw-composer` to the agent-composer wrap; the session composer
+   assigns it to the compact box, so navigation still reads as one morphing area. */
 ::view-transition-group(cw-composer) {
   animation-duration: 480ms;
   animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
@@ -1027,7 +1060,8 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   ::view-transition-old(cw-composer),
   ::view-transition-new(cw-composer) { animation: none; }
 }
-.cw-composer-input::placeholder { color: var(--cw-fg-4); }
+.cw-home-composer-input::placeholder,
+.cw-composer input::placeholder { color: var(--cw-fg-4); }
 .cw-send-button {
   width: 34px;
   height: 34px;
@@ -1073,6 +1107,11 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   color: var(--cw-fg-4);
   font-size: 11px;
 }
+.cw-home-composer small {
+  text-align: center;
+  color: var(--cw-fg-4);
+  font-size: 11px;
+}
 .cw-model-picker {
   display: inline-flex;
   align-items: center;
@@ -1089,7 +1128,7 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 
 /* Project home — "new conversation" surface */
 .cw-project-hero.is-slim { align-items: center; padding-bottom: var(--cw-space-4); margin-bottom: var(--cw-space-5); }
-.cw-project-hero.is-slim h1 { font-size: var(--cw-text-xl); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cw-project-hero.is-slim h1 { font-size: var(--cw-text-2xl); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Sidebar SESSIONS "View all" — hidden until the section header is hovered (Claude pattern). */
 .cw-section-viewall {
   border: 0;
@@ -1167,24 +1206,16 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 20px;
+  gap: 14px;
   min-height: 58vh;
   max-width: 760px;
   margin: 0 auto;
   padding: 0 16px;
 }
-.cw-home-blank .cw-composer-box { width: 100%; }
-.cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); }
-.cw-home-blank .cw-composer {
-  position: static;
-  width: 100%;
-  max-width: 100%;
-  border-top: 0;
-  background: transparent;
-  padding: 0;
-}
+.cw-home-blank .cw-agent-composer-wrap { width: 100%; }
+.cw-home-blank .cw-home-composer-box { width: 100%; }
+.cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); font-weight: 500; }
 .cw-suggested-prompts {
-  grid-column: 1 / -1;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -1282,52 +1313,216 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   text-align: center;
 }
 
-/* Agent / mode picker — segmented tab row above the home composer. Picks which
-   agent surface (coworker / speedwagon / deep research / buddy) drives the chat. */
-.cw-agent-picker {
+/* Agent composer wrap — shared container that holds the picker tabs row + the
+   composer box. The border and accent colour are owned here so both children
+   inherit from a single source. data-agent drives per-agent CSS custom property
+   swaps with a smooth colour transition (@property enables cross-fade). */
+@property --cw-agent-accent      { syntax: '<color>'; inherits: true; initial-value: oklch(0.55 0.13 68); }
+@property --cw-agent-accent-soft { syntax: '<color>'; inherits: true; initial-value: oklch(0.96 0.025 68); }
+@property --cw-agent-send-bg     { syntax: '<color>'; inherits: true; initial-value: oklch(0.38 0.11 68); }
+
+.cw-agent-composer-wrap {
+  --cw-agent-accent:      oklch(0.55 0.13 68);
+  --cw-agent-accent-soft: oklch(0.96 0.025 68);
+  --cw-agent-send-bg:     oklch(0.38 0.11 68);
+  /* Wrap is layout-only. The composer-box (below) owns the paper surface +
+     agent-tinted border; the active tab indicator owns the selected bookmark. */
+  background: transparent;
+  border: 0;
+  overflow: visible;
+  view-transition-name: cw-composer;
+}
+.cw-agent-composer-wrap .cw-home-composer {
+  /* Pull the composer paper 1px under the active bookmark so their borders
+     meet without a hairline gap. */
+  margin-top: -1px;
+  position: relative;
+  z-index: 2;
+}
+/* Per-agent accent swaps. The same custom properties feed the home composer
+   and the session preview chip, keeping visual state in one selector family. */
+.cw-agent-composer-wrap[data-agent="coworker"],
+.cw-session-agent-chip[data-agent="coworker"] {
+  --cw-agent-accent: oklch(0.55 0.13 68);
+  --cw-agent-accent-soft: oklch(0.96 0.025 68);
+  --cw-agent-send-bg: oklch(0.38 0.11 68);
+}
+.cw-agent-composer-wrap[data-agent="speedwagon"],
+.cw-session-agent-chip[data-agent="speedwagon"] {
+  --cw-agent-accent: oklch(0.52 0.13 240);
+  --cw-agent-accent-soft: oklch(0.95 0.025 240);
+  --cw-agent-send-bg: oklch(0.38 0.12 240);
+}
+.cw-agent-composer-wrap[data-agent="deep-research"],
+.cw-session-agent-chip[data-agent="deep-research"] {
+  --cw-agent-accent: oklch(0.52 0.10 155);
+  --cw-agent-accent-soft: oklch(0.95 0.020 155);
+  --cw-agent-send-bg: oklch(0.38 0.09 155);
+}
+.cw-agent-composer-wrap[data-agent="buddy"],
+.cw-session-agent-chip[data-agent="buddy"] {
+  --cw-agent-accent: oklch(0.58 0.12 20);
+  --cw-agent-accent-soft: oklch(0.96 0.028 20);
+  --cw-agent-send-bg: oklch(0.42 0.11 20);
+}
+
+/* Picker tabs row — transparent so only the active bookmark tab carries color. */
+.cw-agent-tabs-area {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 16px 0 36px;
+  background: transparent;
+  border-bottom: 0;
+  position: relative;
 }
 .cw-agent-tabs {
+  --cw-agent-indicator-left: 0px;
+  --cw-agent-indicator-width: 0px;
   display: inline-flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: 4px;
-  padding: 4px;
-  border-radius: var(--cw-radius-full);
-  background: var(--cw-bg-muted);
+  align-items: flex-end;
+  gap: 12px;
+  padding: 0;
+  background: transparent;
+  overflow: visible;
+  position: relative;
+  isolation: isolate;
 }
+.cw-agent-tab-indicator {
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  z-index: 1;
+  width: var(--cw-agent-indicator-width);
+  height: 34px;
+  border-radius: 14px 14px 0 0;
+  background: var(--cw-agent-accent);
+  pointer-events: none;
+  transform: translateX(var(--cw-agent-indicator-left));
+  animation: cw-agent-tab-appear 140ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+@keyframes cw-agent-tab-appear {
+  from {
+    opacity: 0;
+    transform: translateX(var(--cw-agent-indicator-left)) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(var(--cw-agent-indicator-left)) translateY(0);
+  }
+}
+/* Inactive tabs (v3 colours): muted text + slight opacity — fade behind active. */
 .cw-agent-tab {
+  position: relative;
+  z-index: 3;
   display: inline-flex;
   align-items: center;
   gap: 6px;
   border: 0;
-  border-radius: var(--cw-radius-full);
+  border-radius: 10px;
   background: transparent;
-  color: var(--cw-fg-3);
-  padding: 7px 14px;
+  color: var(--cw-fg-4);
+  opacity: 0.7;
+  padding: 8px 16px;
   font-size: 13px;
   font-weight: 500;
   font-family: inherit;
   cursor: pointer;
-  transition: background 120ms, color 120ms, box-shadow 120ms;
+  transition: color 120ms, opacity 120ms;
 }
-.cw-agent-tab:hover { color: var(--cw-fg-1); }
+.cw-agent-tab:hover { color: var(--cw-fg-2); opacity: 1; }
+/* Active tab: accent bookmark with rounded top corners. Bottom edge meets the
+   composer-box top exactly (no overlap) — same accent colour as the box border
+   makes the two reads as one continuous accent stroke at the join. */
 .cw-agent-tab.is-active {
-  background: var(--cw-bg);
-  color: var(--cw-accent);
+  background: transparent;
+  color: var(--cw-paper);
+  opacity: 1;
   font-weight: 600;
-  box-shadow: var(--cw-shadow-sm);
+  border-radius: 14px 14px 0 0;
+  margin-bottom: -1px;
 }
-.cw-agent-blurb {
-  margin: 0;
+
+/* composer-box owns the paper frame: agent-tinted border + radius. */
+.cw-agent-composer-wrap .cw-home-composer-box {
+  border: 1px solid var(--cw-agent-accent);
+  border-radius: 20px;
+  background: var(--cw-paper);
+  position: relative;
+  z-index: 0;
+  transition: box-shadow 120ms;
+}
+.cw-agent-composer-wrap .cw-home-composer-box:focus-within {
+  box-shadow: 0 0 0 2.5px color-mix(in oklch, var(--cw-agent-accent), transparent 90%);
+}
+.cw-agent-composer-wrap .cw-send-button { background: var(--cw-agent-send-bg); }
+.cw-agent-composer-wrap .cw-send-button:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--cw-agent-send-bg), black 6%);
+}
+
+/* Preview pill — right-edge of the tabs row, tonally muted */
+.cw-preview-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: var(--cw-radius-full);
+  background: var(--cw-bg-muted);
+  color: var(--cw-fg-4);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Suggested prompts fade-in animation (re-plays when key changes on agent switch) */
+.cw-suggested-prompts {
+  animation: cw-prompt-fade-in 180ms ease-out;
+}
+@keyframes cw-prompt-fade-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cw-suggested-prompts { animation: none; }
+  .cw-agent-composer-wrap { transition: none; }
+  .cw-agent-tab-indicator,
+  .cw-agent-tab {
+    animation: none;
+    transition: none;
+  }
+}
+
+/* Accessibility utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Session header agent identity chip — shows which agent was selected in home */
+.cw-session-agent-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--cw-radius-full);
+  border: 1px solid color-mix(in oklch, var(--cw-agent-accent) 40%, var(--cw-border));
+  background: color-mix(in oklch, var(--cw-agent-accent-soft) 50%, var(--cw-paper));
+  color: var(--cw-fg-2);
   font-size: 12px;
-  color: var(--cw-fg-3);
-  text-align: center;
+  font-weight: 500;
 }
+.cw-preview-pill--micro { font-size: 9px; padding: 1px 5px; }
 
 .cw-empty-state {
   display: flex;
@@ -1362,7 +1557,7 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   .cw-file-path { align-items: flex-start; flex-direction: column; gap: 10px; }
   /* Composer sits in the upper third so the iOS keyboard doesn't cover it. */
   .cw-home-blank { min-height: auto; justify-content: flex-start; padding-top: 12vh; }
-  .cw-home-blank .cw-composer { padding: 0; }
+  .cw-home-blank .cw-home-composer { padding: 0; }
 }
 
 /* Authoritative pass from Design System preview/icons-nav-files.html.

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -520,7 +520,7 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
 .cw-artifact-preview section { border: 1px solid var(--cw-border); border-radius: var(--cw-radius-lg); padding: 10px; background: var(--cw-bg); margin-bottom: 8px; }
 .cw-artifact-preview section p { margin: 5px 0; font-size: 12px; }
 
-.cw-dialog-backdrop { position: fixed; inset: 0; z-index: 30; display: grid; place-items: center; background: oklch(0.18 0.01 60 / .26); }
+.cw-dialog-backdrop { position: fixed; inset: 0; z-index: 70; display: grid; place-items: center; background: oklch(0.18 0.01 60 / .26); }
 .cw-dialog { position: relative; width: min(440px, calc(100vw - 32px)); border: 1px solid var(--cw-border); border-radius: var(--cw-radius-xl); background: var(--cw-bg); box-shadow: var(--cw-shadow-popover); padding: 24px; animation: cw-enter .22s ease both; }
 .cw-close { position: absolute; top: 12px; right: 12px; border: 0; background: transparent; padding: 4px; border-radius: var(--cw-radius-sm); color: var(--cw-ink-4); cursor: pointer; }
 .cw-close:hover { color: var(--cw-ink); background: var(--cw-paper-3); }
@@ -593,6 +593,7 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 
 .cw-project-card,
 .cw-session-card {
+  cursor: pointer;
   min-height: 126px;
   justify-content: flex-start;
   padding: 14px;
@@ -942,45 +943,91 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 .cw-composer {
   position: sticky;
   bottom: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
-  align-items: center;
-  padding: 14px clamp(24px, 6vw, 72px) 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px clamp(20px, 5vw, 56px) 16px;
   border-top: 1px solid var(--cw-border);
   background: var(--cw-bg);
   width: 100%;
-  max-width: 920px;
+  max-width: 860px;
   margin: 0 auto;
 }
+/* Rounded single-row pill (PR #114 base): textarea grows in place, attach + send
+   sit on the right. The optional actionsSlot (home's model picker) tucks in before
+   them. Auto-grow makes it taller for multiline while staying rounded. */
 .cw-composer-box {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 46px;
-  padding: 6px 6px 6px 14px;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 6px;
+  padding: 5px 7px 5px 18px;
   border: 1px solid var(--cw-border);
-  border-radius: 999px;
+  border-radius: 24px;
   background: var(--cw-paper);
   transition: border-color 120ms, box-shadow 120ms;
+  /* Shared name so navigating home <-> session morphs the box (see route viewTransition). */
+  view-transition-name: cw-composer;
 }
 .cw-composer-box:focus-within {
   border-color: var(--cw-border-hover);
   box-shadow: 0 0 0 3px color-mix(in oklch, var(--cw-accent), transparent 86%);
 }
-.cw-composer input {
+/* Home "new conversation": roomier column layout — textarea on top, a bottom
+   toolbar row holding the model picker (left) and attach + send (right). */
+.cw-composer-box--large {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  padding: 14px 16px 12px;
+  border-radius: 20px;
+}
+.cw-composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.cw-composer-actions-spacer { flex: 1; }
+.cw-composer-input {
   flex: 1;
   min-width: 0;
-  height: 34px;
+  min-height: 24px;
+  max-height: 200px;
   border: 0;
-  border-radius: 0;
   background: transparent;
-  padding: 0;
+  padding: 7px 0;
   outline: 0;
+  resize: none;
+  overflow-y: hidden;
+  font: inherit;
   font-size: 14px;
+  line-height: 1.5;
   color: var(--cw-fg-1);
 }
-.cw-composer input::placeholder { color: var(--cw-fg-4); }
+/* In the column layout, let the textarea keep its JS auto-grow height instead of
+   flex-growing to fill the box (flex-grow on the column axis would override the
+   inline height and pin it to one line). align-items: stretch handles full width. */
+.cw-composer-box--large .cw-composer-input { flex: 0 0 auto; min-height: 24px; padding: 4px 0; }
+
+/* home -> session composer morph (route navigate with viewTransition: true).
+   The shared `cw-composer` name lets the browser tween the box from the home
+   center to the bottom-of-session pill; we just tune timing + cross-fade. */
+::view-transition-group(cw-composer) {
+  animation-duration: 480ms;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+::view-transition-old(cw-composer),
+::view-transition-new(cw-composer) {
+  /* Fade the differing inner content (large toolbar vs pill) so the reshape reads
+     as one element morphing rather than two boxes stacked. */
+  animation-duration: 320ms;
+}
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(cw-composer),
+  ::view-transition-old(cw-composer),
+  ::view-transition-new(cw-composer) { animation: none; }
+}
+.cw-composer-input::placeholder { color: var(--cw-fg-4); }
 .cw-send-button {
   width: 34px;
   height: 34px;
@@ -996,18 +1043,165 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 }
 .cw-send-button:hover:not(:disabled) { background: var(--cw-primary-hover, var(--cw-primary)); }
 .cw-send-button:disabled { opacity: 0.45; cursor: not-allowed; }
-.cw-artifact-button {
-  height: 38px;
-  border-radius: 999px;
-  padding: 0 14px;
-  white-space: nowrap;
+.cw-send-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid color-mix(in oklch, var(--cw-fg-on-primary, white), transparent 55%);
+  border-top-color: var(--cw-fg-on-primary, white);
+  border-radius: 50%;
+  animation: cw-spin 0.6s linear infinite;
 }
+@keyframes cw-spin { to { transform: rotate(360deg); } }
+.cw-attach-button {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--cw-fg-3);
+  flex: 0 0 auto;
+  cursor: pointer;
+  transition: background 120ms, color 120ms;
+}
+.cw-attach-button:hover:not(:disabled) { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
+.cw-attach-button:disabled { opacity: 0.45; cursor: not-allowed; }
 .cw-composer small {
-  grid-column: 1 / -1;
   text-align: center;
   color: var(--cw-fg-4);
   font-size: 11px;
 }
+.cw-model-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  border-radius: var(--cw-radius-full);
+  border: 1px solid var(--cw-border);
+  background: var(--cw-bg);
+  color: var(--cw-fg-2);
+  padding: 0 10px;
+  font-size: 12px;
+}
+.cw-model-picker select { border: 0; outline: 0; background: transparent; color: inherit; cursor: pointer; font-size: 12px; }
+
+/* Project home — "new conversation" surface */
+.cw-project-hero.is-slim { align-items: center; padding-bottom: var(--cw-space-4); margin-bottom: var(--cw-space-5); }
+.cw-project-hero.is-slim h1 { font-size: var(--cw-text-xl); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* Sidebar SESSIONS "View all" — hidden until the section header is hovered (Claude pattern). */
+.cw-section-viewall {
+  border: 0;
+  background: transparent;
+  color: var(--cw-fg-3);
+  font-size: 11px;
+  padding: 2px 6px;
+  margin-left: auto;
+  white-space: nowrap;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms, color 120ms;
+}
+.cw-section-header:hover .cw-section-viewall,
+.cw-section-viewall:focus-visible { opacity: 1; }
+.cw-section-viewall:hover { color: var(--cw-fg-1); }
+
+/* z-index ladder (keep these in sync when adding new layers):
+   25  toast
+   30  marquee / misc
+   48–51  sidebar (drawer, reveal, resizer)
+   58  sessions-overlay backdrop
+   60  sessions-overlay panel
+   70  ConfirmDialog backdrop (always the topmost modal, even over the overlay) */
+
+/* "View all" sessions overlay — wide modal floating over the main area. */
+.cw-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 58;
+  background: color-mix(in oklch, var(--cw-ink) 38%, transparent);
+}
+.cw-sessions-overlay {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 60;
+  width: min(880px, 92vw);
+  max-height: 82vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--cw-paper);
+  border: 1px solid var(--cw-border);
+  border-radius: var(--cw-radius-lg);
+  box-shadow: 0 20px 60px color-mix(in oklch, var(--cw-ink), transparent 68%);
+  overflow: hidden;
+}
+.cw-overlay-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--cw-border);
+}
+.cw-overlay-head h2 { margin: 0; font-size: var(--cw-text-lg); }
+.cw-overlay-close {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--cw-radius-sm);
+  background: transparent;
+  color: var(--cw-fg-3);
+  cursor: pointer;
+  transition: background 120ms, color 120ms;
+}
+.cw-overlay-close:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
+.cw-overlay-body { padding: 20px; overflow-y: auto; }
+.cw-overlay-body .cw-session-grid { margin-bottom: 0; }
+.cw-home-blank {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  min-height: 58vh;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+.cw-home-blank .cw-composer-box { width: 100%; }
+.cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); }
+.cw-home-blank .cw-composer {
+  position: static;
+  width: 100%;
+  max-width: 100%;
+  border-top: 0;
+  background: transparent;
+  padding: 0;
+}
+.cw-suggested-prompts {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+.cw-suggested-chip {
+  border: 1px solid var(--cw-border);
+  border-radius: var(--cw-radius-full);
+  background: var(--cw-bg);
+  color: var(--cw-fg-3);
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 120ms, border-color 120ms, color 120ms;
+}
+.cw-suggested-chip:hover { background: var(--cw-bg-muted); border-color: var(--cw-border-hover); color: var(--cw-fg-1); }
 
 /* ── Attachment tray (composer) & attachment chips ───────────────────────── */
 .cw-attach-chip {
@@ -1116,10 +1310,12 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   .cw-project-card,
   .cw-session-card { min-height: 118px; }
   .cw-composer { grid-template-columns: 1fr; padding: 12px 18px; }
-  .cw-artifact-button { width: 100%; }
   .cw-message-body { max-width: calc(100vw - 82px); }
   .cw-file-row { min-height: 58px; }
   .cw-file-path { align-items: flex-start; flex-direction: column; gap: 10px; }
+  /* Composer sits in the upper third so the iOS keyboard doesn't cover it. */
+  .cw-home-blank { min-height: auto; justify-content: flex-start; padding-top: 12vh; }
+  .cw-home-blank .cw-composer { padding: 0; }
 }
 
 /* Authoritative pass from Design System preview/icons-nav-files.html.

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1282,6 +1282,53 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   text-align: center;
 }
 
+/* Agent / mode picker — segmented tab row above the home composer. Picks which
+   agent surface (coworker / speedwagon / deep research / buddy) drives the chat. */
+.cw-agent-picker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+.cw-agent-tabs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: var(--cw-radius-full);
+  background: var(--cw-bg-muted);
+}
+.cw-agent-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  border-radius: var(--cw-radius-full);
+  background: transparent;
+  color: var(--cw-fg-3);
+  padding: 7px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 120ms, color 120ms, box-shadow 120ms;
+}
+.cw-agent-tab:hover { color: var(--cw-fg-1); }
+.cw-agent-tab.is-active {
+  background: var(--cw-bg);
+  color: var(--cw-accent);
+  font-weight: 600;
+  box-shadow: var(--cw-shadow-sm);
+}
+.cw-agent-blurb {
+  margin: 0;
+  font-size: 12px;
+  color: var(--cw-fg-3);
+  text-align: center;
+}
+
 .cw-empty-state {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary

This PR reshapes the project home into a “new conversation” surface.

Instead of showing recent sessions/files on the home page, the main focus is now a larger composer where users can choose an agent-style surface, pick a model, start from suggested prompts, and submit the first message directly into a new session.

## What changed

- Added a project-home composer with a roomier multiline input.
- Added preview agent tabs:
  - Coworker
  - Speedwagon
  - Deep Research
  - Buddy
- Agent selection updates the greeting, placeholder, accent color, and suggested prompt chips.
- Added a model picker inside the home composer toolbar.
- Submitting from home creates a session and carries the first message into the session page for auto-send.
- The selected agent is shown as a transient `Preview` chip in the session header.
- Sidebar `+` now returns users to the project home composer instead of creating an empty session immediately.
- Added a “View all” sessions overlay from the sidebar so browsing old sessions stays available without competing with the home composer.
- Separated the home composer from the session composer boundary so home-only picker/preview UI does not leak into the session input API.

## Screenshots

### Project home composer
<img width="1440" height="1000" alt="home-composer-separated" src="https://github.com/user-attachments/assets/897b9f38-c290-478c-90ad-92cda93ef7fc" />

### Sessions overlay
<img width="1200" height="766" alt="sessions-overlay-fullscreen" src="https://github.com/user-attachments/assets/a93037b7-1c0d-4b55-ba79-0e5588522b31" />

## Notes

This is intentionally still preview UI.

- Agent/model selection is not persisted to the backend yet.
- The agent chip in the session header is a preview indicator, not a durable session property.
- Backend dispatch/wiring for selected agents and models will be handled in a follow-up PR.

## Verification

- `pnpm -C app test:unit -- src/domain/agentSurfaces.test.ts`
- `pnpm -C app lint`
- `git diff --cached --check`
- Local Chrome smoke:
  - project home composer renders
  - agent tabs update the composer state
  - suggested prompts fill the composer
  - first message creates a session and auto-sends
  - transient session agent chip resets when navigating to another session