### PR TITLE
feat(app): redirect to /login on JWT expiry with session toast

### DIFF
--- a/app/src/api/client.test.ts
+++ b/app/src/api/client.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setUnauthorizedHandler, notifyUnauthorized } from './client';
+
+describe('notifyUnauthorized reason classification', () => {
+  let receivedReason: string | undefined;
+
+  beforeEach(() => {
+    receivedReason = undefined;
+    setUnauthorizedHandler((reason) => { receivedReason = reason; });
+  });
+
+  it('classifies JWT_EXPIRED_MESSAGE as "expired"', () => {
+    notifyUnauthorized(401, { error: 'token has expired' });
+    expect(receivedReason).toBe('expired');
+  });
+
+  it('classifies any other message as "invalid"', () => {
+    notifyUnauthorized(401, { error: 'unauthorized' });
+    expect(receivedReason).toBe('invalid');
+  });
+
+  it('classifies missing error field as "invalid"', () => {
+    notifyUnauthorized(401, {});
+    expect(receivedReason).toBe('invalid');
+  });
+
+  it('does not fire for non-401 status', () => {
+    notifyUnauthorized(403, { error: 'token has expired' });
+    expect(receivedReason).toBeUndefined();
+  });
+
+  it('does not fire when skipAuth is true', () => {
+    notifyUnauthorized(401, { error: 'token has expired' }, true);
+    expect(receivedReason).toBeUndefined();
+  });
+});

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -4,6 +4,26 @@
 
 const BASE_URL_KEY = 'cowork.v2.baseUrl';
 const TOKEN_KEY = 'cowork.v2.token';
