### PR TITLE
chore(dep): update ailoy using microsandbox 0.5.2, fix frontend bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=38d32c4a3e2db3333e0287819770ed77bc7f5e66#38d32c4a3e2db3333e0287819770ed77bc7f5e66"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=58e0c38af84b7a38257065d4f623a8060fa20f4c#58e0c38af84b7a38257065d4f623a8060fa20f4c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4472,8 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6611b7bf93b63777a11fe0b20b4ab5054106e1acedd515b17baaf35db305da40"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -4519,8 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9189d47562fa2d3535c41d90f628889fdb2df97b5d6cda47d989f4bac8db9299"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -4531,8 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd9bb1b8f24d18d0ee8b87bb69116aa980e28f46f9d21b95e828b6e8454fb22"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -4544,8 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b630bf80e759c44cee3548f838fa1924a3b19602ee514852119110a94796736"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -4569,8 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee41ba848ec0b748016de0ae699d38a4c7bd2f944e9bcf2547f49be9aa51549"
 dependencies = [
  "chrono",
  "libc",
@@ -4580,16 +4585,19 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea26dfddce6da6248f75ca73466f7703c5890585840b53437e69b8e447f70b9e"
 dependencies = [
  "sea-orm-migration",
+ "serde_json",
 ]
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95022aa7fe1ecded9c680e1d52de80d66f3f9f48888fec829b05ead0d4a4623d"
 dependencies = [
  "base64",
  "bytes",
@@ -4626,8 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c830f6feb8ed866946651cea9d2f693103cec812fc8be47ff2ad089e81945f4"
 dependencies = [
  "chrono",
  "ciborium",
@@ -4639,8 +4648,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84eadc5c5fc8d55f135ae718cd51c712817cea8ef54ae942c09318b596e33fb5"
 dependencies = [
  "bytes",
  "chrono",
@@ -4667,8 +4677,9 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.0"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.0#fa3b2a563e8a519eae0edc84a79d2e325acb0c49"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f449293c7b6630dfccda66980000bd882a22369d9c2d885a7a808a68c323a7"
 dependencies = [
  "dirs 6.0.0",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "38d32c4a3e2db3333e0287819770ed77bc7f5e66", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "58e0c38af84b7a38257065d4f623a8060fa20f4c", features = ["sandbox"] }

--- a/app/src/components/ArtifactsPanel.tsx
+++ b/app/src/components/ArtifactsPanel.tsx
@@ -34,6 +34,7 @@ export function ArtifactsPanel({ projectId, sessionId, onCopyToShared }: Artifac
   const { data: rawEntries = [], isLoading } = useQuery({
     queryKey: ['dirents', 'artifacts', projectId, sessionId],
     queryFn: () => listDirentsRaw(scope, true),
+    enabled: Boolean(sessionId),
   });
 
   // Show files only, strip scope prefix for display

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -221,8 +221,8 @@ export function Sidebar() {
 
   const sessionsQuery = useQuery({
     queryKey: ['sessions', activeProjectSlug],
-    queryFn: () => listSessions(activeProject?.id ?? ''),
-    enabled: Boolean(activeProjectSlug),
+    queryFn: () => listSessions(activeProject!.id),
+    enabled: Boolean(activeProjectSlug) && Boolean(activeProject),
   });
 
   const activeSessionId = useActiveSessionId();


### PR DESCRIPTION
## Summary

### Backend: bump ailoy + microsandbox (msb 0.5.2)

- Updated ailoy to rev `58e0c38` (`38d32c4` → `58e0c38`)
- microsandbox (msb) crates bumped from `0.5.0` (git tag) → `0.5.2` (crates.io)
  - Source changed from the `superradcompany/microsandbox` git repo to the official crates.io registry release

### Frontend: fix premature `useQuery` calls returning 404 / 400

Both frontend bugs are race conditions: `useQuery` calls fired before their upstream data dependencies had resolved, passing empty strings into URL-constructed paths.

- **`Sidebar.tsx`** — The sessions query was `enabled` as soon as `activeProjectSlug` was present in the URL, but `activeProject` (resolved from `projectsQuery.data`) could still be `undefined` at that point. This caused `listSessions('')` to fire with `GET /sessions?project_ref=` (empty string) → 404. Fixed by gating the query on both `activeProjectSlug` and `activeProject`, and removing the `?? ''` fallback from the `queryFn`.

- **`ArtifactsPanel.tsx`** — The artifacts dirents query had no `enabled` guard. The parent initializes `sessionId` as `session.data?.id ?? ''`, so while the session is still loading `sessionId` is `''`. This produced a malformed URL `GET /dirents?path=projects/.../sessions//artifacts` (double slash) → 400. Fixed by adding `enabled: Boolean(sessionId)`.


## Test plan

- [x] Verify the backend builds cleanly against the updated ailoy rev and msb 0.5.2
- [x] Navigate to a project page — confirm no 404 for `/sessions?project_ref=` in the network tab
- [x] Open a session — confirm no 400 for `/dirents?path=...sessions//artifacts` in the network tab
- [x] Confirm the sidebar session list loads correctly once the projects query resolves
- [x] Confirm the artifacts panel loads correctly once the session UUID is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)