### PR TITLE
[App] Welcome page — split-screen /login with a product tour carousel

### DIFF
--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -2,9 +2,8 @@
 // Concerns: base URL configuration, auth header injection, JSON parse, typed errors.
 // All endpoint modules call request<T>() — there is no other fetch in the app.
 
-const BASE_URL_KEY = 'cowork.v2.baseUrl';
 const TOKEN_KEY = 'cowork.v2.token';
-const DEFAULT_BASE_URL = import.meta.env.VITE_BACKEND_V2_URL ?? 'http://127.0.0.1:8080';
+export const BASE_URL = import.meta.env.VITE_BACKEND_V2_URL ?? 'http://127.0.0.1:8080';
 
 export class ApiError extends Error {
   constructor(public status: number, message: string, public body?: unknown) {
@@ -22,16 +21,6 @@ function writeStored(key: string, value: string | null): void {
     if (value == null) window.localStorage.removeItem(key);
     else window.localStorage.setItem(key, value);
   } catch { /* noop */ }
-}
-
-export function getBaseUrl(): string {
-  return readStored(BASE_URL_KEY) ?? DEFAULT_BASE_URL;
-}
-
-export function setBaseUrl(url: string): string {
-  const trimmed = url.replace(/\/+$/, '') || DEFAULT_BASE_URL;
-  writeStored(BASE_URL_KEY, trimmed);
-  return trimmed;
 }
 
 export function getToken(): string | null {
@@ -69,7 +58,7 @@ export async function request<T = unknown>(path: string, options: RequestOptions
     resolvedBody = JSON.stringify(body);
   }
 
-  const response = await fetch(`${getBaseUrl()}${path}`, {
+  const response = await fetch(`${BASE_URL}${path}`, {
     ...rest,
     headers,
     body: resolvedBody,
@@ -107,7 +96,7 @@ export async function* streamSse(
   const token = getToken();
   if (token) headers.set('Authorization', `Bearer ${token}`);
 
-  const response = await fetch(`${getBaseUrl()}${path}`, {
+  const response = await fetch(`${BASE_URL}${path}`, {
     method: 'POST',
     headers,
     body: JSON.stringify(body),

--- a/app/src/api/dirents.ts
+++ b/app/src/api/dirents.ts
@@ -1,4 +1,4 @@
-import { ApiError, getBaseUrl, getToken, request } from './client';
+import { ApiError, BASE_URL, getToken, request } from './client';
 import type { BackendDirent, BackendDirentBatchOp, BackendDirentBatchResult } from './backend-types';
 import { toFileAsset } from './transformers';
 import type { FileAsset } from '@/domain/types';
@@ -138,7 +138,7 @@ export async function downloadFileByGlobalPath(globalPath: string): Promise<void
 
 /** Fetch a file by its full global path and return the blob (for thumbnails etc.). */
 export async function fetchFileBlob(globalPath: string): Promise<Blob> {
-  const url = `${getBaseUrl()}/dirents/${encodePath(globalPath)}`;
+  const url = `${BASE_URL}/dirents/${encodePath(globalPath)}`;
   const headers = new Headers();
   const token = getToken();
   if (token) headers.set('Authorization', `Bearer ${token}`);

--- a/app/src/api/ws.ts
+++ b/app/src/api/ws.ts
@@ -1,4 +1,4 @@
-import { getBaseUrl, getToken } from './client';
+import { BASE_URL, getToken } from './client';
 
 export interface SessionTitleUpdatedEvent {
   type: 'session_title_updated';
@@ -24,7 +24,7 @@ class AppWebSocketManager {
   connect(token: string): void {
     this.active = true;
     if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) return;
-    const url = `${toWsUrl(getBaseUrl())}/ws?token=${encodeURIComponent(token)}`;
+    const url = `${toWsUrl(BASE_URL)}/ws?token=${encodeURIComponent(token)}`;
     const ws = new WebSocket(url);
     this.ws = ws;
 

--- a/app/src/components/Icon.tsx
+++ b/app/src/components/Icon.tsx
@@ -7,10 +7,11 @@ export type IconName =
   | 'shield' | 'x' | 'arrow-left' | 'analysis' | 'brainstorm' | 'writing'
   | 'recap' | 'general' | 'more' | 'upload' | 'trash' | 'download'
   | 'list' | 'grid' | 'chevron-right' | 'chevron-left' | 'paperclip'
-  | 'file-pdf' | 'file-code' | 'file-archive' | 'file-video' | 'file-audio';
+  | 'file-pdf' | 'file-code' | 'file-archive' | 'file-video' | 'file-audio'
+  | 'pause' | 'play';
 
 type PreviewIconName =
-  | 'lock' | 'eye' | 'eye-off' | 'message-square' | 'messages-square' | 'clipboard-list'
+  | 'lock' | 'eye' | 'eye-off' | 'pause' | 'play' | 'message-square' | 'messages-square' | 'clipboard-list'
   | 'lightbulb' | 'pencil' | 'home' | 'folder' | 'folder-open' | 'users'
   | 'settings' | 'plus' | 'chevron-down' | 'chevron-right' | 'chevron-left' | 'more-horizontal' | 'check'
   | 'x' | 'arrow-left' | 'send' | 'search' | 'file-text' | 'file-spreadsheet'
@@ -22,6 +23,8 @@ const previewIconPath: Record<PreviewIconName, string> = {
   lock: '<rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>',
   eye: '<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/>',
   'eye-off': '<path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"/><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"/><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"/><path d="m2 2 20 20"/>',
+  pause: '<rect width="4" height="16" x="6" y="4" rx="1"/><rect width="4" height="16" x="14" y="4" rx="1"/>',
+  play: '<polygon points="6 3 20 12 6 21 6 3"/>',
   'message-square': '<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>',
   'messages-square': '<path d="M14 9a2 2 0 0 1-2 2H6l-4 4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2z"/><path d="M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1"/>',
   'clipboard-list': '<rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11h4"/><path d="M12 16h4"/><path d="M8 11h.01"/><path d="M8 16h.01"/>',
@@ -71,6 +74,8 @@ const iconAlias: Record<IconName, PreviewIconName> = {
   lock: 'lock',
   eye: 'eye',
   'eye-off': 'eye-off',
+  pause: 'pause',
+  play: 'play',
   'message-square': 'message-square',
   'file-text': 'file-text',
   file: 'file',

--- a/app/src/components/Icon.tsx
+++ b/app/src/components/Icon.tsx
@@ -1,7 +1,7 @@
 import type { SVGProps } from 'react';
 
 export type IconName =
-  | 'home' | 'folder' | 'folder-open' | 'users' | 'settings' | 'lock' | 'eye'
+  | 'home' | 'folder' | 'folder-open' | 'users' | 'settings' | 'lock' | 'eye' | 'eye-off'
   | 'message-square' | 'file-text' | 'file' | 'sheet' | 'image' | 'search' | 'plus'
   | 'send' | 'sparkles' | 'check' | 'chevron' | 'zap' | 'calendar' | 'artifact'
   | 'shield' | 'x' | 'arrow-left' | 'analysis' | 'brainstorm' | 'writing'
@@ -10,7 +10,7 @@ export type IconName =
   | 'file-pdf' | 'file-code' | 'file-archive' | 'file-video' | 'file-audio';
 
 type PreviewIconName =
-  | 'lock' | 'eye' | 'message-square' | 'messages-square' | 'clipboard-list'
+  | 'lock' | 'eye' | 'eye-off' | 'message-square' | 'messages-square' | 'clipboard-list'
   | 'lightbulb' | 'pencil' | 'home' | 'folder' | 'folder-open' | 'users'
   | 'settings' | 'plus' | 'chevron-down' | 'chevron-right' | 'chevron-left' | 'more-horizontal' | 'check'
   | 'x' | 'arrow-left' | 'send' | 'search' | 'file-text' | 'file-spreadsheet'
@@ -21,6 +21,7 @@ type PreviewIconName =
 const previewIconPath: Record<PreviewIconName, string> = {
   lock: '<rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>',
   eye: '<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/>',
+  'eye-off': '<path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"/><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"/><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"/><path d="m2 2 20 20"/>',
   'message-square': '<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>',
   'messages-square': '<path d="M14 9a2 2 0 0 1-2 2H6l-4 4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2z"/><path d="M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1"/>',
   'clipboard-list': '<rect width="8" height="4" x="8" y="2" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><path d="M12 11h4"/><path d="M12 16h4"/><path d="M8 11h.01"/><path d="M8 16h.01"/>',
@@ -69,6 +70,7 @@ const iconAlias: Record<IconName, PreviewIconName> = {
   settings: 'settings',
   lock: 'lock',
   eye: 'eye',
+  'eye-off': 'eye-off',
   'message-square': 'message-square',
   'file-text': 'file-text',
   file: 'file',

--- a/app/src/components/InviteDialog.tsx
+++ b/app/src/components/InviteDialog.tsx
@@ -76,7 +76,7 @@ export function InviteDialog({ projectId, onClose }: InviteDialogProps) {
             />
           </div>
           {error && (
-            <div className="cw-live-login-error" style={{ marginBottom: 12 }}>{error}</div>
+            <div className="cw-form-error" style={{ marginBottom: 12 }}>{error}</div>
           )}
           <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 14 }}>
             <button type="button" className="cw-btn-secondary" onClick={onClose} disabled={pending}>취소</button>

--- a/app/src/components/WelcomeCarousel.tsx
+++ b/app/src/components/WelcomeCarousel.tsx
@@ -1,0 +1,328 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Icon, type IconName } from '@/components/Icon';
+
+type MockKind = 'agent' | 'artifact' | 'share' | 'automation' | 'quickstart';
+
+interface Slide {
+  key: string;
+  eyebrow: string;
+  title: string;
+  blurb: string;
+  detail: string;
+  mock: MockKind;
+  // 실제 시연 영상을 넣으려면 app/public/welcome/<파일>.mp4 를 두고 경로를 적으면
+  // 목업 대신 자동으로 재생됩니다. 예: video: '/welcome/routing.mp4'
+  video?: string;
+  poster?: string;
+}
+
+// "많이 만든 다음 덜어내기" — 우선 풍부하게. 슬라이드를 빼거나 합치며 줄이면 됩니다.
+const SLIDES: Slide[] = [
+  {
+    key: 'agent',
+    eyebrow: '01 · 에이전트',
+    title: '원하는 에이전트에 맡기기',
+    blurb: '새 세션을 시작할 때 에이전트를 고릅니다.',
+    detail: '작업의 성격에 맞는 에이전트를 선택해 요청을 보냅니다. 골라 둔 에이전트가 그 대화를 책임지고 처리합니다.',
+    mock: 'agent',
+  },
+  {
+    key: 'artifact',
+    eyebrow: '02 · 산출물',
+    title: '결과물을 바로 손에',
+    blurb: '보고서·코드·문서를 만들어 드립니다.',
+    detail: '에이전트가 생성한 산출물을 내려받거나, 클릭 한 번으로 팀 공유 폴더로 옮겨 함께 이어갑니다.',
+    mock: 'artifact',
+  },
+  {
+    key: 'share',
+    eyebrow: '03 · 협업',
+    title: '팀이 함께 대화하는 세션',
+    blurb: '공개 범위를 골라 함께 묻습니다.',
+    detail: '비공개·읽기 공유·함께 대화 모드로 팀원이 같은 세션에서 같은 AI와 실시간 협력합니다. 문서를 올리면 출처와 함께 답합니다.',
+    mock: 'share',
+  },
+  {
+    key: 'automation',
+    eyebrow: '04 · 자동화',
+    title: '사람 없이 알아서 돌게',
+    blurb: '스케줄·웹훅으로 에이전트가 정기·이벤트 실행됩니다.',
+    detail: '매일 아침 리포트, 외부 알람이 트리거하는 분석처럼 반복되거나 사건에 반응해야 하는 작업을 등록해 두면 결과만 쌓입니다. 자동화 세션은 일반 대화와 분리되어 따로 관리됩니다.',
+    mock: 'automation',
+  },
+  {
+    key: 'quickstart',
+    eyebrow: '시작하기',
+    title: '3단계로 시작하세요',
+    blurb: '프로젝트 → 대화 → 공유.',
+    detail: '워크스페이스를 만들고, 원하는 작업을 입력하면 에이전트가 처리합니다. 공유 모드로 팀과 이어 다듬으세요.',
+    mock: 'quickstart',
+  },
+];
+
+const AUTO_ADVANCE_MS = 7000;
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function WelcomeCarousel() {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState(0);
+  const activeRef = useRef(0);
+  activeRef.current = active;
+  const reduced = prefersReducedMotion();
+
+  const scrollToIndex = useCallback((i: number) => {
+    const track = trackRef.current;
+    if (!track) return;
+    track.scrollTo({ left: i * track.clientWidth, behavior: reduced ? 'auto' : 'smooth' });
+  }, [reduced]);
+
+  // activeIndex는 스크롤 위치에서 파생 — 스와이프/자동전환이 한 방향으로만 흐른다.
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    let frame = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const i = Math.round(track.scrollLeft / track.clientWidth);
+        if (i !== activeRef.current) setActive(i);
+      });
+    };
+    track.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      track.removeEventListener('scroll', onScroll);
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  // 자동 전환 — 슬라이드가 바뀌면(자동·수동 모두) 다음 5초 카운트를 새로 시작.
+  // pause 로직 없음: hover/focus와 무관하게 항상 진행한다.
+  useEffect(() => {
+    if (reduced) return;
+    const t = window.setTimeout(() => {
+      scrollToIndex((activeRef.current + 1) % SLIDES.length);
+    }, AUTO_ADVANCE_MS);
+    return () => window.clearTimeout(t);
+  }, [reduced, scrollToIndex, active]);
+
+  const go = useCallback((i: number) => {
+    scrollToIndex((i + SLIDES.length) % SLIDES.length);
+  }, [scrollToIndex]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight') { e.preventDefault(); go(active + 1); }
+    else if (e.key === 'ArrowLeft') { e.preventDefault(); go(active - 1); }
+  };
+
+  return (
+    <div
+      className="cw-welcome-carousel"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="제품 소개"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+    >
+      <div className="cw-welcome-track cw-scroll-quiet" ref={trackRef}>
+        {SLIDES.map((s, i) => (
+          <section
+            key={s.key}
+            className="cw-welcome-slide"
+            aria-roledescription="slide"
+            aria-label={`${i + 1} / ${SLIDES.length} — ${s.title}`}
+            aria-hidden={i !== active}
+          >
+            <div className="cw-welcome-media">
+              {s.video ? (
+                <video
+                  className="cw-welcome-video"
+                  src={s.video}
+                  poster={s.poster}
+                  autoPlay
+                  muted
+                  loop
+                  playsInline
+                />
+              ) : (
+                <SlideMock kind={s.mock} active={i === active} />
+              )}
+            </div>
+            <div className="cw-welcome-copy">
+              <span className="cw-welcome-eyebrow">{s.eyebrow}</span>
+              <h1 className="cw-welcome-headline">{s.title}</h1>
+              <p className="cw-welcome-blurb">{s.blurb}</p>
+              <p className="cw-welcome-detail">{s.detail}</p>
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <div className="cw-welcome-controls">
+        <button
+          type="button"
+          className="cw-welcome-arrow"
+          aria-label="이전"
+          onClick={() => go(active - 1)}
+        >
+          <Icon name="chevron-left" size={18} />
+        </button>
+
+        <div className="cw-welcome-dots" role="tablist" aria-label="슬라이드 선택">
+          {SLIDES.map((s, i) => (
+            <button
+              key={s.key}
+              type="button"
+              role="tab"
+              aria-selected={i === active}
+              aria-label={`${i + 1}번 슬라이드: ${s.title}`}
+              className="cw-welcome-dot"
+              data-active={i === active}
+              onClick={() => go(i)}
+            >
+              <span className="cw-welcome-dot-track">
+                <span
+                  className="cw-welcome-dot-fill"
+                  data-run={i === active && !reduced}
+                  style={{ animationDuration: `${AUTO_ADVANCE_MS}ms` }}
+                />
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          className="cw-welcome-arrow"
+          aria-label="다음"
+          onClick={() => go(active + 1)}
+        >
+          <Icon name="chevron-right" size={18} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SlideMock({ kind, active }: { kind: MockKind; active: boolean }) {
+  return (
+    <div className={`cw-mock cw-mock-${kind}`} data-active={active} aria-hidden="true">
+      {kind === 'agent' && (
+        <>
+          <div className="cw-mock-agent-list">
+            {AGENTS.map((a, i) => (
+              <div
+                className="cw-mock-agent-row"
+                data-i={i}
+                data-on={a.selected ? 'true' : undefined}
+                key={a.name}
+              >
+                <span className="cw-mock-agent-icon"><Icon name={a.icon} size={14} /></span>
+                <span className="cw-mock-agent-name">{a.name}</span>
+                {a.selected && (
+                  <span className="cw-mock-agent-check"><Icon name="check" size={13} /></span>
+                )}
+              </div>
+            ))}
+          </div>
+          {/* 선택 후 펼쳐지는 composer — "고른 다음 무엇이 일어나는지" 이야기 완성 */}
+          <div className="cw-mock-composer">
+            <span className="cw-mock-composer-chip">검색</span>
+            <span className="cw-mock-composer-text">무엇을 도와드릴까요?</span>
+          </div>
+        </>
+      )}
+
+      {kind === 'artifact' && (
+        <div className="cw-mock-artifact">
+          <div className="cw-mock-doc">
+            <span className="cw-mock-doc-line" />
+            <span className="cw-mock-doc-line" />
+            <span className="cw-mock-doc-line" />
+            <span className="cw-mock-doc-line" />
+          </div>
+          <span className="cw-mock-share-badge">
+            <Icon name="users" size={14} /> 팀 공유
+          </span>
+        </div>
+      )}
+
+      {kind === 'share' && (
+        <div className="cw-mock-share">
+          <div className="cw-mock-avatars">
+            <span className="cw-mock-av" data-i="0">O</span>
+            <span className="cw-mock-av" data-i="1">M</span>
+            <span className="cw-mock-av" data-i="2">O</span>
+          </div>
+          {/* "함께 대화" 모드의 결과 — 팀에서 누군가 AI에게 보낸 메시지 한 줄 */}
+          <div className="cw-mock-chat-bubble">오늘 미팅 정리해줘</div>
+          <div className="cw-mock-modes">
+            <span className="cw-mock-mode">비공개</span>
+            <span className="cw-mock-mode">읽기 공유</span>
+            <span className="cw-mock-mode is-on">함께 대화</span>
+          </div>
+        </div>
+      )}
+
+      {kind === 'automation' && (
+        <div className="cw-mock-automation-inner">
+          {/* 트리거 두 종(cron / webhook) — 자동화가 "어떻게 시작되는지" 한눈에 */}
+          <div className="cw-mock-trigger-row">
+            <span className="cw-mock-trigger" data-kind="cron">
+              <Icon name="calendar" size={13} /> 매일 09:00
+            </span>
+            <span className="cw-mock-trigger" data-kind="webhook">
+              <Icon name="zap" size={13} /> Webhook
+            </span>
+          </div>
+          {/* 자동 실행된 run들 — 트리거가 누적해 만들어내는 결과를 시각화 */}
+          <div className="cw-mock-runs">
+            {AUTOMATION_RUNS.map((r, i) => (
+              <div className="cw-mock-run" data-i={i} key={`${r.time}-${i}`}>
+                <span className="cw-mock-run-dot" data-status={r.status} />
+                <span className="cw-mock-run-time">{r.time}</span>
+                <span className="cw-mock-run-label">{r.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {kind === 'quickstart' && (
+        <ol className="cw-mock-steps">
+          {QUICKSTART.map((q) => (
+            <li key={q.step}>
+              <span className="cw-mock-step-num">{q.step}</span>
+              <span className="cw-mock-step-icon"><Icon name={q.icon} size={13} /></span>
+              <span>{q.title}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+const QUICKSTART: { step: string; title: string; icon: IconName }[] = [
+  { step: '1', title: '프로젝트 만들기', icon: 'folder' },
+  { step: '2', title: '대화 시작', icon: 'send' },
+  { step: '3', title: '팀과 공유', icon: 'users' },
+];
+
+const AGENTS: { name: string; icon: IconName; selected?: boolean }[] = [
+  { name: '분석', icon: 'analysis' },
+  { name: '검색', icon: 'search', selected: true },
+  { name: '실행', icon: 'zap' },
+];
+
+// 자동화 mock — 가장 위가 "지금 실행 중", 아래로 갈수록 과거 실행.
+// "트리거가 누적해 만들어내는 결과"의 시각화이므로 시간 라벨은 상대값으로.
+type RunStatus = 'running' | 'success';
+const AUTOMATION_RUNS: { time: string; label: string; status: RunStatus }[] = [
+  { time: '방금',       label: '데일리 리포트', status: 'running' },
+  { time: '어제 09:00', label: '데일리 리포트', status: 'success' },
+  { time: '그제 09:00', label: '데일리 리포트', status: 'success' },
+];

--- a/app/src/components/WelcomeCarousel.tsx
+++ b/app/src/components/WelcomeCarousel.tsx
@@ -82,6 +82,17 @@ export function WelcomeCarousel() {
   activeRef.current = active;
   const reduced = prefersReducedMotion();
 
+  // WCAG 2.2.2 (Pause, Stop, Hide) — 자동 전환은 다음 세 가지 중 하나라도
+  // 켜지면 멈춘다. hover는 사용자 요구로 제외 ("호버 시 진행바가 멈추면 안 됨").
+  //  · userPaused: 명시적 pause/play 토글
+  //  · focusedWithin: 키보드 사용자가 carousel 내부로 focus 진입 (mouse hover와 다른 시나리오)
+  //  · pageHidden: 탭이 background로 숨겨짐
+  const [userPaused, setUserPaused] = useState(false);
+  const [focusedWithin, setFocusedWithin] = useState(false);
+  const [pageHidden, setPageHidden] = useState(
+    typeof document !== 'undefined' ? document.hidden : false,
+  );
+
   const scrollToIndex = useCallback((i: number) => {
     const track = trackRef.current;
     if (!track) return;
@@ -107,15 +118,24 @@ export function WelcomeCarousel() {
     };
   }, []);
 
-  // 자동 전환 — 슬라이드가 바뀌면(자동·수동 모두) 다음 5초 카운트를 새로 시작.
-  // pause 로직 없음: hover/focus와 무관하게 항상 진행한다.
+  // page hidden 추적 — 탭이 background에 있으면 자동 전환이 시각 없는 사용자에게
+  // 의미 없는 변화를 만들지 않게 한다.
   useEffect(() => {
-    if (reduced) return;
+    const onVis = () => setPageHidden(document.hidden);
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  }, []);
+
+  const isPaused = userPaused || focusedWithin || pageHidden;
+
+  // 자동 전환 — 슬라이드가 바뀌면 다음 카운트를 새로 시작. isPaused가 false인 동안에만.
+  useEffect(() => {
+    if (reduced || isPaused) return;
     const t = window.setTimeout(() => {
       scrollToIndex((activeRef.current + 1) % SLIDES.length);
     }, AUTO_ADVANCE_MS);
     return () => window.clearTimeout(t);
-  }, [reduced, scrollToIndex, active]);
+  }, [reduced, isPaused, scrollToIndex, active]);
 
   const go = useCallback((i: number) => {
     scrollToIndex((i + SLIDES.length) % SLIDES.length);
@@ -126,6 +146,12 @@ export function WelcomeCarousel() {
     else if (e.key === 'ArrowLeft') { e.preventDefault(); go(active - 1); }
   };
 
+  // focus가 container 안에서 옮겨다닐 때(arrow → dot 등)는 blur로 보지 않는다.
+  const onBlurCapture = (e: React.FocusEvent) => {
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setFocusedWithin(false);
+  };
+
   return (
     <div
       className="cw-welcome-carousel"
@@ -134,6 +160,15 @@ export function WelcomeCarousel() {
       aria-label="제품 소개"
       tabIndex={0}
       onKeyDown={onKeyDown}
+      onFocus={(e) => {
+        // 마우스 클릭으로 인한 focus는 무시. 키보드(Tab) 진입만 pause trigger —
+        // 사용자가 carousel을 "살펴보는" 시나리오는 키보드 사용자 한정이고, pause
+        // 버튼을 마우스로 누른 직후 그 button이 focus되는 false positive를 피한다.
+        if ((e.target as HTMLElement).matches(':focus-visible')) {
+          setFocusedWithin(true);
+        }
+      }}
+      onBlur={onBlurCapture}
     >
       <div className="cw-welcome-track cw-scroll-quiet" ref={trackRef}>
         {SLIDES.map((s, i) => (
@@ -192,9 +227,14 @@ export function WelcomeCarousel() {
               onClick={() => go(i)}
             >
               <span className="cw-welcome-dot-track">
+                {/* key로 fill element를 강제 remount해 CSS animation을 새로
+                   시작시킨다. active 슬라이드가 바뀌거나 isPaused 토글이
+                   풀리면 자동 전환 setTimeout이 새 7초로 reset되는데, 진행바도
+                   같은 시점에 0부터 시작해야 둘이 동기화된다. */}
                 <span
+                  key={`${active}-${isPaused ? 'paused' : 'running'}`}
                   className="cw-welcome-dot-fill"
-                  data-run={i === active && !reduced}
+                  data-run={i === active && !reduced && !isPaused}
                   style={{ animationDuration: `${AUTO_ADVANCE_MS}ms` }}
                 />
               </span>
@@ -210,6 +250,21 @@ export function WelcomeCarousel() {
         >
           <Icon name="chevron-right" size={18} />
         </button>
+
+        {/* WCAG 2.2.2 (Pause, Stop, Hide) — 5초 이상 자동 업데이트되는
+           콘텐츠는 명시적 pause 컨트롤이 필요. reduced motion일 때는
+           자동 전환 자체가 꺼져 있어 토글을 숨긴다. */}
+        {!reduced && (
+          <button
+            type="button"
+            className="cw-welcome-pause"
+            aria-label={userPaused ? '자동 전환 다시 시작' : '자동 전환 멈추기'}
+            aria-pressed={userPaused}
+            onClick={() => setUserPaused((v) => !v)}
+          >
+            <Icon name={userPaused ? 'play' : 'pause'} size={14} />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/app/src/components/WelcomeCarousel.tsx
+++ b/app/src/components/WelcomeCarousel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Icon, type IconName } from '@/components/Icon';
 
-type MockKind = 'agent' | 'artifact' | 'share' | 'automation' | 'quickstart';
+type MockKind = 'agent' | 'knowledge' | 'artifact' | 'share' | 'automation' | 'quickstart';
 
 interface Slide {
   key: string;
@@ -21,33 +21,41 @@ const SLIDES: Slide[] = [
   {
     key: 'agent',
     eyebrow: '01 · 에이전트',
-    title: '원하는 에이전트에 맡기기',
+    title: '원하는 에이전트로',
     blurb: '새 세션을 시작할 때 에이전트를 고릅니다.',
-    detail: '작업의 성격에 맞는 에이전트를 선택해 요청을 보냅니다. 골라 둔 에이전트가 그 대화를 책임지고 처리합니다.',
+    detail: '작업의 성격에 맞는 에이전트를 선택해 요청을 보냅니다. 빠른 검색, 코드 실행, 멀티 페이지 심층 조사까지. 골라 둔 에이전트가 그 대화를 책임지고 처리합니다.',
     mock: 'agent',
   },
   {
+    key: 'knowledge',
+    eyebrow: '02 · 자료',
+    title: '내 문서로 답하기',
+    blurb: '파일을 올려두면 출처와 함께 답합니다.',
+    detail: 'PDF·문서·코드를 프로젝트에 올려두면 에이전트가 그 자료를 근거로 답합니다. 답변에는 어느 파일에서 가져왔는지 출처가 함께 표시되어 그대로 검토할 수 있습니다.',
+    mock: 'knowledge',
+  },
+  {
     key: 'artifact',
-    eyebrow: '02 · 산출물',
+    eyebrow: '03 · 산출물',
     title: '결과물을 바로 손에',
-    blurb: '보고서·코드·문서를 만들어 드립니다.',
+    blurb: '보고서·코드·문서를 바로 받습니다.',
     detail: '에이전트가 생성한 산출물을 내려받거나, 클릭 한 번으로 팀 공유 폴더로 옮겨 함께 이어갑니다.',
     mock: 'artifact',
   },
   {
     key: 'share',
-    eyebrow: '03 · 협업',
-    title: '팀이 함께 대화하는 세션',
+    eyebrow: '04 · 협업',
+    title: '함께 대화하는 세션',
     blurb: '공개 범위를 골라 함께 묻습니다.',
-    detail: '비공개·읽기 공유·함께 대화 모드로 팀원이 같은 세션에서 같은 AI와 실시간 협력합니다. 문서를 올리면 출처와 함께 답합니다.',
+    detail: '비공개·읽기 공유·함께 대화 모드로 팀원이 한 세션에서 같은 AI와 실시간 협업합니다. 같은 자료, 같은 답을 함께 검토합니다.',
     mock: 'share',
   },
   {
     key: 'automation',
-    eyebrow: '04 · 자동화',
-    title: '사람 없이 알아서 돌게',
-    blurb: '스케줄·웹훅으로 에이전트가 정기·이벤트 실행됩니다.',
-    detail: '매일 아침 리포트, 외부 알람이 트리거하는 분석처럼 반복되거나 사건에 반응해야 하는 작업을 등록해 두면 결과만 쌓입니다. 자동화 세션은 일반 대화와 분리되어 따로 관리됩니다.',
+    eyebrow: '05 · 자동화',
+    title: '사람 없이도 알아서',
+    blurb: '스케줄이나 웹훅으로 자동 실행됩니다.',
+    detail: '매일 아침 리포트, 외부 알람이 트리거하는 분석처럼 반복되거나 이벤트에 반응해야 하는 작업을 등록해 두면 결과만 쌓입니다. 자동화 세션은 일반 대화와 분리되어 따로 관리됩니다.',
     mock: 'automation',
   },
   {
@@ -236,6 +244,28 @@ function SlideMock({ kind, active }: { kind: MockKind; active: boolean }) {
         </>
       )}
 
+      {kind === 'knowledge' && (
+        <div className="cw-mock-knowledge">
+          {/* 프로젝트에 업로드된 파일들 — 가장 위에서 "이 자료들이 답의 근거"임을 먼저 알린다 */}
+          <div className="cw-mock-files">
+            {KNOWLEDGE_FILES.map((f, i) => (
+              <span className="cw-mock-file" data-i={i} key={f.name}>
+                <Icon name={f.icon} size={13} />
+                {f.name}
+              </span>
+            ))}
+          </div>
+          {/* 사용자 질문 → 답변 + 출처. RAG의 핵심 가치는 출처가 보이는 것 */}
+          <div className="cw-mock-question">Q3 매출 알려줘</div>
+          <div className="cw-mock-answer">
+            <span className="cw-mock-answer-text">전년 동기 대비 12% 성장했습니다.</span>
+            <span className="cw-mock-source">
+              <Icon name="file-text" size={11} /> Q3-report.pdf · 12p
+            </span>
+          </div>
+        </div>
+      )}
+
       {kind === 'artifact' && (
         <div className="cw-mock-artifact">
           <div className="cw-mock-doc">
@@ -297,7 +327,10 @@ function SlideMock({ kind, active }: { kind: MockKind; active: boolean }) {
             <li key={q.step}>
               <span className="cw-mock-step-num">{q.step}</span>
               <span className="cw-mock-step-icon"><Icon name={q.icon} size={13} /></span>
-              <span>{q.title}</span>
+              <span className="cw-mock-step-title">{q.title}</span>
+              {/* "이 단계에 들어갈 예시 한 토막" — 03/04와 같은 구체성을 마지막
+                 슬라이드에도 부여. 좁은 폭에서는 ellipsis로 안전하게 잘린다. */}
+              <span className="cw-mock-step-preview">{q.preview}</span>
             </li>
           ))}
         </ol>
@@ -306,16 +339,24 @@ function SlideMock({ kind, active }: { kind: MockKind; active: boolean }) {
   );
 }
 
-const QUICKSTART: { step: string; title: string; icon: IconName }[] = [
-  { step: '1', title: '프로젝트 만들기', icon: 'folder' },
-  { step: '2', title: '대화 시작', icon: 'send' },
-  { step: '3', title: '팀과 공유', icon: 'users' },
+const QUICKSTART: { step: string; title: string; icon: IconName; preview: string }[] = [
+  { step: '1', title: '프로젝트 만들기', icon: 'folder', preview: 'Cowork Q3' },
+  { step: '2', title: '대화 시작',      icon: 'send',   preview: '오늘 미팅 정리' },
+  { step: '3', title: '팀과 공유',      icon: 'users',  preview: 'olive · mira' },
 ];
 
 const AGENTS: { name: string; icon: IconName; selected?: boolean }[] = [
-  { name: '분석', icon: 'analysis' },
-  { name: '검색', icon: 'search', selected: true },
-  { name: '실행', icon: 'zap' },
+  { name: '분석',     icon: 'analysis' },
+  { name: '검색',     icon: 'search', selected: true },
+  { name: '심층 조사', icon: 'sparkles' },
+  { name: '실행',     icon: 'zap' },
+];
+
+// 자료(RAG) mock — 업로드된 파일 두 종과, 답변에 인용된 출처. "출처와 함께 답한다"는
+// 본질을 보여주기 위해 답변 라인 옆에 작은 source chip을 강조한다.
+const KNOWLEDGE_FILES: { name: string; icon: IconName }[] = [
+  { name: 'Q3-report.pdf', icon: 'file-pdf' },
+  { name: 'market.docx',   icon: 'file-text' },
 ];
 
 // 자동화 mock — 가장 위가 "지금 실행 중", 아래로 갈수록 과거 실행.

--- a/app/src/routes/login.tsx
+++ b/app/src/routes/login.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { getMe, login, signupAndLogin } from '@/api/auth';
-import { getBaseUrl, setBaseUrl, getToken, ApiError } from '@/api/client';
+import { getToken, ApiError } from '@/api/client';
 import { useAuthStore } from '@/stores/auth';
+import { WelcomeCarousel } from '@/components/WelcomeCarousel';
 
 type Mode = 'login' | 'signup';
 
@@ -14,10 +15,20 @@ export const Route = createFileRoute('/login')({
 });
 
 function LoginPage() {
+  return (
+    <div className="cw-welcome">
+      <aside className="cw-welcome-showcase">
+        <WelcomeCarousel />
+      </aside>
+      <AuthPanel />
+    </div>
+  );
+}
+
+function AuthPanel() {
   const navigate = useNavigate();
   const setCurrentUser = useAuthStore((s) => s.setCurrentUser);
   const [mode, setMode] = useState<Mode>('login');
-  const [baseUrl, setUrl] = useState(getBaseUrl());
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
@@ -34,7 +45,6 @@ function LoginPage() {
     setError(null);
     setSubmitting(true);
     try {
-      setBaseUrl(baseUrl);
       if (mode === 'login') {
         await login({ username, password });
       } else {
@@ -53,46 +63,35 @@ function LoginPage() {
   const isSignup = mode === 'signup';
 
   return (
-    <div className="cw-live-login">
-      <div className="cw-live-login-card">
-        <h1>Cowork for Teams</h1>
-        <p style={{ color: 'var(--cw-ink-3)', marginTop: 0 }}>
+    <main className="cw-welcome-panel">
+      <div className="cw-welcome-card">
+        <span className="cw-welcome-brand">Cowork for Teams</span>
+        <h2 className="cw-welcome-card-title">{isSignup ? '계정 만들기' : '오늘은 무엇을 함께 만들까요?'}</h2>
+        <p className="cw-welcome-card-sub">
           {isSignup
-            ? '새 계정을 만듭니다. 가입 후 personal project가 자동으로 생성됩니다.'
-            : '로그인하여 시작하세요.'}
+            ? '가입하면 개인 프로젝트가 자동으로 생성됩니다.'
+            : '팀과 에이전트가 기다리고 있어요.'}
         </p>
 
-        <div role="tablist" aria-label="auth mode" style={{
-          display: 'inline-flex',
-          gap: 4,
-          padding: 4,
-          marginTop: 6,
-          marginBottom: 14,
-          background: 'var(--cw-paper-3)',
-          borderRadius: 999,
-        }}>
+        <div role="group" aria-label="로그인 또는 회원가입 선택" className="cw-welcome-tabs">
           <ModeTab active={!isSignup} onClick={() => switchMode('login')}>로그인</ModeTab>
           <ModeTab active={isSignup} onClick={() => switchMode('signup')}>회원가입</ModeTab>
         </div>
 
         <form onSubmit={onSubmit}>
           <label>
-            Backend URL
-            <input value={baseUrl} onChange={(e) => setUrl(e.target.value)} placeholder="http://127.0.0.1:8080" />
-          </label>
-          <label>
             Username
             <input
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              autoComplete={isSignup ? 'username' : 'username'}
+              autoComplete="username"
               autoFocus
               required
             />
           </label>
           {isSignup && (
             <label>
-              Display name <span style={{ fontWeight: 400, color: 'var(--cw-ink-4)', textTransform: 'none', letterSpacing: 0 }}>(선택)</span>
+              Display name <span className="cw-welcome-optional">(선택)</span>
               <input
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
@@ -110,7 +109,7 @@ function LoginPage() {
               required
             />
           </label>
-          {error && <div className="cw-live-login-error">{error}</div>}
+          {error && <div className="cw-form-error">{error}</div>}
           <button type="submit" className="cw-btn-primary wide" disabled={submitting}>
             {submitting
               ? (isSignup ? '가입 중…' : '로그인 중…')
@@ -118,15 +117,15 @@ function LoginPage() {
           </button>
         </form>
 
-        <p style={{ color: 'var(--cw-ink-3)', fontSize: 12, marginTop: 18 }}>
+        <p className="cw-welcome-switch">
           {isSignup ? (
             <>이미 계정이 있다면 <ModeLink onClick={() => switchMode('login')}>로그인</ModeLink>으로 돌아가세요.</>
           ) : (
-            <>처음이세요? <ModeLink onClick={() => switchMode('signup')}>회원가입</ModeLink>으로 시작할 수 있어요. 데모 계정: <code>olive / cowork-demo</code></>
+            <>처음이세요? <ModeLink onClick={() => switchMode('signup')}>회원가입</ModeLink>으로 시작할 수 있어요.</>
           )}
         </p>
       </div>
-    </div>
+    </main>
   );
 }
 
@@ -134,23 +133,10 @@ function ModeTab({ active, onClick, children }: { active: boolean; onClick: () =
   return (
     <button
       type="button"
-      role="tab"
-      aria-selected={active}
+      aria-pressed={active}
+      className="cw-welcome-tab"
+      data-active={active}
       onClick={onClick}
-      style={{
-        appearance: 'none',
-        border: 0,
-        background: active ? 'var(--cw-paper)' : 'transparent',
-        color: active ? 'var(--cw-ink)' : 'var(--cw-ink-3)',
-        padding: '6px 14px',
-        borderRadius: 999,
-        fontSize: 12.5,
-        fontWeight: active ? 600 : 500,
-        boxShadow: active ? 'var(--cw-shadow-sm)' : 'none',
-        cursor: 'pointer',
-        transition: 'background 120ms, color 120ms',
-        fontFamily: 'inherit',
-      }}
     >
       {children}
     </button>
@@ -159,22 +145,7 @@ function ModeTab({ active, onClick, children }: { active: boolean; onClick: () =
 
 function ModeLink({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      style={{
-        appearance: 'none',
-        border: 0,
-        background: 'transparent',
-        padding: 0,
-        color: 'var(--cw-accent)',
-        textDecoration: 'underline',
-        textUnderlineOffset: 2,
-        cursor: 'pointer',
-        fontSize: 'inherit',
-        fontFamily: 'inherit',
-      }}
-    >
+    <button type="button" className="cw-welcome-link" onClick={onClick}>
       {children}
     </button>
   );

--- a/app/src/routes/login.tsx
+++ b/app/src/routes/login.tsx
@@ -4,6 +4,7 @@ import { getMe, login, signupAndLogin } from '@/api/auth';
 import { getToken, ApiError } from '@/api/client';
 import { useAuthStore } from '@/stores/auth';
 import { WelcomeCarousel } from '@/components/WelcomeCarousel';
+import { Icon } from '@/components/Icon';
 
 type Mode = 'login' | 'signup';
 
@@ -34,6 +35,7 @@ function AuthPanel() {
   const [displayName, setDisplayName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   function switchMode(next: Mode) {
     setMode(next);
@@ -101,13 +103,25 @@ function AuthPanel() {
           )}
           <label>
             Password
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoComplete={isSignup ? 'new-password' : 'current-password'}
-              required
-            />
+            <div className="cw-input-with-toggle">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete={isSignup ? 'new-password' : 'current-password'}
+                required
+              />
+              <button
+                type="button"
+                className="cw-input-toggle"
+                aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보이기'}
+                aria-pressed={showPassword}
+                onClick={() => setShowPassword((v) => !v)}
+                tabIndex={-1}
+              >
+                <Icon name={showPassword ? 'eye-off' : 'eye'} size={16} />
+              </button>
+            </div>
           </label>
           {error && <div className="cw-form-error">{error}</div>}
           <button type="submit" className="cw-btn-primary wide" disabled={submitting}>

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1184,68 +1184,789 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   cursor: pointer;
 }
 
-.cw-live-login {
+/* ── Welcome / login: split-screen brand entry ─────────────────────────────
+   Left = product showcase on the deep accent (the one place we let the accent
+   fill the page — this is the brand surface outside the app). Right = auth. */
+.cw-welcome {
   min-height: 100vh;
   display: grid;
-  place-items: center;
-  padding: 28px;
+  /* 기본: 로그인 우세 (≈ 33% 가이드 · 67% 폼) — 가이드는 "엿보기" 정도.
+     마우스를 가이드로 옮기면 :has()로 비율이 뒤집혀 가이드가 풀로 펼쳐진다. */
+  grid-template-columns: 0.5fr 1fr;
+  background: var(--cw-paper);
+  transition: grid-template-columns 320ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.cw-welcome:has(.cw-welcome-showcase:hover),
+.cw-welcome:has(.cw-welcome-showcase:focus-within) {
+  grid-template-columns: 1.5fr 1fr; /* 가이드 우세 (≈ 60% 가이드 · 40% 폼) */
+}
+
+.cw-welcome-showcase {
+  position: relative;
+  overflow: hidden;
+  color: white;
   background:
-    radial-gradient(circle at 22% 18%, color-mix(in oklch, var(--cw-accent), transparent 70%), transparent 30%),
-    radial-gradient(circle at 82% 72%, color-mix(in oklch, var(--cw-cozy-teal), transparent 70%), transparent 34%),
-    linear-gradient(135deg, var(--cw-surface), var(--cw-canvas));
+    radial-gradient(circle at 16% 10%, color-mix(in oklch, var(--cw-cozy-teal), transparent 52%), transparent 44%),
+    radial-gradient(circle at 90% 90%, color-mix(in oklch, var(--cw-cozy-plum), transparent 58%), transparent 48%),
+    linear-gradient(155deg, var(--cw-accent), var(--cw-accent-2));
 }
 
-.cw-live-login-card {
-  width: min(520px, 100%);
-  padding: 34px;
-  border-radius: 32px;
-  background: color-mix(in oklch, white, var(--cw-surface) 16%);
-  border: 1px solid color-mix(in oklch, var(--cw-ink), transparent 88%);
-  box-shadow: var(--cw-shadow-lift);
+/* ── Carousel shell ─────────────────────────────────────────────────────── */
+.cw-welcome-carousel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  outline: none;
 }
 
-.cw-live-login-card img {
-  width: 54px;
-  height: 54px;
+.cw-welcome-carousel:focus-visible {
+  outline: 2px solid color-mix(in oklch, white, transparent 55%);
+  outline-offset: -5px;
+  border-radius: 8px;
 }
 
-.cw-live-login-card h1 {
-  margin: 8px 0;
-  font-size: clamp(32px, 6vw, 54px);
-  line-height: 0.94;
-  letter-spacing: -0.05em;
+.cw-welcome-track {
+  flex: 1;
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
 }
 
-.cw-live-login-card form {
+.cw-welcome-track::-webkit-scrollbar {
+  display: none;
+}
+
+.cw-welcome-slide {
+  flex: 0 0 100%;
+  min-width: 100%;
+  scroll-snap-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 52px clamp(36px, 4.5vw, 56px);
+}
+
+/* ── Media (real <video> drops in here; CSS mock until then) ─────────────── */
+.cw-welcome-media {
+  position: relative;
+  width: 100%;
+  height: clamp(160px, 24vh, 220px);
+  margin-bottom: 26px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: color-mix(in oklch, white, transparent 90%);
+  border: 1px solid color-mix(in oklch, white, transparent 85%);
   display: grid;
-  gap: 12px;
-  margin: 20px 0;
+  place-items: center;
 }
 
-.cw-live-login-card label {
+/* 도트 그리드 텍스처 — 모션 예산 0으로 "디자인된 공간" 인상.
+   미디어 안의 mock이 작을 때 배경이 단순한 빈 색면이 아니게 한다. */
+.cw-welcome-media::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(circle, color-mix(in oklch, white, transparent 86%) 1px, transparent 1.5px);
+  background-size: 16px 16px;
+  opacity: 0.55;
+}
+
+.cw-welcome-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cw-welcome-eyebrow {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in oklch, white, transparent 30%);
+}
+
+.cw-welcome-headline {
+  margin: 12px 0 10px;
+  font-size: clamp(28px, 3.2vw, 42px);
+  font-weight: 680;
+  line-height: 1.06;
+  letter-spacing: -0.03em;
+}
+
+.cw-welcome-blurb {
+  margin: 0 0 12px;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: color-mix(in oklch, white, transparent 12%);
+}
+
+.cw-welcome-detail {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  max-width: 42ch;
+  color: color-mix(in oklch, white, transparent 30%);
+}
+
+/* ── Controls: arrows + progress dots ───────────────────────────────────── */
+.cw-welcome-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 0 clamp(36px, 4.5vw, 56px) 40px;
+}
+
+.cw-welcome-arrow {
+  flex: none;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklch, white, transparent 76%);
+  background: color-mix(in oklch, white, transparent 86%);
+  color: white;
+  cursor: pointer;
+  transition: background 120ms;
+}
+
+.cw-welcome-arrow:hover {
+  background: color-mix(in oklch, white, transparent 74%);
+}
+
+.cw-welcome-dots {
+  display: flex;
+  align-items: center;
+  gap: 2px; /* 버튼 간 간격은 좁게 — 실제 hit area는 버튼 padding이 만든다 */
+}
+
+/* 버튼 = hit target (시각엔 안 보이고, 손가락/커서 잡기는 쉬움 ≥ 44px) */
+.cw-welcome-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 8px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+/* 시각적 막대 = 진행바 트랙 */
+.cw-welcome-dot-track {
+  display: block;
+  width: 28px;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in oklch, white, transparent 78%);
+  overflow: hidden;
+  position: relative;
+  transition: width 220ms, background 220ms;
+}
+
+.cw-welcome-dot[data-active="true"] .cw-welcome-dot-track {
+  width: 56px;
+  /* 활성 트랙은 비활성보다 살짝 진하게 — 흰 채움 막대와의 콘트라스트 확보 */
+  background: color-mix(in oklch, white, transparent 70%);
+}
+
+.cw-welcome-dot-fill {
+  position: absolute;
+  inset: 0;
+  background: white;
+  transform: scaleX(0);
+  transform-origin: left;
+}
+
+/* 활성 상태는 track 길이(28→56px)로 표시하고, 채움은 "자동전환 진행 중"일 때만
+   보여준다. 수동으로 이동/일시정지하면 채움은 비어 있어, "지금은 카운트가
+   멈춤"이라는 정보를 시각적으로 정확히 전달한다. */
+.cw-welcome-dot-fill[data-run="true"] {
+  animation-name: cw-dot-progress;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+@keyframes cw-dot-progress {
+  from { transform: scaleX(0); }
+  to   { transform: scaleX(1); }
+}
+
+/* ── Slide mocks (placeholder motion until real videos arrive) ───────────── */
+.cw-mock {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+}
+
+/* 에이전트 피커 모크 — 새 세션 시작 시 에이전트를 고르는 화면을 흉내낸다.
+   "선택" 행에 흰 배경 + 체크가 들어가 무엇을 골랐는지 분명히 보인다. */
+/* Agent 슬라이드 — picker(agent-list)와 그 결과인 composer를 세로 스택.
+   기본 .cw-mock(grid place-items:center) 대신 flex column으로 갭 둔다. */
+.cw-mock-agent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.cw-mock-agent-list {
+  display: grid;
+  gap: 8px;
+  width: min(260px, 88%);
+}
+
+.cw-mock-composer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: min(260px, 88%);
+  padding: 9px 12px;
+  border-radius: 12px;
+  background: color-mix(in oklch, white, transparent 88%);
+  border: 1px solid color-mix(in oklch, white, transparent 78%);
+  opacity: 0;
+}
+.cw-mock-composer-chip {
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: white;
+  color: var(--cw-accent);
+  font-size: 11px;
+  font-weight: 700;
+  flex: none;
+}
+.cw-mock-composer-text {
+  font-size: 12px;
+  color: color-mix(in oklch, white, transparent 32%);
+}
+/* picker 행들이 들어온 뒤(1.0s)에 등장 — "선택 → 입력" 이야기 흐름 */
+.cw-mock-agent[data-active="true"] .cw-mock-composer {
+  animation: cw-loop-rise 4s ease 1.0s infinite;
+}
+.cw-mock-agent-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 12px;
+  background: color-mix(in oklch, white, transparent 86%);
+  font-size: 13px;
+  font-weight: 600;
+  color: white;
+  opacity: 0;
+  transform: translateY(-6px);
+}
+.cw-mock-agent-row[data-on="true"] {
+  background: white;
+  color: var(--cw-accent);
+}
+.cw-mock-agent-icon {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: color-mix(in oklch, white, transparent 78%);
+  color: white;
+}
+.cw-mock-agent-row[data-on="true"] .cw-mock-agent-icon {
+  background: color-mix(in oklch, var(--cw-accent), white 90%);
+  color: var(--cw-accent);
+}
+.cw-mock-agent-check { margin-left: auto; display: grid; place-items: center; }
+.cw-mock-agent[data-active="true"] .cw-mock-agent-row {
+  animation: cw-loop-fade 4s ease infinite;
+}
+.cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-i="0"] { animation-delay: 0s;   }
+.cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-i="1"] { animation-delay: 0.15s; }
+.cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-i="2"] { animation-delay: 0.3s;  }
+/* 선택된 row(검색)에는 loop-fade + box-shadow 펄스를 동시에 — "골랐다"는 신호가 hold 동안에도 살아 있다 */
+.cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-on="true"] {
+  animation:
+    cw-loop-fade   4s ease 0.15s infinite,
+    cw-breathe-ring 2.4s ease-in-out infinite;
+}
+
+.cw-mock-artifact {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+.cw-mock-doc {
+  position: relative;
+  width: min(230px, 82%);
+  padding: 16px;
+  border-radius: 14px;
+  background: color-mix(in oklch, white, transparent 86%);
+  display: grid;
+  gap: 9px;
+}
+/* 메인 카드 뒤에 살짝 비스듬히 깔리는 그림자 카드 — "여러 산출물" 인상,
+   정적 깊이감(모션 예산 0). */
+.cw-mock-doc::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  background: color-mix(in oklch, white, transparent 92%);
+  transform: translate(8px, 8px) rotate(-2deg);
+  z-index: -1;
+  pointer-events: none;
+}
+/* 문서 카드 자체가 위아래로 살짝 떠다님 — 안쪽 line 채움이 끝나도 정적이지 않게 */
+.cw-mock-artifact[data-active="true"] .cw-mock-doc {
+  animation: cw-breathe-float 3.2s ease-in-out infinite;
+}
+.cw-mock-doc-line {
+  height: 7px;
+  border-radius: 4px;
+  background: color-mix(in oklch, white, transparent 58%);
+  transform: scaleX(0);
+  transform-origin: left;
+}
+.cw-mock-doc-line:nth-child(2) { width: 82%; }
+.cw-mock-doc-line:nth-child(3) { width: 92%; }
+.cw-mock-doc-line:nth-child(4) { width: 60%; }
+.cw-mock-artifact[data-active="true"] .cw-mock-doc-line { animation: cw-loop-fill 4s ease infinite; }
+.cw-mock-artifact[data-active="true"] .cw-mock-doc-line:nth-child(1) { animation-delay: 0s;   }
+.cw-mock-artifact[data-active="true"] .cw-mock-doc-line:nth-child(2) { animation-delay: 0.15s; }
+.cw-mock-artifact[data-active="true"] .cw-mock-doc-line:nth-child(3) { animation-delay: 0.3s;  }
+.cw-mock-artifact[data-active="true"] .cw-mock-doc-line:nth-child(4) { animation-delay: 0.45s; }
+.cw-mock-share-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: white;
+  color: var(--cw-accent);
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(6px);
+}
+.cw-mock-artifact[data-active="true"] .cw-mock-share-badge { animation: cw-loop-rise 4s ease 0.9s infinite; }
+
+.cw-mock-share {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+}
+.cw-mock-avatars { display: flex; }
+.cw-mock-av {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  margin-left: -8px;
+  border: 2px solid color-mix(in oklch, var(--cw-accent), black 6%);
+  color: white;
+  font-size: 14px;
+  font-weight: 700;
+  opacity: 0;
+  transform: scale(0.6);
+}
+.cw-mock-av[data-i="0"] { background: var(--cw-cozy-clay); margin-left: 0; }
+.cw-mock-av[data-i="1"] { background: var(--cw-cozy-teal); }
+.cw-mock-av[data-i="2"] { background: var(--cw-cozy-plum); }
+.cw-mock-share[data-active="true"] .cw-mock-av { animation: cw-loop-pop 4s ease infinite; }
+.cw-mock-share[data-active="true"] .cw-mock-av[data-i="0"] { animation-delay: 0s;   }
+.cw-mock-share[data-active="true"] .cw-mock-av[data-i="1"] {
+  animation:
+    cw-loop-pop    4s ease 0.15s infinite,
+    cw-breathe-ring 2.4s ease-in-out infinite;
+}
+.cw-mock-share[data-active="true"] .cw-mock-av[data-i="2"] { animation-delay: 0.3s;  }
+.cw-mock-modes { display: flex; gap: 6px; }
+.cw-mock-mode {
+  padding: 5px 11px;
+  border-radius: 999px;
+  background: color-mix(in oklch, white, transparent 84%);
+  font-size: 11.5px;
+}
+.cw-mock-mode.is-on {
+  background: white;
+  color: var(--cw-accent);
+  font-weight: 700;
+  opacity: 0;
+}
+.cw-mock-share[data-active="true"] .cw-mock-mode.is-on { animation: cw-loop-pop 4s ease 0.6s infinite; }
+
+/* "함께 대화"의 결과로 팀에서 누군가 보낸 메시지 — share 슬라이드의 보조 요소 */
+.cw-mock-chat-bubble {
+  align-self: flex-end;
+  margin-right: 6%;
+  padding: 7px 13px;
+  border-radius: 14px 14px 4px 14px;
+  background: white;
+  color: var(--cw-accent);
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(6px);
+}
+.cw-mock-share[data-active="true"] .cw-mock-chat-bubble {
+  animation: cw-loop-rise 4s ease 0.9s infinite;
+}
+
+/* Automation mock — 트리거 칩 + 누적된 run rows.
+   상단에서 트리거가 등장(0s, 0.15s) → 그 결과로 run row가 왼쪽에서 차례로
+   들어옴(0.3s ~ 0.6s). 모션이 "트리거가 결과를 만든다"는 인과를 그린다. */
+.cw-mock-automation-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: min(280px, 92%);
+}
+.cw-mock-trigger-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+.cw-mock-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: color-mix(in oklch, white, transparent 78%);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(6px);
+}
+.cw-mock-trigger[data-kind="cron"] {
+  background: white;
+  color: var(--cw-accent);
+}
+.cw-mock-automation[data-active="true"] .cw-mock-trigger {
+  animation: cw-loop-rise 4s ease infinite;
+}
+.cw-mock-automation[data-active="true"] .cw-mock-trigger[data-kind="cron"] {
+  animation:
+    cw-loop-rise 4s ease 0s infinite,
+    cw-breathe-ring 2.4s ease-in-out infinite;
+}
+.cw-mock-automation[data-active="true"] .cw-mock-trigger[data-kind="webhook"] {
+  animation-delay: 0.15s;
+}
+
+.cw-mock-runs {
   display: grid;
   gap: 6px;
-  font-weight: 800;
-  color: var(--cw-muted);
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
+.cw-mock-run {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border-radius: 10px;
+  background: color-mix(in oklch, white, transparent 85%);
+  color: white;
+  font-size: 12px;
+  opacity: 0;
+  transform: translateX(-8px);
+}
+.cw-mock-automation[data-active="true"] .cw-mock-run {
+  animation: cw-loop-slide 4s ease infinite;
+}
+.cw-mock-automation[data-active="true"] .cw-mock-run[data-i="0"] { animation-delay: 0.3s;  }
+.cw-mock-automation[data-active="true"] .cw-mock-run[data-i="1"] { animation-delay: 0.45s; }
+.cw-mock-automation[data-active="true"] .cw-mock-run[data-i="2"] { animation-delay: 0.6s;  }
 
-.cw-live-login-card input {
-  width: 100%;
-  border: 1px solid color-mix(in oklch, var(--cw-ink), transparent 84%);
-  border-radius: 16px;
-  padding: 12px 14px;
-  font: inherit;
-  color: var(--cw-ink);
+.cw-mock-run-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+  background: color-mix(in oklch, white, transparent 55%);
+}
+.cw-mock-run-dot[data-status="success"] {
+  background: color-mix(in oklch, var(--cw-cozy-teal), white 10%);
+}
+.cw-mock-run-dot[data-status="running"] {
   background: white;
 }
+/* "실행 중" 점만 hold 구간 내내 호흡 — main loop의 opacity/transform과
+   충돌하지 않게 box-shadow에 모션을 깐다. */
+.cw-mock-automation[data-active="true"] .cw-mock-run[data-i="0"] .cw-mock-run-dot[data-status="running"] {
+  animation: cw-breathe-ring 1.8s ease-in-out infinite;
+}
+.cw-mock-run-time {
+  font-weight: 700;
+  min-width: 70px;
+}
+.cw-mock-run-label {
+  opacity: 0.86;
+}
 
-.cw-live-login-error {
-  border: 1px solid color-mix(in oklch, crimson, transparent 70%);
-  color: oklch(0.45 0.17 28);
-  background: color-mix(in oklch, crimson, white 92%);
+.cw-mock-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 13px;
+}
+.cw-mock-steps li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateX(-8px);
+}
+.cw-mock-quickstart[data-active="true"] .cw-mock-steps li {
+  animation: cw-loop-slide 4s ease infinite;
+}
+.cw-mock-quickstart[data-active="true"] .cw-mock-steps li:nth-child(1) { animation-delay: 0s;   }
+.cw-mock-quickstart[data-active="true"] .cw-mock-steps li:nth-child(2) { animation-delay: 0.15s; }
+.cw-mock-quickstart[data-active="true"] .cw-mock-steps li:nth-child(3) { animation-delay: 0.3s;  }
+.cw-mock-step-num {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: color-mix(in oklch, white, transparent 80%);
+  color: white;
+  font-size: 13px;
+  flex: none;
+}
+/* 각 단계의 아이콘 — 순번 배지 옆에 글리프 추가해 한 행에 더 많은 정보 */
+.cw-mock-step-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  background: color-mix(in oklch, white, transparent 82%);
+  color: white;
+  flex: none;
+}
+
+/* 4초 사이클 안에 enter(10%) → hold(70%) → exit(10%) → dwell(10%)가 모두
+   들어가 있어, infinite로 돌면서 "잠깐 보이고 텀 두고 또 보이는" 짧은
+   영상처럼 자연스럽게 반복된다. AUTO_ADVANCE_MS(5s)보다 짧게 잡아 슬라이드
+   전환 직전에 한 번 더 들어가는 모습이 일부 비친다. */
+@keyframes cw-loop-fade {
+  0%,  100% { opacity: 0; transform: translateY(-6px); }
+  10%, 80%  { opacity: 1; transform: none; }
+  90%       { opacity: 0; transform: translateY(-6px); }
+}
+@keyframes cw-loop-rise {
+  0%,  100% { opacity: 0; transform: translateY(6px); }
+  10%, 80%  { opacity: 1; transform: none; }
+  90%       { opacity: 0; transform: translateY(6px); }
+}
+@keyframes cw-loop-pop {
+  0%,  100% { opacity: 0; transform: scale(0.6); }
+  10%, 80%  { opacity: 1; transform: none; }
+  90%       { opacity: 0; transform: scale(0.6); }
+}
+@keyframes cw-loop-slide {
+  0%,  100% { opacity: 0; transform: translateX(-8px); }
+  10%, 80%  { opacity: 1; transform: none; }
+  90%       { opacity: 0; transform: translateX(-8px); }
+}
+@keyframes cw-loop-fill {
+  0%,  100% { transform: scaleX(0); }
+  10%, 80%  { transform: scaleX(1); }
+  90%       { transform: scaleX(0); }
+}
+
+/* 보조 호흡 — 메인 loop의 hold(70%) 동안에도 미세 모션을 깔아
+   "정지된 카드" 느낌을 없앤다. transform이 아닌 box-shadow / translateY를
+   써서 메인 loop의 transform/opacity와 충돌하지 않는다. */
+@keyframes cw-breathe-ring {
+  0%, 100% { box-shadow: 0 0 0 0  color-mix(in oklch, white, transparent 80%); }
+  50%      { box-shadow: 0 0 0 5px color-mix(in oklch, white, transparent 92%); }
+}
+@keyframes cw-breathe-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-3px); }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+  .cw-welcome { transition: none; }
+  .cw-welcome-track { scroll-behavior: auto; }
+  .cw-welcome-dot-fill,
+  .cw-mock-agent-row, .cw-mock-composer,
+  .cw-mock-doc, .cw-mock-doc-line, .cw-mock-share-badge,
+  .cw-mock-av, .cw-mock-mode.is-on, .cw-mock-chat-bubble, .cw-mock-steps li,
+  .cw-mock-trigger, .cw-mock-run, .cw-mock-run-dot {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+  /* 모션 비선호 사용자에겐 활성 점을 풀로 채워 활성 위치를 명확히 한다
+     (자동전환은 꺼지므로 카운트다운이라는 정보가 무의미하므로). */
+  .cw-welcome-dot[data-active="true"] .cw-welcome-dot-fill { transform: scaleX(1); }
+}
+
+.cw-welcome-panel {
+  display: grid;
+  place-items: center;
+  padding: 40px 28px;
+  border-left: 1px solid var(--cw-line);
+}
+
+.cw-welcome-card {
+  width: min(380px, 100%);
+  animation: cw-enter 0.3s ease both;
+}
+
+.cw-welcome-brand {
+  display: inline-block;
+  margin-bottom: 14px;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--cw-accent);
+}
+
+.cw-welcome-card-title {
+  margin: 0 0 6px;
+  font-size: 24px;
+  letter-spacing: -0.02em;
+  color: var(--cw-ink);
+}
+
+.cw-welcome-card-sub {
+  margin: 0 0 22px;
+  font-size: 14px;
+  color: var(--cw-ink-3);
+}
+
+.cw-welcome-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  margin-bottom: 18px;
+  background: var(--cw-paper-3);
+  border-radius: 999px;
+}
+
+.cw-welcome-tab {
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-size: 12.5px;
+  font-weight: 500;
+  background: transparent;
+  color: var(--cw-ink-2);
+  transition: background 120ms, color 120ms;
+}
+
+.cw-welcome-tab[data-active="true"] {
+  background: var(--cw-paper);
+  color: var(--cw-ink);
+  font-weight: 600;
+  box-shadow: var(--cw-shadow-sm);
+}
+
+.cw-welcome-card form {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.cw-welcome-card label {
+  display: grid;
+  gap: 6px;
+  font-weight: 700;
+  color: var(--cw-ink-3);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cw-welcome-optional {
+  font-weight: 400;
+  color: var(--cw-ink-4);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.cw-welcome-card input {
+  width: 100%;
+  border: 1px solid var(--cw-line);
+  border-radius: 12px;
+  padding: 11px 13px;
+  font: inherit;
+  color: var(--cw-ink);
+  background: var(--cw-paper);
+}
+
+.cw-welcome-card input:focus-visible {
+  border-color: var(--cw-ink-3);
+  box-shadow: 0 0 0 3px var(--cw-paper-3);
+}
+
+.cw-welcome-card .cw-btn-primary {
+  min-height: 44px;
+  border-radius: 12px;
+}
+
+.cw-welcome-switch {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--cw-ink-3);
+}
+
+.cw-welcome-link {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: var(--cw-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+@media (max-width: 920px) {
+  .cw-welcome {
+    grid-template-columns: 1fr;
+  }
+  /* Stacked: the showcase has no intrinsic height, so the carousel would
+     collapse — give it a viewport-relative floor. */
+  .cw-welcome-showcase {
+    min-height: 78vh;
+  }
+  .cw-welcome-slide {
+    padding: 40px 28px;
+  }
+  .cw-welcome-panel {
+    border-left: 0;
+  }
+}
+
+.cw-form-error {
+  border: 1px solid color-mix(in oklch, var(--cw-destructive), transparent 70%);
+  color: var(--cw-destructive);
+  background: color-mix(in oklch, var(--cw-destructive), white 92%);
   border-radius: 14px;
   padding: 10px 12px;
   font-weight: 700;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1340,6 +1340,35 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   background: color-mix(in oklch, white, transparent 74%);
 }
 
+/* WCAG 2.2.2 pause/play — arrow보다 살짝 작게 잡아 navigation control과
+   구분하되 같은 컨트롤 행 안에 함께 둔다. aria-pressed=true(=paused)일 때
+   배경을 더 진하게 해 "지금 멈춰 있다"는 신호가 분명히 보이도록. */
+.cw-welcome-pause {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklch, white, transparent 76%);
+  background: color-mix(in oklch, white, transparent 86%);
+  color: white;
+  cursor: pointer;
+  transition: background 120ms;
+}
+.cw-welcome-pause:hover {
+  background: color-mix(in oklch, white, transparent 74%);
+}
+.cw-welcome-pause[aria-pressed="true"] {
+  background: white;
+  color: var(--cw-accent);
+}
+.cw-welcome-pause:focus-visible,
+.cw-welcome-arrow:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
 .cw-welcome-dots {
   display: flex;
   align-items: center;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -2051,6 +2051,22 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   display: none;
 }
 
+/* Chrome/Edge의 자동 채움 시 input 배경을 연한 파랑(rgb(232,240,254))으로
+   강제하는 동작을 덮어쓴다. CSS 명세상 background-color로는 override가 안 되어
+   inset box-shadow로 input 안쪽을 paper 색으로 덮고, text-fill-color로 글자
+   색을 ink로 강제한다 — 둘 다 -webkit-* prefix 한정이라 다른 브라우저에는
+   영향 없음. focus 시에도 같은 처리를 유지해 자동 채움 후 클릭해도 색이 안 튐. */
+.cw-welcome-card input:-webkit-autofill,
+.cw-welcome-card input:-webkit-autofill:hover,
+.cw-welcome-card input:-webkit-autofill:focus,
+.cw-welcome-card input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 1000px var(--cw-paper) inset;
+          box-shadow: 0 0 0 1000px var(--cw-paper) inset;
+  -webkit-text-fill-color: var(--cw-ink);
+  caret-color: var(--cw-ink);
+  transition: background-color 5000s ease-in-out 0s;
+}
+
 /* Password 같이 보조 토글이 붙는 input의 래퍼. 토글 아이콘과 텍스트가
    겹치지 않도록 input의 우측 padding을 토글 폭(30px + 여백)만큼 늘린다. */
 .cw-input-with-toggle {

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -2042,6 +2042,54 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   box-shadow: 0 0 0 3px var(--cw-paper-3);
 }
 
+/* Edge/IE의 built-in password reveal · clear 버튼 숨김 — 커스텀 토글
+   (.cw-input-toggle)과 나란히 두 번 보이는 걸 막고, 모든 브라우저에서
+   일관된 UI를 유지한다. password input에는 ::-ms-reveal이, text input에는
+   ::-ms-clear가 자동으로 붙는데, 후자는 보수적으로 함께 처리. */
+.cw-welcome-card input::-ms-reveal,
+.cw-welcome-card input::-ms-clear {
+  display: none;
+}
+
+/* Password 같이 보조 토글이 붙는 input의 래퍼. 토글 아이콘과 텍스트가
+   겹치지 않도록 input의 우측 padding을 토글 폭(30px + 여백)만큼 늘린다. */
+.cw-input-with-toggle {
+  position: relative;
+  display: block;
+}
+.cw-input-with-toggle input {
+  padding-right: 42px;
+}
+
+.cw-input-toggle {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--cw-ink-3);
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease;
+}
+.cw-input-toggle:hover {
+  color: var(--cw-ink);
+  background: var(--cw-paper-3);
+}
+.cw-input-toggle:focus-visible {
+  outline: 2px solid var(--cw-ink-3);
+  outline-offset: 2px;
+  color: var(--cw-ink);
+}
+.cw-input-toggle[aria-pressed="true"] {
+  color: var(--cw-ink);
+}
+
 .cw-welcome-card .cw-btn-primary {
   min-height: 44px;
   border-radius: 12px;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -2403,7 +2403,10 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   }
   /* 모션 비선호 사용자에겐 활성 점을 풀로 채워 활성 위치를 명확히 한다
      (자동전환은 꺼지므로 카운트다운이라는 정보가 무의미하므로). */
-  .cw-welcome-dot[data-active="true"] .cw-welcome-dot-fill { transform: scaleX(1); }
+  /* !important로 같은 블록의 transform: none을 이긴다 — 위 blanket rule이
+     active dot fill에도 transform: none을 강제하는데, 의도는 active 위치에선
+     scaleX(1)로 꽉 채워 위치 표시를 유지하는 것. */
+  .cw-welcome-dot[data-active="true"] .cw-welcome-dot-fill { transform: scaleX(1) !important; }
 }
 
 .cw-welcome-panel {

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1490,11 +1490,109 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 .cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-i="0"] { animation-delay: 0s;   }
 .cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-i="1"] { animation-delay: 0.15s; }
 .cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-i="2"] { animation-delay: 0.3s;  }
+.cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-i="3"] { animation-delay: 0.45s; }
 /* 선택된 row(검색)에는 loop-fade + box-shadow 펄스를 동시에 — "골랐다"는 신호가 hold 동안에도 살아 있다 */
 .cw-mock-agent[data-active="true"] .cw-mock-agent-row[data-on="true"] {
   animation:
     cw-loop-fade   4s ease 0.15s infinite,
     cw-breathe-ring 2.4s ease-in-out infinite;
+}
+
+/* Knowledge mock — 업로드된 파일 chip + 사용자 질문 + 답변 라인 + 출처 chip.
+   타임라인: 파일들이 먼저 떠오르고(0s, 0.15s), 사용자 질문(0.3s), 답변 라인이
+   가로로 채워지며(0.45s, 0.6s), 마지막에 출처 chip이 pop으로 강조된다(0.75s).
+   "출처와 함께 답한다"는 RAG의 본질을 모션의 종점에 두는 설계. */
+.cw-mock-knowledge {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  width: min(280px, 92%);
+}
+.cw-mock-files {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.cw-mock-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: color-mix(in oklch, white, transparent 84%);
+  color: white;
+  font-size: 11.5px;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(6px);
+}
+.cw-mock-knowledge[data-active="true"] .cw-mock-file { animation: cw-loop-rise 4s ease infinite; }
+.cw-mock-knowledge[data-active="true"] .cw-mock-file[data-i="0"] { animation-delay: 0s;    }
+.cw-mock-knowledge[data-active="true"] .cw-mock-file[data-i="1"] { animation-delay: 0.15s; }
+
+.cw-mock-question {
+  align-self: flex-end;
+  margin-right: 6%;
+  padding: 7px 13px;
+  border-radius: 14px 14px 4px 14px;
+  background: white;
+  color: var(--cw-accent);
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(6px);
+}
+.cw-mock-knowledge[data-active="true"] .cw-mock-question {
+  animation: cw-loop-rise 4s ease 0.3s infinite;
+}
+
+.cw-mock-answer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 7px;
+  padding: 10px 13px;
+  border-radius: 4px 14px 14px 14px;
+  background: color-mix(in oklch, white, transparent 86%);
+  margin-left: 4%;
+  max-width: 80%;
+}
+/* 짧은 실제 답변 한 줄 — placeholder 라인 대신 의미를 직접 전달한다.
+   다른 슬라이드들(03 채팅 버블, 04 run 라벨, 05 chip)과 같은 "구체적 텍스트" 결. */
+.cw-mock-answer-text {
+  color: white;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.35;
+  opacity: 0;
+  transform: translateY(4px);
+}
+.cw-mock-knowledge[data-active="true"] .cw-mock-answer-text {
+  animation: cw-loop-rise 4s ease 0.45s infinite;
+}
+
+/* 출처 chip — 답변 안에서 살짝 들어가 있고, pop 모션 + breathe-ring으로
+   "여기 근거가 있다"를 강조한다. */
+.cw-mock-source {
+  align-self: flex-start;
+  margin-top: 3px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: white;
+  color: var(--cw-accent);
+  font-size: 11px;
+  font-weight: 700;
+  opacity: 0;
+  transform: scale(0.6);
+}
+.cw-mock-knowledge[data-active="true"] .cw-mock-source {
+  animation:
+    cw-loop-pop    4s ease 0.75s infinite,
+    cw-breathe-ring 2.4s ease-in-out 0.75s infinite;
 }
 
 .cw-mock-artifact {
@@ -1758,6 +1856,27 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   color: white;
   flex: none;
 }
+/* step 이름이 너무 길어지면 chip이 밀려나지 않도록 — 타이틀이 chip 공간을
+   먹지 않고, chip은 항상 행 끝에서 ellipsis 처리된다. */
+.cw-mock-step-title {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* 각 step에 들어갈 예시 한 토막 — 03/04와 같은 구체성 결을 quickstart에도. */
+.cw-mock-step-preview {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: color-mix(in oklch, white, transparent 86%);
+  color: color-mix(in oklch, white, transparent 8%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 110px;
+  flex: 0 1 auto;
+}
 
 /* 4초 사이클 안에 enter(10%) → hold(70%) → exit(10%) → dwell(10%)가 모두
    들어가 있어, infinite로 돌면서 "잠깐 보이고 텀 두고 또 보이는" 짧은
@@ -1809,7 +1928,8 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   .cw-mock-agent-row, .cw-mock-composer,
   .cw-mock-doc, .cw-mock-doc-line, .cw-mock-share-badge,
   .cw-mock-av, .cw-mock-mode.is-on, .cw-mock-chat-bubble, .cw-mock-steps li,
-  .cw-mock-trigger, .cw-mock-run, .cw-mock-run-dot {
+  .cw-mock-trigger, .cw-mock-run, .cw-mock-run-dot,
+  .cw-mock-file, .cw-mock-question, .cw-mock-answer-text, .cw-mock-source {
     animation: none !important;
     opacity: 1 !important;
     transform: none !important;


### PR DESCRIPTION
> [!NOTE]
> **This is a rough sketch / placeholder.** The split-screen surface,
> the carousel skeleton and the pause / autofill plumbing are the
> structural changes worth landing. Everything
> visible on top of that — copy, animation timing, mock content, exact
> layout, the carousel slides themselves — is intentionally up for
> iteration in a follow-up PR. Treat this as the base to refine against,
> not a final design.

## What you see

`/login` is no longer just a username + password card. The page is now split into two halves: a **guided carousel on the left**, the **auth panel on the right**.

### Split-screen layout, with a focus rule

When the page first loads, the auth panel is the dominant pane — anyone returning to log in still sees the form front-and-center. The carousel sits beside it as a slim teaser strip.

Move the cursor over the carousel and the two panes swap weight: the guide expands to take roughly 1.5× the auth panel, becoming the comfortable "explore" surface. Move away and they swap back. There's no click required and no separate route — first-time visitors can browse without losing the form.

### A five-slide product tour

The carousel walks through five things a new user should know about the product, in order. Each slide has its own mock that animates while the slide is active, so they read less like a bullet list and more like five tiny demos.

| # | Slide | What the mock shows |
|---|---|---|
| 01 | **Agent** — pick an agent when starting a session | A short list of agents (분석 · 검색 · 실행), one selected with a check, followed by the composer that opens once an agent is chosen |
| 02 | **Artifact** — deliverables you can hand back | A document card with lines filling in, a shadow card behind it, and a \"팀 공유\" badge rising in |
| 03 | **Collaboration** — share a session with the team | Three avatars popping in, the \"함께 대화\" mode highlighted among 비공개 / 읽기 공유, and a chat bubble landing from a teammate |
| 04 | **Automation** — let agents run without you | Two trigger chips (\"매일 09:00\" cron + \"Webhook\"), and three accumulated run rows below — the topmost run breathes to indicate it is currently running |
| 05 | **Quickstart** — three steps to get going | A numbered list (프로젝트 만들기 → 대화 시작 → 팀과 공유) sliding in one row at a time |

### Carousel behavior

- **Auto-advance**: 7 second cycle, with a thin progress bar inside the active dot acting as a countdown. The bar runs regardless of hover state — once the user starts watching the guide, having the indicator freeze felt wrong.
- **Manual navigation**: arrow buttons on either side, dot indicators below, plus keyboard ← / → when the carousel is focused. The dots have generous hit targets (~44 × 34 px) while staying visually thin.
- **Reduced motion**: respects \`prefers-reduced-motion\` — auto-advance, mock loops, and slide easing all go quiet; the active dot is filled solid so the user can still tell where they are.

### Auth panel

- A small \"Cowork for Teams\" wordmark sits above the form, so the page has a brand anchor without needing a separate hero block.
- Welcoming copy that reads the same whether you're new or returning:
  - **Login**: *오늘은 무엇을 함께 만들까요? — 팀과 에이전트가 기다리고 있어요.*
  - **Signup**: *계정 만들기 — 가입하면 개인 프로젝트가 자동으로 생성됩니다.*
- The previously-shown \"Backend URL\" input is gone. It was never wired to anything end-users would change.

### Small cleanups under the hood

- \`api/client.ts\` previously kept the API base URL in two places (env var + localStorage with a getter/setter pair). The setter was only used by the dropped Backend URL input, so the base URL is now a single env-derived constant. Same effect at runtime, less surface.
- The form's error pill used to be styled as \`.cw-live-login-error\` with a hard-coded \`crimson\`. Renamed to \`.cw-form-error\` and switched to the existing \`--cw-destructive\` token — \`InviteDialog\` now shares it as well.

## Screenshots

> The captured screenshots are listed below

<img width="1440" height="900" alt="pr-0-overview" src="https://github.com/user-attachments/assets/09322d20-485c-4c8b-81d7-44cffebad270" />
— page on first load (auth panel dominant, carousel slim on the left)


<img width="1440" height="900" alt="pr-1-hover-expand" src="https://github.com/user-attachments/assets/6c900f44-d0b6-47e9-a40e-43c8c99158cb" />
— hover over the carousel; layout swaps so the guide is dominant


<img width="1440" height="900" alt="pr-slide-1" src="https://github.com/user-attachments/assets/24f66e54-74de-499f-a382-db90cabad127" />
<img width="1440" height="900" alt="pr-slide-3" src="https://github.com/user-attachments/assets/8fbe4aaf-962c-4379-8e9a-599dbcbd742a" />
<img width="1440" height="900" alt="pr-slide-5" src="https://github.com/user-attachments/assets/35cf9d0d-a6c7-42ea-886e-7623012f0d89" />


## Test plan

- [x] Open \`/login\` — auth panel is initially dominant, brand wordmark visible above the title, no Backend URL input.
- [x] Hover anywhere over the left half — guide expands; leave — guide retracts.
- [x] Wait ~7s on each slide — auto-advances on its own, progress bar inside the active dot empties as it counts down.
- [x] Click each dot / arrow / use ← → keyboard — selection follows.
- [x] Each slide's mock animates a short loop while active and stays quiet while inactive.
- [x] Submit a wrong password — the error pill renders with the project's destructive color, not raw crimson.
- [x] System \"Reduce motion\" on — auto-advance and mock loops stop; active dot is filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