+
+export type UnauthorizedReason = 'expired' | 'invalid';
+let unauthorizedHandler: ((reason: UnauthorizedReason) => void) | null = null;
+// Guard against multiple in-flight 401 responses all firing the handler.
+let unauthorizedTriggered = false;
+
+export function setUnauthorizedHandler(cb: (reason: UnauthorizedReason) => void): void {
+  unauthorizedHandler = cb;
+  unauthorizedTriggered = false;
+}
+
+export function notifyUnauthorized(status: number, body: unknown, skipAuth?: boolean): void {
+  if (status !== 401 || skipAuth || !unauthorizedHandler || unauthorizedTriggered) return;
+  unauthorizedTriggered = true;
+  const msg = typeof body === 'object' && body && 'error' in body
+    ? String((body as Record<string, unknown>).error)
+    : '';
+  const reason: UnauthorizedReason = msg === 'token has expired' ? 'expired' : 'invalid';
+  unauthorizedHandler(reason);
+}
 const DEFAULT_BASE_URL = import.meta.env.VITE_BACKEND_V2_URL ?? 'http://127.0.0.1:8080';
 
 export class ApiError extends Error {
@@ -40,6 +60,8 @@ export function getToken(): string | null {
 
 export function setToken(token: string | null): void {
   writeStored(TOKEN_KEY, token);
+  // A new token means a new session — reset the guard so future 401s trigger the handler.
+  if (token) unauthorizedTriggered = false;
 }
 
 interface RequestOptions extends Omit<RequestInit, 'body'> {
@@ -82,6 +104,7 @@ export async function request<T = unknown>(path: string, options: RequestOptions
     const msg = typeof parsed === 'object' && parsed && 'error' in parsed
       ? String((parsed as Record<string, unknown>).error)
       : (raw || `${response.status} ${response.statusText}`);
+    notifyUnauthorized(response.status, parsed, skipAuth);
     throw new ApiError(response.status, msg, parsed);
   }
 
@@ -116,6 +139,9 @@ export async function* streamSse(
 
   if (!response.ok || !response.body) {
     const raw = await response.text().catch(() => '');
+    let parsed: unknown;
+    try { parsed = raw ? JSON.parse(raw) : undefined; } catch { parsed = raw; }
+    notifyUnauthorized(response.status, parsed);
     throw new ApiError(response.status, raw || `${response.status} ${response.statusText}`);
   }
 

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -15,8 +15,8 @@ export function setUnauthorizedHandler(cb: (reason: UnauthorizedReason) => void)
   unauthorizedTriggered = false;
 }
 
-// 백엔드 출처: backend/src/auth/jwt.rs — ExpiredSignature 에러 메시지
-// 이 문자열이 변경되면 만료 배너가 표시되지 않음 (backend error_code 필드 추가로 개선 예정)
+// Source: backend/src/auth/jwt.rs — the error message emitted on ExpiredSignature.
+// If this string changes the expired-session banner will silently stop appearing.
 const JWT_EXPIRED_MESSAGE = 'token has expired';
 
 export function notifyUnauthorized(status: number, body: unknown, skipAuth?: boolean): void {

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -15,13 +15,17 @@ export function setUnauthorizedHandler(cb: (reason: UnauthorizedReason) => void)
   unauthorizedTriggered = false;
 }
 
+// 백엔드 출처: backend/src/auth/jwt.rs — ExpiredSignature 에러 메시지
+// 이 문자열이 변경되면 만료 배너가 표시되지 않음 (backend error_code 필드 추가로 개선 예정)
+const JWT_EXPIRED_MESSAGE = 'token has expired';
+
 export function notifyUnauthorized(status: number, body: unknown, skipAuth?: boolean): void {
   if (status !== 401 || skipAuth || !unauthorizedHandler || unauthorizedTriggered) return;
   unauthorizedTriggered = true;
   const msg = typeof body === 'object' && body && 'error' in body
     ? String((body as Record<string, unknown>).error)
     : '';
-  const reason: UnauthorizedReason = msg === 'token has expired' ? 'expired' : 'invalid';
+  const reason: UnauthorizedReason = msg === JWT_EXPIRED_MESSAGE ? 'expired' : 'invalid';
   unauthorizedHandler(reason);
 }
 const DEFAULT_BASE_URL = import.meta.env.VITE_BACKEND_V2_URL ?? 'http://127.0.0.1:8080';

--- a/app/src/api/dirents.ts
+++ b/app/src/api/dirents.ts
@@ -1,4 +1,4 @@
-import { ApiError, getBaseUrl, getToken, request } from './client';
+import { ApiError, getBaseUrl, getToken, notifyUnauthorized, request } from './client';
 import type { BackendDirent, BackendDirentBatchOp, BackendDirentBatchResult } from './backend-types';
 import { toFileAsset } from './transformers';
 import type { FileAsset } from '@/domain/types';
@@ -145,6 +145,9 @@ export async function fetchFileBlob(globalPath: string): Promise<Blob> {
   const response = await fetch(url, { headers });
   if (!response.ok) {
     const raw = await response.text().catch(() => '');
+    let parsed: unknown;
+    try { parsed = raw ? JSON.parse(raw) : undefined; } catch { parsed = raw; }
+    notifyUnauthorized(response.status, parsed);
     throw new ApiError(response.status, raw || `${response.status} ${response.statusText}`);
   }
   return response.blob();

--- a/app/src/api/ws.test.ts
+++ b/app/src/api/ws.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getMe } from './auth';
 
 // client 모듈 전체를 mock — ws.ts가 getToken, notifyUnauthorized를 import하므로
 vi.mock('./client', () => ({
@@ -35,11 +36,14 @@ class MockWebSocket {
 let wsInstances: MockWebSocket[] = [];
 const OriginalWebSocket = globalThis.WebSocket;
 
-beforeEach(() => {
+beforeEach(async () => {
   wsInstances = [];
   vi.useFakeTimers();
   vi.mocked(notifyUnauthorized).mockClear();
   vi.mocked(getToken).mockReturnValue('test-token');
+  // 기본값: getMe는 401 'invalid token'으로 reject (rapid-close 테스트에서 notifyUnauthorized 호출 유지)
+  const { ApiError } = await import('./client');
+  vi.mocked(getMe).mockRejectedValue(new ApiError(401, 'invalid token', { error: 'invalid token' }));
   // @ts-expect-error mock
   globalThis.WebSocket = class extends MockWebSocket {
     constructor() {
@@ -59,7 +63,7 @@ afterEach(() => {
 });
 
 describe('AppWebSocketManager rapid-close heuristic', () => {
-  it('accumulates rapidCloseCount across reconnect cycles when connections are short-lived', () => {
+  it('accumulates rapidCloseCount across reconnect cycles when connections are short-lived', async () => {
     const mgr = new AppWebSocketManager();
     mgr.connect('token');
 
@@ -82,6 +86,9 @@ describe('AppWebSocketManager rapid-close heuristic', () => {
     // 3차 연결 — 500ms 후 close → RAPID_CLOSE_MAX(3) 도달
     vi.advanceTimersByTime(500);
     wsInstances[2].onclose?.({ code: 1006, reason: '' });
+
+    // getMe()가 async이므로 microtask 소진 후 확인
+    await Promise.resolve();
 
     expect(notifyUnauthorized).toHaveBeenCalledOnce();
   });
@@ -118,14 +125,55 @@ describe('AppWebSocketManager rapid-close heuristic', () => {
     expect(notifyUnauthorized).not.toHaveBeenCalled();
   });
 
-  it('triggers logout immediately for close code 4401', () => {
+  it('stops reconnecting for close code 4401 (auth close code)', () => {
+    const mgr = new AppWebSocketManager();
+    mgr.connect('token');
+    wsInstances[0].onclose?.({ code: 4401, reason: '' });
+    // active is set to false — no further reconnect timer
+    vi.advanceTimersByTime(10000);
+    expect(wsInstances).toHaveLength(1); // no reconnect happened
+  });
+});
+
+describe('AppWebSocketManager auth close classification', () => {
+  it('calls notifyUnauthorized with expired body when getMe returns 401 "token has expired"', async () => {
+    const { ApiError } = await import('./client');
+    vi.mocked(getMe).mockRejectedValue(new ApiError(401, 'token has expired', { error: 'token has expired' }));
+
     const mgr = new AppWebSocketManager();
     mgr.connect('token');
 
     wsInstances[0].onclose?.({ code: 4401, reason: '' });
 
-    // 4401 → immediate logout (Task 2에서 async가 되지만, 최소 active=false 확인)
-    // Task 2 완성 후 notifyUnauthorized 호출 여부 검증
-    expect(wsInstances[0].readyState).toBeDefined(); // placeholder, Task 2에서 보강
+    await Promise.resolve();
+
+    expect(notifyUnauthorized).toHaveBeenCalledWith(401, { error: 'token has expired' });
+  });
+
+  it('calls notifyUnauthorized with invalid body when getMe returns generic 401', async () => {
+    const { ApiError } = await import('./client');
+    vi.mocked(getMe).mockRejectedValue(new ApiError(401, 'unauthorized', { error: 'unauthorized' }));
+
+    const mgr = new AppWebSocketManager();
+    mgr.connect('token');
+
+    wsInstances[0].onclose?.({ code: 4401, reason: '' });
+
+    await Promise.resolve();
+
+    expect(notifyUnauthorized).toHaveBeenCalledWith(401, { error: 'unauthorized' });
+  });
+
+  it('does NOT call notifyUnauthorized when getMe succeeds (WS flap, not auth failure)', async () => {
+    vi.mocked(getMe).mockResolvedValue({ id: '1', username: 'test', displayName: 'Test' } as any);
+
+    const mgr = new AppWebSocketManager();
+    mgr.connect('token');
+
+    wsInstances[0].onclose?.({ code: 4401, reason: '' });
+
+    await Promise.resolve();
+
+    expect(notifyUnauthorized).not.toHaveBeenCalled();
   });
 });

--- a/app/src/api/ws.test.ts
+++ b/app/src/api/ws.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { getMe } from './auth';
 
-// client 모듈 전체를 mock — ws.ts가 getToken, notifyUnauthorized를 import하므로
+// Mock the entire client module — ws.ts imports getToken and notifyUnauthorized from it.
 vi.mock('./client', () => ({
   getBaseUrl: () => 'http://localhost:8080',
   getToken: vi.fn(() => 'test-token'),
@@ -13,7 +13,7 @@ vi.mock('./client', () => ({
   },
 }));
 
-// auth 모듈 mock (Task 2에서 사용)
+// Mock the auth module so getMe can be controlled per test.
 vi.mock('./auth', () => ({
   getMe: vi.fn(),
 }));
@@ -41,7 +41,7 @@ beforeEach(async () => {
   vi.useFakeTimers();
   vi.mocked(notifyUnauthorized).mockClear();
   vi.mocked(getToken).mockReturnValue('test-token');
-  // 기본값: getMe는 401 'invalid token'으로 reject (rapid-close 테스트에서 notifyUnauthorized 호출 유지)
+  // Default: getMe rejects with 401 so rapid-close tests still see notifyUnauthorized called.
   const { ApiError } = await import('./client');
   vi.mocked(getMe).mockRejectedValue(new ApiError(401, 'invalid token', { error: 'invalid token' }));
   // @ts-expect-error mock
@@ -67,27 +67,27 @@ describe('AppWebSocketManager rapid-close heuristic', () => {
     const mgr = new AppWebSocketManager();
     mgr.connect('token');
 
-    // 1차 연결 — 500ms 후 close (threshold 2000ms 미만)
+    // 1st connection — closes after 500ms (below 2000ms threshold)
     expect(wsInstances).toHaveLength(1);
     vi.advanceTimersByTime(500);
     wsInstances[0].onclose?.({ code: 1006, reason: '' });
 
-    // 3000ms reconnect timer
+    // wait out the 3000ms reconnect timer
     vi.advanceTimersByTime(3000);
     expect(wsInstances).toHaveLength(2);
 
-    // 2차 연결 — 500ms 후 close
+    // 2nd connection — closes after 500ms
     vi.advanceTimersByTime(500);
     wsInstances[1].onclose?.({ code: 1006, reason: '' });
 
     vi.advanceTimersByTime(3000);
     expect(wsInstances).toHaveLength(3);
 
-    // 3차 연결 — 500ms 후 close → RAPID_CLOSE_MAX(3) 도달
+    // 3rd connection — closes after 500ms → reaches RAPID_CLOSE_MAX (3)
     vi.advanceTimersByTime(500);
     wsInstances[2].onclose?.({ code: 1006, reason: '' });
 
-    // getMe()가 async이므로 microtask 소진 후 확인
+    // flush microtask so the async getMe() rejection is processed
     await Promise.resolve();
 
     expect(notifyUnauthorized).toHaveBeenCalledOnce();
@@ -97,21 +97,21 @@ describe('AppWebSocketManager rapid-close heuristic', () => {
     const mgr = new AppWebSocketManager();
     mgr.connect('token');
 
-    // 1차 연결 — short-lived
+    // 1st connection — short-lived
     vi.advanceTimersByTime(500);
     wsInstances[0].onclose?.({ code: 1006, reason: '' });
 
-    // 2차 연결 — 3000ms 살다가 종료 (RAPID_CLOSE_THRESHOLD_MS=2000ms 초과 → 카운터 리셋)
-    vi.advanceTimersByTime(3000); // reconnect timer 소진
-    vi.advanceTimersByTime(3000); // 이 접속의 lifetime = 3000ms > 2000ms threshold
+    // 2nd connection — lives for 3000ms (> RAPID_CLOSE_THRESHOLD_MS=2000ms → counter resets)
+    vi.advanceTimersByTime(3000); // exhaust the reconnect timer
+    vi.advanceTimersByTime(3000); // this connection's lifetime = 3000ms > 2000ms threshold
     wsInstances[1].onclose?.({ code: 1006, reason: '' });
 
-    // 3차 연결 — short-lived again (count reset → only 1, not 3)
+    // 3rd connection — short-lived again (count starts from 1, not 3)
     vi.advanceTimersByTime(3000);
     vi.advanceTimersByTime(500);
     wsInstances[2].onclose?.({ code: 1006, reason: '' });
 
-    // notifyUnauthorized 아직 호출되면 안 됨
+    // counter is only 1 — notifyUnauthorized must not have been called
     expect(notifyUnauthorized).not.toHaveBeenCalled();
   });
 
@@ -121,7 +121,7 @@ describe('AppWebSocketManager rapid-close heuristic', () => {
 
     wsInstances[0].onclose?.({ code: 1008, reason: '' });
 
-    // rapid-close 카운터가 1이 되었을 뿐, notifyUnauthorized 즉시 호출 안 됨
+    // counter is 1, but RAPID_CLOSE_MAX not reached — notifyUnauthorized must not fire
     expect(notifyUnauthorized).not.toHaveBeenCalled();
   });
 

--- a/app/src/api/ws.test.ts
+++ b/app/src/api/ws.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// client 모듈 전체를 mock — ws.ts가 getToken, notifyUnauthorized를 import하므로
+vi.mock('./client', () => ({
+  getBaseUrl: () => 'http://localhost:8080',
+  getToken: vi.fn(() => 'test-token'),
+  notifyUnauthorized: vi.fn(),
+  ApiError: class ApiError extends Error {
+    constructor(public status: number, message: string, public body?: unknown) {
+      super(message);
+    }
+  },
+}));
+
+// auth 모듈 mock (Task 2에서 사용)
+vi.mock('./auth', () => ({
+  getMe: vi.fn(),
+}));
+
+import { getToken, notifyUnauthorized } from './client';
+import { AppWebSocketManager } from './ws';
+
+// WebSocket mock
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onclose: ((evt: { code: number; reason: string }) => void) | null = null;
+  onmessage: ((evt: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  close() { this.readyState = 3; }
+}
+
+let wsInstances: MockWebSocket[] = [];
+const OriginalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+  wsInstances = [];
+  vi.useFakeTimers();
+  vi.mocked(notifyUnauthorized).mockClear();
+  vi.mocked(getToken).mockReturnValue('test-token');
+  // @ts-expect-error mock
+  globalThis.WebSocket = class extends MockWebSocket {
+    constructor() {
+      super();
+      wsInstances.push(this);
+    }
+  };
+  // @ts-expect-error assigning to readonly static for mock purposes
+  globalThis.WebSocket.OPEN = 1;
+  // @ts-expect-error assigning to readonly static for mock purposes
+  globalThis.WebSocket.CONNECTING = 0;
+});
+
+afterEach(() => {
+  globalThis.WebSocket = OriginalWebSocket;
+  vi.useRealTimers();
+});
+
+describe('AppWebSocketManager rapid-close heuristic', () => {
+  it('accumulates rapidCloseCount across reconnect cycles when connections are short-lived', () => {
+    const mgr = new AppWebSocketManager();
+    mgr.connect('token');
+
+    // 1차 연결 — 500ms 후 close (threshold 2000ms 미만)
+    expect(wsInstances).toHaveLength(1);
+    vi.advanceTimersByTime(500);
+    wsInstances[0].onclose?.({ code: 1006, reason: '' });
+
+    // 3000ms reconnect timer
+    vi.advanceTimersByTime(3000);
+    expect(wsInstances).toHaveLength(2);
+
+    // 2차 연결 — 500ms 후 close
+    vi.advanceTimersByTime(500);
+    wsInstances[1].onclose?.({ code: 1006, reason: '' });
+
+    vi.advanceTimersByTime(3000);
+    expect(wsInstances).toHaveLength(3);
+
+    // 3차 연결 — 500ms 후 close → RAPID_CLOSE_MAX(3) 도달
+    vi.advanceTimersByTime(500);
+    wsInstances[2].onclose?.({ code: 1006, reason: '' });
+
+    expect(notifyUnauthorized).toHaveBeenCalledOnce();
+  });
+
+  it('resets rapidCloseCount when a connection lives longer than threshold', () => {
+    const mgr = new AppWebSocketManager();
+    mgr.connect('token');
+
+    // 1차 연결 — short-lived
+    vi.advanceTimersByTime(500);
+    wsInstances[0].onclose?.({ code: 1006, reason: '' });
+
+    // 2차 연결 — 3000ms 살다가 종료 (RAPID_CLOSE_THRESHOLD_MS=2000ms 초과 → 카운터 리셋)
+    vi.advanceTimersByTime(3000); // reconnect timer 소진
+    vi.advanceTimersByTime(3000); // 이 접속의 lifetime = 3000ms > 2000ms threshold
+    wsInstances[1].onclose?.({ code: 1006, reason: '' });
+
+    // 3차 연결 — short-lived again (count reset → only 1, not 3)
+    vi.advanceTimersByTime(3000);
+    vi.advanceTimersByTime(500);
+    wsInstances[2].onclose?.({ code: 1006, reason: '' });
+
+    // notifyUnauthorized 아직 호출되면 안 됨
+    expect(notifyUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('does NOT trigger logout for close code 1008 (proxy policy violation)', () => {
+    const mgr = new AppWebSocketManager();
+    mgr.connect('token');
+
+    wsInstances[0].onclose?.({ code: 1008, reason: '' });
+
+    // rapid-close 카운터가 1이 되었을 뿐, notifyUnauthorized 즉시 호출 안 됨
+    expect(notifyUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('triggers logout immediately for close code 4401', () => {
+    const mgr = new AppWebSocketManager();
+    mgr.connect('token');
+
+    wsInstances[0].onclose?.({ code: 4401, reason: '' });
+
+    // 4401 → immediate logout (Task 2에서 async가 되지만, 최소 active=false 확인)
+    // Task 2 완성 후 notifyUnauthorized 호출 여부 검증
+    expect(wsInstances[0].readyState).toBeDefined(); // placeholder, Task 2에서 보강
+  });
+});

--- a/app/src/api/ws.ts
+++ b/app/src/api/ws.ts
@@ -1,4 +1,5 @@
-import { getBaseUrl, getToken, notifyUnauthorized } from './client';
+import { ApiError, getBaseUrl, getToken, notifyUnauthorized } from './client';
+import { getMe } from './auth';  // Task 2에서 사용, 여기서 미리 추가
 
 export interface SessionTitleUpdatedEvent {
   type: 'session_title_updated';
@@ -15,11 +16,15 @@ function toWsUrl(httpBase: string): string {
   return httpBase.replace(/^https?/, (m) => (m === 'https' ? 'wss' : 'ws'));
 }
 
-// WS auth close codes: 4401 is app-defined; 1008 is Policy Violation (RFC 6455).
-const AUTH_CLOSE_CODES = new Set([4401, 1008]);
-// Detect auth failure by consecutive rapid closes (backend may not send a specific code).
-const RAPID_CLOSE_THRESHOLD_MS = 1000;
+// 앱이 정의한 WS 인증 실패 코드 (4401만 — 1008은 프록시가 발생시키는 범용 코드라 제외)
+const AUTH_CLOSE_CODES = new Set([4401]);
+// 접속이 이 시간(ms) 이내에 끊기면 short-lived로 간주
+const RAPID_CLOSE_THRESHOLD_MS = 2000;
 const RAPID_CLOSE_MAX = 3;
+
+// Task 2에서 사용 예정 — 미리 import만 해둠
+void ApiError;
+void getMe;
 
 class AppWebSocketManager {
   private ws: WebSocket | null = null;
@@ -27,14 +32,14 @@ class AppWebSocketManager {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private active = false;
   private rapidCloseCount = 0;
-  private lastCloseTime = 0;
+  private connectionStartTime = 0;  // lastCloseTime 대체: WS 생성 시점 기록
 
   connect(token: string): void {
     this.active = true;
-    this.rapidCloseCount = 0;
-    this.lastCloseTime = 0;
+    // early-return 이후에 connectionStartTime 설정 — OPEN/CONNECTING이면 새 소켓 없음
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) return;
     const url = `${toWsUrl(getBaseUrl())}/ws?token=${encodeURIComponent(token)}`;
+    this.connectionStartTime = Date.now();  // 실제 소켓 생성 직전에 기록
     const ws = new WebSocket(url);
     this.ws = ws;
 
@@ -48,22 +53,23 @@ class AppWebSocketManager {
     ws.onclose = (evt) => {
       if (!this.active) return;
 
-      // Explicit auth close codes — stop reconnecting and trigger logout.
+      // onclose가 발생한 시점에 this.ws를 null로 — 재연결 시 early-return 방지
+      this.ws = null;
+
+      // 앱 정의 인증 실패 코드 — 재연결 중단 후 로그아웃 (Task 2에서 HTTP fallback으로 교체)
       if (AUTH_CLOSE_CODES.has(evt.code)) {
         this.active = false;
-        notifyUnauthorized(401, { error: 'invalid token' });
+        notifyUnauthorized(401, { error: 'invalid token' });  // Task 2에서 교체
         return;
       }
 
-      // Rapid-close heuristic: if the connection keeps dropping within 1s of
-      // opening, assume the token is invalid and bail instead of looping forever.
-      const now = Date.now();
-      if (now - this.lastCloseTime < RAPID_CLOSE_THRESHOLD_MS) {
+      // 접속 유지 시간으로 short-lived 여부 판단
+      const lifetime = Date.now() - this.connectionStartTime;
+      if (lifetime < RAPID_CLOSE_THRESHOLD_MS) {
         this.rapidCloseCount += 1;
       } else {
-        this.rapidCloseCount = 1;
+        this.rapidCloseCount = 0;  // 충분히 오래 살았으면 카운터 리셋
       }
-      this.lastCloseTime = now;
 
       if (this.rapidCloseCount >= RAPID_CLOSE_MAX && getToken()) {
         this.active = false;
@@ -82,6 +88,7 @@ class AppWebSocketManager {
 
   disconnect(): void {
     this.active = false;
+    this.rapidCloseCount = 0;  // 명시적 disconnect 시 카운터 리셋
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -96,4 +103,5 @@ class AppWebSocketManager {
   }
 }
 
+export { AppWebSocketManager };
 export const appWs = new AppWebSocketManager();

--- a/app/src/api/ws.ts
+++ b/app/src/api/ws.ts
@@ -1,4 +1,4 @@
-import { getBaseUrl, getToken } from './client';
+import { getBaseUrl, getToken, notifyUnauthorized } from './client';
 
 export interface SessionTitleUpdatedEvent {
   type: 'session_title_updated';
@@ -15,14 +15,24 @@ function toWsUrl(httpBase: string): string {
   return httpBase.replace(/^https?/, (m) => (m === 'https' ? 'wss' : 'ws'));
 }
 
+// WS auth close codes: 4401 is app-defined; 1008 is Policy Violation (RFC 6455).
+const AUTH_CLOSE_CODES = new Set([4401, 1008]);
+// Detect auth failure by consecutive rapid closes (backend may not send a specific code).
+const RAPID_CLOSE_THRESHOLD_MS = 1000;
+const RAPID_CLOSE_MAX = 3;
+
 class AppWebSocketManager {
   private ws: WebSocket | null = null;
   private handlers = new Set<Handler>();
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private active = false;
+  private rapidCloseCount = 0;
+  private lastCloseTime = 0;
 
   connect(token: string): void {
     this.active = true;
+    this.rapidCloseCount = 0;
+    this.lastCloseTime = 0;
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) return;
     const url = `${toWsUrl(getBaseUrl())}/ws?token=${encodeURIComponent(token)}`;
     const ws = new WebSocket(url);
@@ -35,8 +45,32 @@ class AppWebSocketManager {
       } catch { /* noop */ }
     };
 
-    ws.onclose = () => {
+    ws.onclose = (evt) => {
       if (!this.active) return;
+
+      // Explicit auth close codes — stop reconnecting and trigger logout.
+      if (AUTH_CLOSE_CODES.has(evt.code)) {
+        this.active = false;
+        notifyUnauthorized(401, { error: 'invalid token' });
+        return;
+      }
+
+      // Rapid-close heuristic: if the connection keeps dropping within 1s of
+      // opening, assume the token is invalid and bail instead of looping forever.
+      const now = Date.now();
+      if (now - this.lastCloseTime < RAPID_CLOSE_THRESHOLD_MS) {
+        this.rapidCloseCount += 1;
+      } else {
+        this.rapidCloseCount = 1;
+      }
+      this.lastCloseTime = now;
+
+      if (this.rapidCloseCount >= RAPID_CLOSE_MAX && getToken()) {
+        this.active = false;
+        notifyUnauthorized(401, { error: 'invalid token' });
+        return;
+      }
+
       this.reconnectTimer = setTimeout(() => {
         const t = getToken();
         if (t && this.active) this.connect(t);

--- a/app/src/api/ws.ts
+++ b/app/src/api/ws.ts
@@ -22,9 +22,6 @@ const AUTH_CLOSE_CODES = new Set([4401]);
 const RAPID_CLOSE_THRESHOLD_MS = 2000;
 const RAPID_CLOSE_MAX = 3;
 
-// Task 2에서 사용 예정 — 미리 import만 해둠
-void ApiError;
-void getMe;
 
 class AppWebSocketManager {
   private ws: WebSocket | null = null;
@@ -56,10 +53,20 @@ class AppWebSocketManager {
       // onclose가 발생한 시점에 this.ws를 null로 — 재연결 시 early-return 방지
       this.ws = null;
 
-      // 앱 정의 인증 실패 코드 — 재연결 중단 후 로그아웃 (Task 2에서 HTTP fallback으로 교체)
+      // 앱 정의 인증 실패 코드 — 재연결 중단 후 HTTP fallback으로 에러 분류
       if (AUTH_CLOSE_CODES.has(evt.code)) {
         this.active = false;
-        notifyUnauthorized(401, { error: 'invalid token' });  // Task 2에서 교체
+        getMe().then(
+          () => {
+            // WS는 닫혔지만 HTTP 인증은 통과 → WS 네트워크 문제, 로그아웃 안 함
+          },
+          (err: unknown) => {
+            if (err instanceof ApiError && err.status === 401) {
+              notifyUnauthorized(401, { error: err.message });
+            }
+            // 5xx, 네트워크 오류: 로그아웃 안 함
+          }
+        );
         return;
       }
 
@@ -73,7 +80,14 @@ class AppWebSocketManager {
 
       if (this.rapidCloseCount >= RAPID_CLOSE_MAX && getToken()) {
         this.active = false;
-        notifyUnauthorized(401, { error: 'invalid token' });
+        getMe().then(
+          () => { /* HTTP 통과 → WS만 불안정, 로그아웃 안 함 */ },
+          (err: unknown) => {
+            if (err instanceof ApiError && err.status === 401) {
+              notifyUnauthorized(401, { error: err.message });
+            }
+          }
+        );
         return;
       }
 

--- a/app/src/api/ws.ts
+++ b/app/src/api/ws.ts
@@ -1,5 +1,5 @@
 import { ApiError, getBaseUrl, getToken, notifyUnauthorized } from './client';
-import { getMe } from './auth';  // Task 2에서 사용, 여기서 미리 추가
+import { getMe } from './auth';
 
 export interface SessionTitleUpdatedEvent {
   type: 'session_title_updated';
@@ -16,9 +16,10 @@ function toWsUrl(httpBase: string): string {
   return httpBase.replace(/^https?/, (m) => (m === 'https' ? 'wss' : 'ws'));
 }
 
-// 앱이 정의한 WS 인증 실패 코드 (4401만 — 1008은 프록시가 발생시키는 범용 코드라 제외)
+// App-defined WS auth failure code. 1008 (Policy Violation) is intentionally excluded
+// as proxies and firewalls emit it for non-auth reasons.
 const AUTH_CLOSE_CODES = new Set([4401]);
-// 접속이 이 시간(ms) 이내에 끊기면 short-lived로 간주
+// Connections that close within this window are considered short-lived.
 const RAPID_CLOSE_THRESHOLD_MS = 2000;
 const RAPID_CLOSE_MAX = 3;
 
@@ -29,14 +30,13 @@ class AppWebSocketManager {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private active = false;
   private rapidCloseCount = 0;
-  private connectionStartTime = 0;  // lastCloseTime 대체: WS 생성 시점 기록
+  private connectionStartTime = 0;  // replaces lastCloseTime: records when the socket was created
 
   connect(token: string): void {
     this.active = true;
-    // early-return 이후에 connectionStartTime 설정 — OPEN/CONNECTING이면 새 소켓 없음
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) return;
     const url = `${toWsUrl(getBaseUrl())}/ws?token=${encodeURIComponent(token)}`;
-    this.connectionStartTime = Date.now();  // 실제 소켓 생성 직전에 기록
+    this.connectionStartTime = Date.now();
     const ws = new WebSocket(url);
     this.ws = ws;
 
@@ -50,38 +50,38 @@ class AppWebSocketManager {
     ws.onclose = (evt) => {
       if (!this.active) return;
 
-      // onclose가 발생한 시점에 this.ws를 null로 — 재연결 시 early-return 방지
+      // Clear the socket reference so the reconnect call doesn't hit the early-return guard.
       this.ws = null;
 
-      // 앱 정의 인증 실패 코드 — 재연결 중단 후 HTTP fallback으로 에러 분류
+      // App-defined auth close code — stop reconnecting and classify the failure via HTTP.
       if (AUTH_CLOSE_CODES.has(evt.code)) {
         this.active = false;
         getMe().then(
           () => {
-            // WS는 닫혔지만 HTTP 인증은 통과 → WS 네트워크 문제, 로그아웃 안 함
+            // WS closed but HTTP auth passed — treat as a transient WS flap, not an auth failure.
           },
           (err: unknown) => {
             if (err instanceof ApiError && err.status === 401) {
               notifyUnauthorized(401, { error: err.message });
             }
-            // 5xx, 네트워크 오류: 로그아웃 안 함
+            // 5xx or network error: do not force logout.
           }
         );
         return;
       }
 
-      // 접속 유지 시간으로 short-lived 여부 판단
+      // Increment counter if the connection was short-lived; reset if it was stable.
       const lifetime = Date.now() - this.connectionStartTime;
       if (lifetime < RAPID_CLOSE_THRESHOLD_MS) {
         this.rapidCloseCount += 1;
       } else {
-        this.rapidCloseCount = 0;  // 충분히 오래 살았으면 카운터 리셋
+        this.rapidCloseCount = 0;
       }
 
       if (this.rapidCloseCount >= RAPID_CLOSE_MAX && getToken()) {
         this.active = false;
         getMe().then(
-          () => { /* HTTP 통과 → WS만 불안정, 로그아웃 안 함 */ },
+          () => { /* HTTP auth passed — WS instability only, do not force logout. */ },
           (err: unknown) => {
             if (err instanceof ApiError && err.status === 401) {
               notifyUnauthorized(401, { error: err.message });
@@ -102,7 +102,7 @@ class AppWebSocketManager {
 
   disconnect(): void {
     this.active = false;
-    this.rapidCloseCount = 0;  // 명시적 disconnect 시 카운터 리셋
+    this.rapidCloseCount = 0;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ import { SessionCardMenu } from '@/components/SessionCardMenu';
 import { canAdministerSession } from '@/lib/permissions';
 import { shortSessionId } from '@/lib/sessionId';
 import { ApiError } from '@/api/client';
+import { forceLogout } from '@/lib/forceLogout';
 import { SessionTitleText } from '@/components/SessionTitleText';
 import type { Session } from '@/domain/types';
 
@@ -461,7 +462,7 @@ export function Sidebar() {
             </div>
             <button
               aria-label="logout"
-              onClick={() => { useAuthStore.getState().reset(); window.location.href = '/login'; }}
+              onClick={() => forceLogout({ reason: 'manual' })}
               style={{ border: 0, background: 'transparent', padding: 0, color: 'var(--cw-ink-3)', cursor: 'pointer' }}
             >
               <Icon name="more" />

--- a/app/src/lib/forceLogout.ts
+++ b/app/src/lib/forceLogout.ts
@@ -1,0 +1,49 @@
+import { appWs } from '@/api/ws';
+import { useAuthStore } from '@/stores/auth';
+
+export type LogoutReason = 'expired' | 'invalid' | 'manual';
+
+const REASON_KEY = 'auth.expiredReason';
+const REDIRECT_KEY = 'auth.redirectAfterLogin';
+
+// Router reference injected from main.tsx to avoid circular imports.
+// Using router.navigate instead of window.location.href prevents a full-page
+// reload that would race with TanStack Router's own client-side redirect and
+// consume the sessionStorage items before the login page can read them.
+let _routerNavigate: ((to: string) => void) | null = null;
+export function setLogoutRouter(navigate: (to: string) => void): void {
+  _routerNavigate = navigate;
+}
+
+export function forceLogout(opts: { reason?: LogoutReason; redirectTo?: string }): void {
+  appWs.disconnect();
+  useAuthStore.getState().reset();
+
+  if (opts.reason && opts.reason !== 'manual') {
+    sessionStorage.setItem(REASON_KEY, opts.reason);
+  }
+
+  // Guard against open redirect: only store same-origin paths.
+  const redirectTo = opts.redirectTo;
+  if (redirectTo && redirectTo.startsWith('/') && !redirectTo.startsWith('//') && redirectTo !== '/login') {
+    sessionStorage.setItem(REDIRECT_KEY, redirectTo);
+  }
+
+  if (_routerNavigate) {
+    _routerNavigate('/login');
+  } else {
+    window.location.href = '/login';
+  }
+}
+
+export function consumeLogoutReason(): LogoutReason | null {
+  const val = sessionStorage.getItem(REASON_KEY) as LogoutReason | null;
+  if (val) sessionStorage.removeItem(REASON_KEY);
+  return val;
+}
+
+export function consumeRedirectAfterLogin(): string | null {
+  const val = sessionStorage.getItem(REDIRECT_KEY);
+  if (val) sessionStorage.removeItem(REDIRECT_KEY);
+  return val;
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -3,12 +3,15 @@ import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { routeTree } from './routeTree.gen';
+import { ApiError, setUnauthorizedHandler } from '@/api/client';
+import { forceLogout, setLogoutRouter } from '@/lib/forceLogout';
 import './styles/globals.css';
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      retry: 1,
+      retry: (failureCount, error) =>
+        !(error instanceof ApiError && error.status === 401) && failureCount < 1,
       refetchOnWindowFocus: false,
       staleTime: 30_000,
     },
@@ -19,6 +22,15 @@ const router = createRouter({
   routeTree,
   defaultPreload: 'intent',
   context: { queryClient },
+});
+
+// Inject router into forceLogout so it uses client-side navigation instead of
+// window.location.href — avoiding a full-page reload that would race with
+// TanStack Router's own redirect and consume the sessionStorage banner items.
+setLogoutRouter((to) => { void router.navigate({ to } as Parameters<typeof router.navigate>[0]); });
+
+setUnauthorizedHandler((reason) => {
+  forceLogout({ reason, redirectTo: window.location.pathname + window.location.search });
 });
 
 declare module '@tanstack/react-router' {

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -27,7 +27,10 @@ const router = createRouter({
 // Inject router into forceLogout so it uses client-side navigation instead of
 // window.location.href — avoiding a full-page reload that would race with
 // TanStack Router's own redirect and consume the sessionStorage banner items.
-setLogoutRouter((to) => { void router.navigate({ to } as Parameters<typeof router.navigate>[0]); });
+setLogoutRouter((to) => {
+  router.navigate({ to } as Parameters<typeof router.navigate>[0])
+    .catch(() => { window.location.href = to; });
+});
 
 setUnauthorizedHandler((reason) => {
   forceLogout({ reason, redirectTo: window.location.pathname + window.location.search });

--- a/app/src/routes/_app.tsx
+++ b/app/src/routes/_app.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Outlet, createFileRoute, redirect } from '@tanstack/react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getToken } from '@/api/client';
+import { ApiError, getToken } from '@/api/client';
 import { getMe } from '@/api/auth';
 import { useAuthStore } from '@/stores/auth';
 import { useLayoutStore } from '@/stores/layout';
@@ -10,8 +10,19 @@ import { appWs } from '@/api/ws';
 import type { Session } from '@/domain/types';
 
 export const Route = createFileRoute('/_app')({
-  beforeLoad: () => {
+  beforeLoad: async ({ context }) => {
     if (!getToken()) throw redirect({ to: '/login' });
+    try {
+      await context.queryClient.fetchQuery({ queryKey: ['me'], queryFn: getMe, staleTime: 5 * 60_000 });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        // notifyUnauthorized (fired from client.ts) already called forceLogout,
+        // which cleared auth state, set sessionStorage, and navigated via router.
+        // Just ensure TanStack Router completes the redirect cleanly.
+        throw redirect({ to: '/login' });
+      }
+      // Non-auth errors (network issues, 5xx) fall through — page renders and handles them.
+    }
   },
   component: AppShell,
 });

--- a/app/src/routes/_app.tsx
+++ b/app/src/routes/_app.tsx
@@ -12,16 +12,19 @@ import type { Session } from '@/domain/types';
 export const Route = createFileRoute('/_app')({
   beforeLoad: async ({ context }) => {
     if (!getToken()) throw redirect({ to: '/login' });
+
+    // 캐시 데이터가 있으면 블로킹 없이 통과 — AppShell의 useQuery가 백그라운드에서 갱신
+    const cached = context.queryClient.getQueryData(['me']);
+    if (cached) return;
+
+    // 첫 로드(콜드 캐시)에서만 서버 확인 — 만료된 토큰을 초기 진입 시점에 잡음
     try {
       await context.queryClient.fetchQuery({ queryKey: ['me'], queryFn: getMe, staleTime: 5 * 60_000 });
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
-        // notifyUnauthorized (fired from client.ts) already called forceLogout,
-        // which cleared auth state, set sessionStorage, and navigated via router.
-        // Just ensure TanStack Router completes the redirect cleanly.
         throw redirect({ to: '/login' });
       }
-      // Non-auth errors (network issues, 5xx) fall through — page renders and handles them.
+      // 네트워크 오류, 5xx: 통과 — 페이지가 자체 에러 상태 처리
     }
   },
   component: AppShell,

--- a/app/src/routes/_app.tsx
+++ b/app/src/routes/_app.tsx
@@ -13,18 +13,18 @@ export const Route = createFileRoute('/_app')({
   beforeLoad: async ({ context }) => {
     if (!getToken()) throw redirect({ to: '/login' });
 
-    // 캐시 데이터가 있으면 블로킹 없이 통과 — AppShell의 useQuery가 백그라운드에서 갱신
+    // Warm cache: pass through without blocking — AppShell's useQuery handles background revalidation.
     const cached = context.queryClient.getQueryData(['me']);
     if (cached) return;
 
-    // 첫 로드(콜드 캐시)에서만 서버 확인 — 만료된 토큰을 초기 진입 시점에 잡음
+    // Cold cache: verify the token with the server on first load.
     try {
       await context.queryClient.fetchQuery({ queryKey: ['me'], queryFn: getMe, staleTime: 5 * 60_000 });
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
         throw redirect({ to: '/login' });
       }
-      // 네트워크 오류, 5xx: 통과 — 페이지가 자체 에러 상태 처리
+      // Network error or 5xx: fall through and let the page handle it.
     }
   },
   component: AppShell,

--- a/app/src/routes/login.tsx
+++ b/app/src/routes/login.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { getMe, login, signupAndLogin } from '@/api/auth';
 import { getBaseUrl, setBaseUrl, getToken, ApiError } from '@/api/client';
 import { useAuthStore } from '@/stores/auth';
+import { consumeLogoutReason, consumeRedirectAfterLogin, type LogoutReason } from '@/lib/forceLogout';
 
 type Mode = 'login' | 'signup';
 
@@ -23,6 +24,12 @@ function LoginPage() {
   const [displayName, setDisplayName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [expiredReason, setExpiredReason] = useState<LogoutReason | null>(null);
+
+  useEffect(() => {
+    const reason = consumeLogoutReason();
+    if (reason) setExpiredReason(reason);
+  }, []);
 
   function switchMode(next: Mode) {
     setMode(next);
@@ -42,7 +49,8 @@ function LoginPage() {
       }
       const me = await getMe();
       setCurrentUser(me);
-      navigate({ to: '/projects' });
+      const redirectTo = consumeRedirectAfterLogin();
+      navigate({ to: redirectTo ?? '/projects' });
     } catch (err) {
       setError(messageOf(err, mode));
     } finally {
@@ -54,6 +62,7 @@ function LoginPage() {
 
   return (
     <div className="cw-live-login">
+      {expiredReason && <SessionExpiredBanner reason={expiredReason} onDismiss={() => setExpiredReason(null)} />}
       <div className="cw-live-login-card">
         <h1>Cowork for Teams</h1>
         <p style={{ color: 'var(--cw-ink-3)', marginTop: 0 }}>
@@ -177,6 +186,47 @@ function ModeLink({ onClick, children }: { onClick: () => void; children: React.
     >
       {children}
     </button>
+  );
+}
+
+function SessionExpiredBanner({ reason, onDismiss }: { reason: LogoutReason; onDismiss: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onDismiss, 5000);
+    return () => clearTimeout(t);
+  }, [onDismiss]);
+
+  const message = reason === 'expired'
+    ? '세션이 만료되어 다시 로그인이 필요합니다.'
+    : '인증 정보가 유효하지 않습니다. 다시 로그인해 주세요.';
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 16,
+      left: '50%',
+      transform: 'translateX(-50%)',
+      background: 'var(--cw-paper)',
+      border: '1px solid var(--cw-border)',
+      borderRadius: 8,
+      padding: '10px 16px',
+      fontSize: 13,
+      color: 'var(--cw-ink-2)',
+      boxShadow: 'var(--cw-shadow-md)',
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      zIndex: 9999,
+      whiteSpace: 'nowrap',
+    }}>
+      {message}
+      <button
+        type="button"
+        onClick={onDismiss}
+        style={{ border: 0, background: 'transparent', padding: 0, color: 'var(--cw-ink-4)', cursor: 'pointer', lineHeight: 1 }}
+      >
+        ✕
+      </button>
+    </div>
   );
 }
 

--- a/app/src/routes/login.tsx
+++ b/app/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { getMe, login, signupAndLogin } from '@/api/auth';
 import { getBaseUrl, setBaseUrl, getToken, ApiError } from '@/api/client';
@@ -25,6 +25,7 @@ function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [expiredReason, setExpiredReason] = useState<LogoutReason | null>(null);
+  const dismissExpiredReason = useCallback(() => setExpiredReason(null), []);
 
   useEffect(() => {
     const reason = consumeLogoutReason();
@@ -62,7 +63,7 @@ function LoginPage() {
 
   return (
     <div className="cw-live-login">
-      {expiredReason && <SessionExpiredBanner reason={expiredReason} onDismiss={() => setExpiredReason(null)} />}
+      {expiredReason && <SessionExpiredBanner reason={expiredReason} onDismiss={dismissExpiredReason} />}
       <div className="cw-live-login-card">
         <h1>Cowork for Teams</h1>
         <p style={{ color: 'var(--cw-ink-3)', marginTop: 0 }}>


### PR DESCRIPTION
## Summary

- **Centralized 401 handling** — `api/client.ts` now exports `setUnauthorizedHandler` / `notifyUnauthorized`. All three HTTP exit points (`request()`, `streamSse()`, `fetchFileBlob()`) funnel 401 responses through this hook. A module-level `unauthorizedTriggered` flag prevents duplicate handler fires from concurrent in-flight requests; the flag resets on `setToken()` so the next session's expiry is still caught after re-login.

- **`forceLogout` helper** (`src/lib/forceLogout.ts`) — single source of truth for the logout flow: disconnects WebSocket, clears zustand auth state, stores `auth.expiredReason` and `auth.redirectAfterLogin` in `sessionStorage`, then navigates using `router.navigate` (injected from `main.tsx`). If `router.navigate` rejects, falls back to `window.location.href` to guarantee the redirect. The router-based navigation prevents a race where a full-page reload would consume the `sessionStorage` items before the login page could read them.

- **Proactive token validation** — `_app.tsx` `beforeLoad` is now async and calls `getMe()` on cold cache (first load or after stale eviction). Subsequent in-app navigations use the cached result without blocking. A 401 response redirects immediately to `/login`; other errors (network, 5xx) fall through so the page handles them in context.

- **WebSocket reconnect guard** — `api/ws.ts` stops the reconnect loop on close code `4401` (app-defined auth failure). Additionally, a rapid-close heuristic fires after ≥ 3 consecutive connections that each close within 2 s of being established — measured as connection lifetime, not the interval between closes, so the heuristic correctly accumulates across the 3-second reconnect delay. Close code `1008` (generic Policy Violation) is intentionally excluded — proxies and firewalls emit it for non-auth reasons and it must not trigger logout. After either trigger, `getMe()` is called over HTTP to confirm the token is actually invalid before forcing logout; if `getMe()` succeeds the disconnect is treated as a transient WS flap, not an auth failure. This also correctly classifies the failure as `expired` vs `invalid` based on the actual server response.

- **Session-expired toast on login page** — `login.tsx` reads `auth.expiredReason` from `sessionStorage` on mount and shows a 5-second auto-dismissing toast. The dismiss callback is memoized with `useCallback` so the auto-dismiss timer is not reset by re-renders caused by typing in the form. Messages are localized (`'expired'` → "세션이 만료되어 다시 로그인이 필요합니다." / `'invalid'` → "인증 정보가 유효하지 않습니다."). After successful login, navigates to `auth.redirectAfterLogin` (validated as a same-origin path) instead of the default `/projects`.

- **Unified logout** — sidebar's inline `reset() + window.location.href` is replaced with `forceLogout({ reason: 'manual' })`. Manual logout carries no `auth.expiredReason`, so no toast appears.

- **Query retry** — `QueryClient` default retry now skips retries on 401 to avoid wasted round-trips with a known-invalid token.

- **`JWT_EXPIRED_MESSAGE` constant** — the `'token has expired'` string matched against backend error responses is extracted to a named constant with a comment pointing to `backend/src/auth/jwt.rs`, making the cross-layer coupling explicit.

## Findings during testing

> **Backend JWT leeway is 60 s** — `jsonwebtoken` v9's `Validation` defaults `leeway` to 60 seconds. A `JWT_EXPIRY_SECONDS=10` token therefore stays accepted for up to 70 s. Manually crafted tokens with `exp = now − 90` were used to reliably trigger 401 in tests.

## Test Records

https://github.com/user-attachments/assets/4f70c8db-b9d7-466d-a20e-3051d54c896c


## Test plan

- [x] Expired token → navigate to `/projects` → redirected to `/login` with "세션이 만료…" toast
- [x] Invalid token → "인증 정보가 유효하지 않습니다." toast
- [x] Login form with wrong credentials → shows credential error only, no session toast (regression)
- [x] Post-login redirect to original URL (e.g. `/projects/foo`)
- [x] Manual logout via sidebar → `/login` with no toast
- [x] Re-login → second session expiry correctly triggers the handler again (`unauthorizedTriggered` reset)
- [x] WS disconnect with code 4401 → `getMe()` HTTP call determines expired vs invalid before logout
- [x] `pnpm lint` passes
- [x] 14 unit tests pass (`ws.test.ts` 7개, `client.test.ts` 5개, `layout.test.ts` 2개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)