### PR TITLE
feat(ui): generic <Select> (custom panel + native dropdown, portaled & collision-aware); adopt app-wide

### DIFF
--- a/app/src/components/SchedulePicker.tsx
+++ b/app/src/components/SchedulePicker.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Icon } from '@/components/Icon';
+import { Select } from '@/components/Select';
 
 export type SchedulePickerValue = { expr: string; tz: string };
 
@@ -185,28 +186,29 @@ export function SchedulePicker({
           onChange={(e) => update({ interval: Math.max(1, Math.min(24, parseInt(e.target.value, 10) || 1)) })}
           title={intervalDisabled ? 'cron으로는 매시간 단위에서만 N>1을 지원합니다.' : ''}
         />
-        <select
-          className="cw-sched-unit"
+        <Select<Unit>
           value={state.unit}
-          onChange={(e) => update({ unit: e.target.value as Unit })}
-        >
-          <option value="hour">{unitLabel.hour}마다 (Hourly)</option>
-          <option value="day">{unitLabel.day} (Daily)</option>
-          <option value="week">{unitLabel.week} (Weekly)</option>
-          <option value="month">{unitLabel.month} (Monthly)</option>
-          <option value="custom">{unitLabel.custom} (Custom cron)</option>
-        </select>
+          onChange={(unit) => update({ unit })}
+          options={[
+            { value: 'hour', label: `${unitLabel.hour}마다 (Hourly)` },
+            { value: 'day', label: `${unitLabel.day} (Daily)` },
+            { value: 'week', label: `${unitLabel.week} (Weekly)` },
+            { value: 'month', label: `${unitLabel.month} (Monthly)` },
+            { value: 'custom', label: `${unitLabel.custom} (Custom cron)` },
+          ]}
+          className="cw-sched-unit"
+          triggerClassName="cw-sched-select"
+          ariaLabel="반복 주기 단위"
+        />
       </div>
 
       {/* Row 2: Monthly mode dropdown */}
       {state.unit === 'month' && (
         <div className="cw-sched-row">
           <span className="cw-sched-label">반복 방식</span>
-          <select
-            className="cw-sched-unit"
+          <Select
             value={state.monthlyMode === 'day' ? `day-${state.dayOfMonth}` : `wk-${state.nth}-${state.nthWeekday}`}
-            onChange={(e) => {
-              const v = e.target.value;
+            onChange={(v) => {
               if (v.startsWith('day-')) {
                 update({ monthlyMode: 'day', dayOfMonth: parseInt(v.slice(4), 10) });
               } else if (v.startsWith('wk-')) {
@@ -214,12 +216,17 @@ export function SchedulePicker({
                 update({ monthlyMode: 'weekday', nth: parseInt(nthStr, 10), nthWeekday: parseInt(wdStr, 10) });
               }
             }}
-          >
-            <option value={`day-${state.dayOfMonth}`}>매월 {state.dayOfMonth}일</option>
-            <option value={`wk-${state.nth}-${state.nthWeekday}`}>
-              매월 {NTH_NAMES[state.nth - 1] ?? `${state.nth}번째`} {WEEKDAY_NAMES[state.nthWeekday]}요일
-            </option>
-          </select>
+            options={[
+              { value: `day-${state.dayOfMonth}`, label: `매월 ${state.dayOfMonth}일` },
+              {
+                value: `wk-${state.nth}-${state.nthWeekday}`,
+                label: `매월 ${NTH_NAMES[state.nth - 1] ?? `${state.nth}번째`} ${WEEKDAY_NAMES[state.nthWeekday]}요일`,
+              },
+            ]}
+            className="cw-sched-unit"
+            triggerClassName="cw-sched-select"
+            ariaLabel="반복 방식"
+          />
         </div>
       )}
 
@@ -241,20 +248,22 @@ export function SchedulePicker({
       {state.unit === 'month' && state.monthlyMode === 'weekday' && (
         <div className="cw-sched-row">
           <span className="cw-sched-label">상세</span>
-          <select
-            className="cw-sched-unit cw-sched-unit-narrow"
+          <Select<number>
             value={state.nth}
-            onChange={(e) => update({ nth: parseInt(e.target.value, 10) })}
-          >
-            {NTH_NAMES.map((n, i) => <option key={i} value={i + 1}>{n}</option>)}
-          </select>
-          <select
+            onChange={(nth) => update({ nth })}
+            options={NTH_NAMES.map((n, i) => ({ value: i + 1, label: n }))}
             className="cw-sched-unit cw-sched-unit-narrow"
+            triggerClassName="cw-sched-select"
+            ariaLabel="몇째 주"
+          />
+          <Select<number>
             value={state.nthWeekday}
-            onChange={(e) => update({ nthWeekday: parseInt(e.target.value, 10) })}
-          >
-            {WEEKDAY_NAMES.map((d, i) => <option key={i} value={i}>{d}요일</option>)}
-          </select>
+            onChange={(nthWeekday) => update({ nthWeekday })}
+            options={WEEKDAY_NAMES.map((d, i) => ({ value: i, label: `${d}요일` }))}
+            className="cw-sched-unit cw-sched-unit-narrow"
+            triggerClassName="cw-sched-select"
+            ariaLabel="요일"
+          />
         </div>
       )}
 

--- a/app/src/components/Select.test.tsx
+++ b/app/src/components/Select.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Behavior tests for the generic <Select>. jsdom does not lay elements out
+ * (getBoundingClientRect returns zeros), so these lock in *behavior* —
+ * open/close, commit, keyboard nav, typeahead, grouping, disabled handling,
+ * dismissal, value types, a11y wiring. Pixel placement (the body portal's
+ * coordinates, viewport/container collision) is verified by Playwright e2e
+ * instead, since it needs a real layout.
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { Select, type SelectGroup, type SelectOption } from './Select';
+
+// A controlled wrapper so commits flow back into `value` (mirrors real usage)
+// while exposing the committed value via onCommit for assertions.
+function ControlledSelect<T>({
+  initial,
+  onCommit,
+  options,
+  ariaLabel = 'Picker',
+}: {
+  initial: T;
+  onCommit?: (value: T) => void;
+  options: SelectOption<T>[] | SelectGroup<T>[];
+  ariaLabel?: string;
+}) {
+  const [value, setValue] = useState<T>(initial);
+  return (
+    <Select<T>
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onCommit?.(next);
+      }}
+      options={options}
+      ariaLabel={ariaLabel}
+    />
+  );
+}
+
+const FRUITS: SelectOption<string>[] = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' },
+];
+
+const FRUITS_BANANA_DISABLED: SelectOption<string>[] = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana', disabled: true },
+  { value: 'cherry', label: 'Cherry' },
+];
+
+const GROUPED: SelectGroup<string>[] = [
+  { label: 'Claude', options: [{ value: 'opus', label: 'Opus' }, { value: 'haiku', label: 'Haiku' }] },
+  { label: 'OpenAI', options: [{ value: 'gpt', label: 'GPT' }] },
+];
+
+const NUMBERS: SelectOption<number>[] = [
+  { value: 1, label: 'One' },
+  { value: 2, label: 'Two' },
+];
+
+beforeAll(() => {
+  // The panel scrolls the focused option into view on open; jsdom has no layout
+  // engine, so stub it to a no-op (otherwise it throws "Not implemented").
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  // Portal mounts into <body>; clean it up so queries don't bleed across tests.
+  cleanup();
+});
+
+const trigger = (name = 'Picker') => screen.getByRole('button', { name });
+
+describe('Select — rendering & toggle', () => {
+  it('shows the selected option label and is closed initially', () => {
+    render(<ControlledSelect options={FRUITS} initial="apple" ariaLabel="Fruit" />);
+    expect(trigger('Fruit').textContent).toContain('Apple');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(trigger('Fruit').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('opens on click, listing every option; clicking the trigger again closes', () => {
+    render(<ControlledSelect options={FRUITS} initial="apple" ariaLabel="Fruit" />);
+    fireEvent.click(trigger('Fruit'));
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+    fireEvent.click(trigger('Fruit'));
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+});
+
+describe('Select — selection (mouse)', () => {
+  it('commits the clicked option, fires onChange, closes, and updates the trigger', () => {
+    const onCommit = vi.fn();
+    render(<ControlledSelect options={FRUITS} initial="apple" onCommit={onCommit} ariaLabel="Fruit" />);
+    fireEvent.click(trigger('Fruit'));
+    fireEvent.click(screen.getByRole('option', { name: 'Cherry' }));
+    expect(onCommit).toHaveBeenCalledWith('cherry');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(trigger('Fruit').textContent).toContain('Cherry');
+  });
+
+  it('preserves non-string (numeric) values through onChange', () => {
+    const onCommit = vi.fn();
+    render(<ControlledSelect options={NUMBERS} initial={1} onCommit={onCommit} ariaLabel="Count" />);
+    fireEvent.click(trigger('Count'));
+    fireEvent.click(screen.getByRole('option', { name: 'Two' }));
+    expect(onCommit).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('Select — keyboard', () => {
+  it('opens on ArrowDown, then ArrowDown moves focus and Enter commits', () => {
+    const onCommit = vi.fn();
+    render(<ControlledSelect options={FRUITS} initial="apple" onCommit={onCommit} ariaLabel="Fruit" />);
+    fireEvent.keyDown(trigger('Fruit'), { key: 'ArrowDown' }); // open (focus = selected)
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    fireEvent.keyDown(trigger('Fruit'), { key: 'ArrowDown' }); // move to Banana
+    fireEvent.keyDown(trigger('Fruit'), { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('banana');
+  });
+
+  it('typeahead jumps focus to the first match', () => {
+    const onCommit = vi.fn();
+    render(<ControlledSelect options={FRUITS} initial="apple" onCommit={onCommit} ariaLabel="Fruit" />);
+    fireEvent.click(trigger('Fruit'));
+    fireEvent.keyDown(trigger('Fruit'), { key: 'c' }); // -> Cherry
+    fireEvent.keyDown(trigger('Fruit'), { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('cherry');
+  });
+
+  it('Escape closes without committing', () => {
+    const onCommit = vi.fn();
+    render(<ControlledSelect options={FRUITS} initial="apple" onCommit={onCommit} ariaLabel="Fruit" />);
+    fireEvent.click(trigger('Fruit'));
+    fireEvent.keyDown(trigger('Fruit'), { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});
+
+describe('Select — disabled options', () => {
+  it('does not commit a disabled option on click and stays open', () => {
+    const onCommit = vi.fn();
+    render(<ControlledSelect options={FRUITS_BANANA_DISABLED} initial="apple" onCommit={onCommit} ariaLabel="Fruit" />);
+    fireEvent.click(trigger('Fruit'));
+    const banana = screen.getByRole('option', { name: 'Banana' });
+    expect(banana.getAttribute('aria-disabled')).toBe('true');
+    fireEvent.click(banana);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(screen.getByRole('listbox')).toBeTruthy();
+  });
+
+  it('arrow navigation skips disabled options', () => {
+    const onCommit = vi.fn();
+    render(<ControlledSelect options={FRUITS_BANANA_DISABLED} initial="apple" onCommit={onCommit} ariaLabel="Fruit" />);
+    fireEvent.keyDown(trigger('Fruit'), { key: 'ArrowDown' }); // open (focus = Apple)
+    fireEvent.keyDown(trigger('Fruit'), { key: 'ArrowDown' }); // skip disabled Banana -> Cherry
+    fireEvent.keyDown(trigger('Fruit'), { key: 'Enter' });
+    expect(onCommit).toHaveBeenCalledWith('cherry');
+  });
+});
+
+describe('Select — grouping', () => {
+  it('renders group headers and marks the panel as grouped', () => {
+    render(<ControlledSelect options={GROUPED} initial="opus" ariaLabel="Model" />);
+    fireEvent.click(trigger('Model'));
+    expect(screen.getByText('Claude')).toBeTruthy();
+    expect(screen.getByText('OpenAI')).toBeTruthy();
+    expect(screen.getByRole('listbox').className).toContain('is-grouped');
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+});
+
+describe('Select — dismissal & a11y', () => {
+  it('closes on an outside pointerdown', () => {
+    render(<ControlledSelect options={FRUITS} initial="apple" ariaLabel="Fruit" />);
+    fireEvent.click(trigger('Fruit'));
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('wires the listbox combobox aria attributes', () => {
+    render(<ControlledSelect options={FRUITS} initial="apple" ariaLabel="Fruit" />);
+    const btn = trigger('Fruit');
+    expect(btn.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(btn);
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('option', { name: 'Apple' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('option', { name: 'Banana' }).getAttribute('aria-selected')).toBe('false');
+  });
+});

--- a/app/src/components/Select.tsx
+++ b/app/src/components/Select.tsx
@@ -1,0 +1,442 @@
+import {
+  Fragment,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { Icon, type IconName } from './Icon';
+
+// A single selectable value. `label` is always a plain string so the
+// component can use it for the default render, the measurement clone, and the
+// accessible name; richer visuals go through `renderOption` / `renderTrigger`.
+export type SelectOption<T> = {
+  value: T;
+  label: string;
+  icon?: IconName;
+  // Applied to the trigger when this option is selected, and to the option
+  // row — the lever for per-value styling (e.g. ShareSelect's mode colors).
+  className?: string;
+  disabled?: boolean;
+};
+
+// Optional grouping (renders a non-interactive header above its options).
+export type SelectGroup<T> = {
+  label?: string;
+  options: SelectOption<T>[];
+};
+
+type SelectProps<T> = {
+  value: T;
+  onChange: (value: T) => void;
+  options: SelectOption<T>[] | SelectGroup<T>[];
+  // Escape hatches — override the default icon+label rendering.
+  renderTrigger?: (option: SelectOption<T>, state: { open: boolean }) => ReactNode;
+  renderOption?: (
+    option: SelectOption<T>,
+    state: { selected: boolean; focused: boolean },
+  ) => ReactNode;
+  // Extra class on the trigger button (state-dependent styling).
+  triggerClassName?: string;
+  // Transition the trigger to the *current* label's intrinsic width via a
+  // hidden measurement clone. Off by default; opt in for value-dependent
+  // widths (ShareSelect). Utility selects usually leave this off.
+  adaptiveWidth?: boolean;
+  ariaLabel?: string;
+  disabled?: boolean;
+  // Shown when `value` matches no option (defensive; consumers normally pass a
+  // value that exists in `options`).
+  placeholder?: string;
+  // Keep our trigger (styling + adaptive width) but open the *native* OS
+  // dropdown instead of our custom panel — via a transparent real <select>
+  // overlaid on the trigger. Gives native mobile pickers / OS list behavior.
+  nativeDropdown?: boolean;
+};
+
+function isGrouped<T>(
+  options: SelectOption<T>[] | SelectGroup<T>[],
+): options is SelectGroup<T>[] {
+  return options.length > 0 && 'options' in options[0];
+}
+
+export function Select<T>({
+  value,
+  onChange,
+  options,
+  renderTrigger,
+  renderOption,
+  triggerClassName = '',
+  adaptiveWidth = false,
+  ariaLabel,
+  disabled = false,
+  placeholder,
+  nativeDropdown = false,
+}: SelectProps<T>) {
+  const groups: SelectGroup<T>[] = isGrouped(options) ? options : [{ options }];
+  const flat = groups.flatMap((group) => group.options);
+  const enabledIndices = flat
+    .map((option, index) => (option.disabled ? -1 : index))
+    .filter((index) => index >= 0);
+
+  const selected = flat.find((option) => option.value === value);
+  const selectedIdx = flat.findIndex((option) => option.value === value);
+
+  const grouped = groups.some((group) => group.label);
+
+  const [open, setOpen] = useState(false);
+  const [focusIdx, setFocusIdx] = useState(() => (selectedIdx >= 0 ? selectedIdx : enabledIndices[0] ?? 0));
+  // Whether the user has navigated by keyboard since opening. Drives the
+  // keyboard focus highlight, so on open nothing is pre-highlighted (the
+  // selected row shows only its check); the highlight follows real interaction.
+  const [kbActive, setKbActive] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const panelRef = useRef<HTMLUListElement>(null);
+  const [width, setWidth] = useState<number | null>(null);
+  // Collision-aware placement: flip above the trigger when there isn't room
+  // below, and cap the panel height to the available space on the chosen side.
+  const [placement, setPlacement] = useState<{ side: 'top' | 'bottom'; maxHeight: number }>({
+    side: 'bottom',
+    maxHeight: 280,
+  });
+
+  // Stable ids so the trigger can point at the active option via
+  // aria-activedescendant (announced by screen readers without moving focus).
+  const baseId = useId();
+  const listboxId = `${baseId}-listbox`;
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
+
+  // Typeahead buffer: typing letters jumps focus to the first matching option
+  // (native <select> parity). Buffer clears after a short idle gap.
+  const typeahead = useRef<{ buffer: string; timer: number }>({ buffer: '', timer: 0 });
+
+  // Adaptive width: mirror the measurement clone's intrinsic width onto the
+  // real trigger. A ResizeObserver keeps it correct across label changes,
+  // font swaps, and locale switches without the component knowing about i18n.
+  useLayoutEffect(() => {
+    if (!adaptiveWidth || !measureRef.current) return;
+    const node = measureRef.current;
+    const apply = () => setWidth(Math.ceil(node.getBoundingClientRect().width));
+    apply();
+    const observer = new ResizeObserver(apply);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [adaptiveWidth]);
+
+  // Outside-click dismissal, mounted only while open. Keyboard lives on the
+  // trigger's onKeyDown (the trigger keeps DOM focus while open), so a document
+  // keydown listener isn't needed and would re-read the keypress that opened
+  // the panel.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [open]);
+
+  // Decide below vs above and clamp the panel height to the available space.
+  // Recomputed on open and while scrolling/resizing; keeps the same object
+  // reference when nothing changes so dependent effects don't churn.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const compute = () => {
+      const trigger = triggerRef.current;
+      const panel = panelRef.current;
+      if (!trigger || !panel) return;
+      const rect = trigger.getBoundingClientRect();
+      const margin = 8;
+      const below = window.innerHeight - rect.bottom - margin;
+      const above = rect.top - margin;
+      // Cap the height to ~N.5 rows so the last visible row is half-cut — a
+      // "there's more, scroll" hint (the MUI pattern). Row height is measured
+      // so it stays correct across font/density changes.
+      const VISIBLE_ROWS = 9;
+      const optionRow = panel.querySelector<HTMLElement>('[role=option]');
+      const rowH = optionRow ? optionRow.getBoundingClientRect().height : 28;
+      const vPad = 8; // panel padding-top + padding-bottom
+      const cap = Math.round((VISIBLE_ROWS + 0.5) * rowH + vPad);
+      // The height the panel actually wants (its content, capped).
+      const desired = Math.min(cap, panel.scrollHeight);
+      // Flip up only when it won't fit below — independent of how much room is
+      // above (mirrors a native <select>'s "open downward unless it can't").
+      const side: 'top' | 'bottom' = below < desired ? 'top' : 'bottom';
+      const maxHeight = Math.max(120, Math.min(cap, side === 'top' ? above : below));
+      setPlacement((prev) =>
+        prev.side === side && prev.maxHeight === maxHeight ? prev : { side, maxHeight },
+      );
+    };
+    compute();
+    window.addEventListener('resize', compute);
+    window.addEventListener('scroll', compute, true);
+    return () => {
+      window.removeEventListener('resize', compute);
+      window.removeEventListener('scroll', compute, true);
+    };
+  }, [open]);
+
+  // Keep the focused option in view as roving focus moves (and on open, so the
+  // current selection is visible even far down a long/grouped list).
+  useEffect(() => {
+    if (!open) return;
+    panelRef.current
+      ?.querySelector<HTMLElement>(`[data-idx="${focusIdx}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [open, focusIdx, placement]);
+
+  function commit(option: SelectOption<T>) {
+    if (option.disabled) return;
+    onChange(option.value);
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function openPanel() {
+    setFocusIdx(selectedIdx >= 0 && !flat[selectedIdx]?.disabled ? selectedIdx : enabledIndices[0] ?? 0);
+    setKbActive(false);
+    setOpen(true);
+  }
+
+  // Move roving focus to the next/previous enabled option, wrapping around.
+  function step(direction: 1 | -1) {
+    if (enabledIndices.length === 0) return;
+    setKbActive(true);
+    const pos = enabledIndices.indexOf(focusIdx);
+    const next = (pos + direction + enabledIndices.length) % enabledIndices.length;
+    setFocusIdx(enabledIndices[next]);
+  }
+
+  // Type-to-jump: accumulate keystrokes and focus the first enabled option
+  // whose label starts with the buffer; the buffer resets after an idle gap.
+  function typeaheadTo(char: string) {
+    setKbActive(true);
+    const ta = typeahead.current;
+    window.clearTimeout(ta.timer);
+    ta.buffer += char.toLowerCase();
+    ta.timer = window.setTimeout(() => { ta.buffer = ''; }, 600);
+    const match = enabledIndices.find((i) => flat[i].label.toLowerCase().startsWith(ta.buffer));
+    if (match != null) setFocusIdx(match);
+  }
+
+  function isTypeaheadChar(event: KeyboardEvent<HTMLButtonElement>) {
+    return event.key.length === 1 && event.key !== ' ' && !event.ctrlKey && !event.metaKey && !event.altKey;
+  }
+
+  function onTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (disabled) return;
+    if (!open) {
+      if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openPanel();
+      } else if (isTypeaheadChar(event)) {
+        openPanel();
+        typeaheadTo(event.key);
+      }
+      return;
+    }
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        step(1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        step(-1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        if (enabledIndices.length) { setKbActive(true); setFocusIdx(enabledIndices[0]); }
+        break;
+      case 'End':
+        event.preventDefault();
+        if (enabledIndices.length) { setKbActive(true); setFocusIdx(enabledIndices[enabledIndices.length - 1]); }
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        if (flat[focusIdx]) commit(flat[focusIdx]);
+        break;
+      case 'Escape':
+        event.preventDefault();
+        setOpen(false);
+        break;
+      case 'Tab':
+        setOpen(false);
+        break;
+      default:
+        if (isTypeaheadChar(event)) {
+          event.preventDefault();
+          typeaheadTo(event.key);
+        }
+    }
+  }
+
+  const triggerContent = selected
+    ? renderTrigger
+      ? renderTrigger(selected, { open })
+      : (
+        <>
+          {selected.icon && <Icon name={selected.icon} />}
+          <span>{selected.label}</span>
+        </>
+      )
+    : <span>{placeholder ?? ''}</span>;
+
+  // Same class string on the real trigger and the measurement clone, so the
+  // clone's box (padding / gap / font / border) matches and its intrinsic
+  // width is exactly what the trigger needs.
+  const triggerClass = ['cw-select', selected?.className, triggerClassName]
+    .filter(Boolean)
+    .join(' ');
+
+  // Native-dropdown mode: our visual-only trigger with a transparent real
+  // <select> overlaid on top (see the `nativeDropdown` prop).
+  if (nativeDropdown) {
+    return (
+      <div
+        ref={wrapRef}
+        className="cw-select-wrap cw-select-wrap--native"
+        style={adaptiveWidth && width != null ? { width } : undefined}
+      >
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-hidden="true"
+          className={triggerClass}
+          style={adaptiveWidth && width != null ? { width } : undefined}
+        >
+          {triggerContent}
+          <span className="cw-select-caret" aria-hidden="true" />
+        </button>
+        {adaptiveWidth && (
+          <span ref={measureRef} className={`${triggerClass} cw-select-measure`} aria-hidden="true">
+            {triggerContent}
+            <span className="cw-select-caret" aria-hidden="true" />
+          </span>
+        )}
+        <select
+          className="cw-select-native-overlay"
+          aria-label={ariaLabel}
+          disabled={disabled}
+          value={String(value)}
+          onChange={(event) => {
+            const next = flat.find((option) => String(option.value) === event.target.value);
+            if (next && !next.disabled) onChange(next.value);
+          }}
+        >
+          {groups.map((group) =>
+            group.label ? (
+              <optgroup key={group.label} label={group.label}>
+                {group.options.map((option) => (
+                  <option key={String(option.value)} value={String(option.value)} disabled={option.disabled}>
+                    {option.label}
+                  </option>
+                ))}
+              </optgroup>
+            ) : (
+              group.options.map((option) => (
+                <option key={String(option.value)} value={String(option.value)} disabled={option.disabled}>
+                  {option.label}
+                </option>
+              ))
+            ),
+          )}
+        </select>
+      </div>
+    );
+  }
+
+  let flatIdx = -1;
+
+  return (
+    <div ref={wrapRef} className="cw-select-wrap">
+      <button
+        ref={triggerRef}
+        type="button"
+        className={triggerClass}
+        style={adaptiveWidth && width != null ? { width } : undefined}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={open && flat[focusIdx] ? optionId(focusIdx) : undefined}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        onClick={() => !disabled && (open ? setOpen(false) : openPanel())}
+        onKeyDown={onTriggerKeyDown}
+      >
+        {triggerContent}
+        <span className="cw-select-caret" aria-hidden="true" />
+      </button>
+
+      {adaptiveWidth && (
+        <span ref={measureRef} className={`${triggerClass} cw-select-measure`} aria-hidden="true">
+          {triggerContent}
+          <span className="cw-select-caret" aria-hidden="true" />
+        </span>
+      )}
+
+      {open && (
+        <ul
+          ref={panelRef}
+          id={listboxId}
+          role="listbox"
+          className={`cw-select-panel ${placement.side === 'top' ? 'is-above' : 'is-below'}${grouped ? ' is-grouped' : ''}`}
+          style={{ maxHeight: placement.maxHeight }}
+          aria-label={ariaLabel}
+        >
+          {groups.map((group, groupIdx) => (
+            <Fragment key={group.label ?? groupIdx}>
+              {group.label && (
+                <li role="presentation" className="cw-select-group-label">
+                  {group.label}
+                </li>
+              )}
+              {group.options.map((option) => {
+                flatIdx += 1;
+                const idx = flatIdx;
+                const isSelected = option.value === value;
+                const isFocused = idx === focusIdx && kbActive;
+                return (
+                  <li
+                    key={String(option.value)}
+                    id={optionId(idx)}
+                    data-idx={idx}
+                    role="option"
+                    aria-selected={isSelected}
+                    aria-disabled={option.disabled || undefined}
+                    className={
+                      'cw-select-option' +
+                      (option.className ? ` ${option.className}` : '') +
+                      (isSelected ? ' is-selected' : '') +
+                      (isFocused ? ' is-focused' : '') +
+                      (option.disabled ? ' is-disabled' : '')
+                    }
+                    onMouseEnter={() => !option.disabled && setFocusIdx(idx)}
+                    onClick={() => commit(option)}
+                  >
+                    {renderOption
+                      ? renderOption(option, { selected: isSelected, focused: isFocused })
+                      : (
+                        <>
+                          {option.icon && <Icon name={option.icon} />}
+                          <span>{option.label}</span>
+                          {isSelected && (
+                            <span className="cw-select-check" aria-hidden="true">✓</span>
+                          )}
+                        </>
+                      )}
+                  </li>
+                );
+              })}
+            </Fragment>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/Select.tsx
+++ b/app/src/components/Select.tsx
@@ -41,6 +41,9 @@ type SelectProps<T> = {
   ) => ReactNode;
   // Extra class on the trigger button (state-dependent styling).
   triggerClassName?: string;
+  // Extra class on the wrapper — use to size the select as a flex/grid item
+  // (the trigger sizing/look goes on triggerClassName).
+  className?: string;
   // Transition the trigger to the *current* label's intrinsic width via a
   // hidden measurement clone. Off by default; opt in for value-dependent
   // widths (ShareSelect). Utility selects usually leave this off.
@@ -69,6 +72,7 @@ export function Select<T>({
   renderTrigger,
   renderOption,
   triggerClassName = '',
+  className = '',
   adaptiveWidth = false,
   ariaLabel,
   disabled = false,
@@ -300,7 +304,7 @@ export function Select<T>({
     return (
       <div
         ref={wrapRef}
-        className="cw-select-wrap cw-select-wrap--native"
+        className={`cw-select-wrap cw-select-wrap--native ${className}`.trim()}
         style={adaptiveWidth && width != null ? { width } : undefined}
       >
         <button
@@ -354,7 +358,7 @@ export function Select<T>({
   let flatIdx = -1;
 
   return (
-    <div ref={wrapRef} className="cw-select-wrap">
+    <div ref={wrapRef} className={`cw-select-wrap ${className}`.trim()}>
       <button
         ref={triggerRef}
         type="button"

--- a/app/src/components/Select.tsx
+++ b/app/src/components/Select.tsx
@@ -8,6 +8,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { Icon, type IconName } from './Icon';
 
 // A single selectable value. `label` is always a plain string so the
@@ -57,6 +58,13 @@ type SelectProps<T> = {
   // dropdown instead of our custom panel — via a transparent real <select>
   // overlaid on the trigger. Gives native mobile pickers / OS list behavior.
   nativeDropdown?: boolean;
+  // CSS selector for the ancestor the panel is kept *inside* (in addition to
+  // the viewport). The panel is portaled to <body> so it's never clipped, but
+  // by default it's only collision-corrected against the viewport — which lets
+  // it spill across a pane boundary (e.g. a session dropdown drifting over the
+  // members column). Pass a selector (matched via trigger.closest) to confine
+  // it to that container instead. Omitted → viewport only.
+  boundary?: string;
 };
 
 function isGrouped<T>(
@@ -78,6 +86,7 @@ export function Select<T>({
   disabled = false,
   placeholder,
   nativeDropdown = false,
+  boundary,
 }: SelectProps<T>) {
   const groups: SelectGroup<T>[] = isGrouped(options) ? options : [{ options }];
   const flat = groups.flatMap((group) => group.options);
@@ -101,12 +110,17 @@ export function Select<T>({
   const measureRef = useRef<HTMLSpanElement>(null);
   const panelRef = useRef<HTMLUListElement>(null);
   const [width, setWidth] = useState<number | null>(null);
-  // Collision-aware placement: flip above the trigger when there isn't room
-  // below, and cap the panel height to the available space on the chosen side.
-  const [placement, setPlacement] = useState<{ side: 'top' | 'bottom'; maxHeight: number }>({
-    side: 'bottom',
-    maxHeight: 280,
-  });
+  // Collision-aware placement for the body-portaled panel. The panel is
+  // position:fixed, so we compute its viewport coordinates here: flip above
+  // when there's no room below, shift left when it would overrun the right
+  // edge, and cap the height to the available space on the chosen side.
+  const [placement, setPlacement] = useState<{
+    side: 'top' | 'bottom';
+    top: number;
+    left: number;
+    minWidth: number;
+    maxHeight: number;
+  }>({ side: 'bottom', top: -9999, left: -9999, minWidth: 0, maxHeight: 280 });
 
   // Stable ids so the trigger can point at the active option via
   // aria-activedescendant (announced by screen readers without moving focus).
@@ -138,15 +152,19 @@ export function Select<T>({
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: MouseEvent) => {
-      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      // The panel is portaled to <body>, so it's outside wrapRef — check both.
+      if (!wrapRef.current?.contains(target) && !panelRef.current?.contains(target)) {
+        setOpen(false);
+      }
     };
     document.addEventListener('mousedown', onPointerDown);
     return () => document.removeEventListener('mousedown', onPointerDown);
   }, [open]);
 
-  // Decide below vs above and clamp the panel height to the available space.
-  // Recomputed on open and while scrolling/resizing; keeps the same object
-  // reference when nothing changes so dependent effects don't churn.
+  // Position the body-portaled panel in the viewport. Recomputed on open and
+  // while scrolling/resizing so it stays glued to the trigger; keeps the same
+  // object reference when nothing changes so dependent effects don't churn.
   useLayoutEffect(() => {
     if (!open) return;
     const compute = () => {
@@ -154,9 +172,29 @@ export function Select<T>({
       const panel = panelRef.current;
       if (!trigger || !panel) return;
       const rect = trigger.getBoundingClientRect();
-      const margin = 8;
-      const below = window.innerHeight - rect.bottom - margin;
-      const above = rect.top - margin;
+      const margin = 8; // keep this far from the box edges
+      const gap = 6; // space between trigger and panel
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      // Collision box = viewport, intersected with the boundary container (if
+      // any) so the panel stays inside its pane instead of drifting across it.
+      // Each edge is inset by `margin` for breathing room.
+      let boxLeft = margin;
+      let boxRight = vw - margin;
+      let boxTop = margin;
+      let boxBottom = vh - margin;
+      if (boundary) {
+        const container = trigger.closest(boundary);
+        if (container) {
+          const b = container.getBoundingClientRect();
+          boxLeft = Math.max(boxLeft, b.left + margin);
+          boxRight = Math.min(boxRight, b.right - margin);
+          boxTop = Math.max(boxTop, b.top + margin);
+          boxBottom = Math.min(boxBottom, b.bottom - margin);
+        }
+      }
+      const below = boxBottom - rect.bottom;
+      const above = rect.top - boxTop;
       // Cap the height to ~N.5 rows so the last visible row is half-cut — a
       // "there's more, scroll" hint (the MUI pattern). Row height is measured
       // so it stays correct across font/density changes.
@@ -167,12 +205,28 @@ export function Select<T>({
       const cap = Math.round((VISIBLE_ROWS + 0.5) * rowH + vPad);
       // The height the panel actually wants (its content, capped).
       const desired = Math.min(cap, panel.scrollHeight);
-      // Flip up only when it won't fit below — independent of how much room is
-      // above (mirrors a native <select>'s "open downward unless it can't").
+      // Vertical: flip up only when it won't fit below — independent of how much
+      // room is above (mirrors a native <select>'s "open down unless it can't").
       const side: 'top' | 'bottom' = below < desired ? 'top' : 'bottom';
       const maxHeight = Math.max(120, Math.min(cap, side === 'top' ? above : below));
+      const panelH = Math.min(panel.scrollHeight, maxHeight);
+      const top = side === 'bottom'
+        ? Math.round(rect.bottom + gap)
+        : Math.round(rect.top - gap - panelH);
+      // Horizontal: align the panel's left to the trigger, but pull it back in
+      // when it would overrun the right edge (mirrors the vertical flip). The
+      // panel is ≥ the trigger width (minWidth) and may be wider for long labels.
+      const minWidth = Math.round(rect.width);
+      const panelW = Math.max(panel.getBoundingClientRect().width, rect.width);
+      let left = rect.left;
+      if (left + panelW > boxRight) left = boxRight - panelW;
+      if (left < boxLeft) left = boxLeft;
+      left = Math.round(left);
       setPlacement((prev) =>
-        prev.side === side && prev.maxHeight === maxHeight ? prev : { side, maxHeight },
+        prev.side === side && prev.top === top && prev.left === left
+        && prev.minWidth === minWidth && prev.maxHeight === maxHeight
+          ? prev
+          : { side, top, left, minWidth, maxHeight },
       );
     };
     compute();
@@ -182,7 +236,7 @@ export function Select<T>({
       window.removeEventListener('resize', compute);
       window.removeEventListener('scroll', compute, true);
     };
-  }, [open]);
+  }, [open, boundary]);
 
   // Keep the focused option in view as roving focus moves (and on open, so the
   // current selection is visible even far down a long/grouped list).
@@ -384,13 +438,18 @@ export function Select<T>({
         </span>
       )}
 
-      {open && (
+      {open && createPortal(
         <ul
           ref={panelRef}
           id={listboxId}
           role="listbox"
           className={`cw-select-panel ${placement.side === 'top' ? 'is-above' : 'is-below'}${grouped ? ' is-grouped' : ''}`}
-          style={{ maxHeight: placement.maxHeight }}
+          style={{
+            top: placement.top,
+            left: placement.left,
+            minWidth: placement.minWidth,
+            maxHeight: placement.maxHeight,
+          }}
           aria-label={ariaLabel}
         >
           {groups.map((group, groupIdx) => (
@@ -439,7 +498,8 @@ export function Select<T>({
               })}
             </Fragment>
           ))}
-        </ul>
+        </ul>,
+        document.body,
       )}
     </div>
   );

--- a/app/src/components/chat/ComposerModelPicker.tsx
+++ b/app/src/components/chat/ComposerModelPicker.tsx
@@ -3,8 +3,8 @@
 // mock for now — the selection is not yet wired to the router/dispatcher — but the
 // labels are the real provider model names, grouped by provider.
 
-import { useId } from 'react';
 import { Icon } from '@/components/Icon';
+import { Select, type SelectGroup } from '@/components/Select';
 
 export type ModelId = string;
 
@@ -46,22 +46,20 @@ export function ComposerModelPicker({
   value: ModelId;
   onChange: (id: ModelId) => void;
 }) {
-  const selectId = useId();
+  const options: SelectGroup<ModelId>[] = PROVIDER_MODELS.map((group) => ({
+    label: group.provider,
+    options: group.models.map((model) => ({ value: model.id, label: model.label })),
+  }));
   return (
     <span className="cw-model-picker" title="모델 선택 (미리보기)">
       <Icon name="sparkles" size={12} />
-      <label htmlFor={selectId} className="sr-only">모델 선택 (미리보기)</label>
-      <select id={selectId} value={value} onChange={(event) => onChange(event.target.value)}>
-        {PROVIDER_MODELS.map((group) => (
-          <optgroup key={group.provider} label={group.provider}>
-            {group.models.map((model) => (
-              <option key={model.id} value={model.id}>
-                {model.label}
-              </option>
-            ))}
-          </optgroup>
-        ))}
-      </select>
+      <Select
+        value={value}
+        onChange={onChange}
+        options={options}
+        triggerClassName="cw-model-picker-trigger"
+        ariaLabel="모델 선택 (미리보기)"
+      />
     </span>
   );
 }

--- a/app/src/components/uiPrimitives.tsx
+++ b/app/src/components/uiPrimitives.tsx
@@ -89,37 +89,19 @@ export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mo
     }
   }, [mode, t]);
 
-  // Outside-click + global keyboard handlers, only mounted while open.
+  // Outside-click dismissal, only mounted while open. Keyboard is handled on
+  // the trigger's onKeyDown (see below) — the trigger keeps DOM focus while
+  // the panel is open, so a document keydown listener isn't needed and would
+  // re-read the very keypress that opened the panel (it's attached by this
+  // effect mid-event), closing it again on Enter.
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: MouseEvent) => {
       if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
     };
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        setOpen(false);
-        triggerRef.current?.focus();
-      } else if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        setFocusIdx((i) => (i + 1) % SHARE_MODES.length);
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        setFocusIdx((i) => (i - 1 + SHARE_MODES.length) % SHARE_MODES.length);
-      } else if (event.key === 'Enter') {
-        event.preventDefault();
-        commit(SHARE_MODES[focusIdx]);
-      }
-    };
     document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-    // `commit` is a stable closure here; effect re-binds per focusIdx so Enter targets the right row.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, focusIdx]);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [open]);
 
   function commit(next: ShareMode) {
     onChange(next);
@@ -135,10 +117,40 @@ export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mo
   }
 
   function onTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
-    if (!open && (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ')) {
-      event.preventDefault();
-      setFocusIdx(SHARE_MODES.indexOf(mode));
-      setOpen(true);
+    if (!open) {
+      // Closed: open on Enter / Space / ArrowDown, focusing the current mode.
+      if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        setFocusIdx(SHARE_MODES.indexOf(mode));
+        setOpen(true);
+      }
+      return;
+    }
+    // Open: navigate / commit / dismiss. Handled here rather than on a
+    // document listener so the keydown that opened the panel can't be
+    // re-read and immediately close it.
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setFocusIdx((i) => (i + 1) % SHARE_MODES.length);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setFocusIdx((i) => (i - 1 + SHARE_MODES.length) % SHARE_MODES.length);
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        commit(SHARE_MODES[focusIdx]);
+        break;
+      case 'Escape':
+        event.preventDefault();
+        setOpen(false);
+        break;
+      case 'Tab':
+        // Let focus move naturally, but don't leave an orphaned open panel.
+        setOpen(false);
+        break;
     }
   }
 

--- a/app/src/components/uiPrimitives.tsx
+++ b/app/src/components/uiPrimitives.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useLayoutEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, type IconName } from './Icon';
+import { Select } from './Select';
 import { shareMeta } from '../domain/metadata';
 import type { ShareMode, User } from '../domain/types';
 
@@ -73,131 +74,23 @@ export function SharePill({ mode, compact = false }: { mode: ShareMode; compact?
 
 export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mode: ShareMode) => void }) {
   const { t } = useTranslation('common');
-  const [open, setOpen] = useState(false);
-  const [focusIdx, setFocusIdx] = useState(() => SHARE_MODES.indexOf(mode));
-  const wrapRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const measureRef = useRef<HTMLSpanElement>(null);
-  const [width, setWidth] = useState<number | null>(null);
-
-  // Re-measure when the visible label or its language changes. The hidden
-  // .cw-share-select-measure clone shares the trigger's box styling, so its
-  // intrinsic width is the value the real trigger should transition to.
-  useLayoutEffect(() => {
-    if (measureRef.current) {
-      setWidth(Math.ceil(measureRef.current.getBoundingClientRect().width));
-    }
-  }, [mode, t]);
-
-  // Outside-click dismissal, only mounted while open. Keyboard is handled on
-  // the trigger's onKeyDown (see below) — the trigger keeps DOM focus while
-  // the panel is open, so a document keydown listener isn't needed and would
-  // re-read the very keypress that opened the panel (it's attached by this
-  // effect mid-event), closing it again on Enter.
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: MouseEvent) => {
-      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onPointerDown);
-    return () => document.removeEventListener('mousedown', onPointerDown);
-  }, [open]);
-
-  function commit(next: ShareMode) {
-    onChange(next);
-    setOpen(false);
-    triggerRef.current?.focus();
-  }
-
-  function toggle() {
-    setOpen((wasOpen) => {
-      if (!wasOpen) setFocusIdx(SHARE_MODES.indexOf(mode));
-      return !wasOpen;
-    });
-  }
-
-  function onTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
-    if (!open) {
-      // Closed: open on Enter / Space / ArrowDown, focusing the current mode.
-      if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        setFocusIdx(SHARE_MODES.indexOf(mode));
-        setOpen(true);
-      }
-      return;
-    }
-    // Open: navigate / commit / dismiss. Handled here rather than on a
-    // document listener so the keydown that opened the panel can't be
-    // re-read and immediately close it.
-    switch (event.key) {
-      case 'ArrowDown':
-        event.preventDefault();
-        setFocusIdx((i) => (i + 1) % SHARE_MODES.length);
-        break;
-      case 'ArrowUp':
-        event.preventDefault();
-        setFocusIdx((i) => (i - 1 + SHARE_MODES.length) % SHARE_MODES.length);
-        break;
-      case 'Enter':
-      case ' ':
-        event.preventDefault();
-        commit(SHARE_MODES[focusIdx]);
-        break;
-      case 'Escape':
-        event.preventDefault();
-        setOpen(false);
-        break;
-      case 'Tab':
-        // Let focus move naturally, but don't leave an orphaned open panel.
-        setOpen(false);
-        break;
-    }
-  }
-
+  // Domain config only — all dropdown behavior lives in <Select>. The per-mode
+  // `className` drives the trigger's share-mode color (see .cw-share-trigger.*),
+  // and `cw-share-trigger` gives it the pill-chip shape.
+  const options = SHARE_MODES.map((m) => ({
+    value: m,
+    label: t(`share.${m}.label`),
+    icon: shareMeta[m].icon,
+    className: shareMeta[m].className,
+  }));
   return (
-    <div ref={wrapRef} className="cw-share-select-wrap">
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`cw-share-select ${shareMeta[mode].className}`}
-        style={width != null ? { width } : undefined}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={toggle}
-        onKeyDown={onTriggerKeyDown}
-      >
-        <Icon name={shareMeta[mode].icon} />
-        <span>{t(`share.${mode}.label`)}</span>
-        <span className="cw-share-select-caret" aria-hidden="true" />
-      </button>
-      <span ref={measureRef} className="cw-share-select cw-share-select-measure" aria-hidden="true">
-        <Icon name={shareMeta[mode].icon} />
-        <span>{t(`share.${mode}.label`)}</span>
-        <span className="cw-share-select-caret" aria-hidden="true" />
-      </span>
-      {open && (
-        <ul role="listbox" className="cw-share-select-panel">
-          {SHARE_MODES.map((key, idx) => (
-            <li
-              key={key}
-              role="option"
-              aria-selected={key === mode}
-              className={
-                'cw-share-select-option' +
-                (key === mode ? ' is-selected' : '') +
-                (idx === focusIdx ? ' is-focused' : '')
-              }
-              onMouseEnter={() => setFocusIdx(idx)}
-              onClick={() => commit(key)}
-            >
-              <Icon name={shareMeta[key].icon} />
-              <span>{t(`share.${key}.label`)}</span>
-              {key === mode && <span className="cw-share-select-check" aria-hidden="true">✓</span>}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
+    <Select
+      value={mode}
+      onChange={onChange}
+      options={options}
+      triggerClassName="cw-share-trigger"
+      adaptiveWidth
+    />
   );
 }
 

--- a/app/src/components/uiPrimitives.tsx
+++ b/app/src/components/uiPrimitives.tsx
@@ -1,8 +1,10 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, type IconName } from './Icon';
 import { shareMeta } from '../domain/metadata';
 import type { ShareMode, User } from '../domain/types';
+
+const SHARE_MODES = Object.keys(shareMeta) as ShareMode[];
 
 export function EmptyState({
   title,
@@ -71,15 +73,120 @@ export function SharePill({ mode, compact = false }: { mode: ShareMode; compact?
 
 export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mode: ShareMode) => void }) {
   const { t } = useTranslation('common');
+  const [open, setOpen] = useState(false);
+  const [focusIdx, setFocusIdx] = useState(() => SHARE_MODES.indexOf(mode));
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const [width, setWidth] = useState<number | null>(null);
+
+  // Re-measure when the visible label or its language changes. The hidden
+  // .cw-share-select-measure clone shares the trigger's box styling, so its
+  // intrinsic width is the value the real trigger should transition to.
+  useLayoutEffect(() => {
+    if (measureRef.current) {
+      setWidth(Math.ceil(measureRef.current.getBoundingClientRect().width));
+    }
+  }, [mode, t]);
+
+  // Outside-click + global keyboard handlers, only mounted while open.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+      } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setFocusIdx((i) => (i + 1) % SHARE_MODES.length);
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setFocusIdx((i) => (i - 1 + SHARE_MODES.length) % SHARE_MODES.length);
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        commit(SHARE_MODES[focusIdx]);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+    // commit is defined in the closure and depends on `mode`/`onChange`; the
+    // effect re-binds on every focusIdx change so Enter targets the right row.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, focusIdx]);
+
+  function commit(next: ShareMode) {
+    onChange(next);
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function toggle() {
+    setOpen((wasOpen) => {
+      if (!wasOpen) setFocusIdx(SHARE_MODES.indexOf(mode));
+      return !wasOpen;
+    });
+  }
+
+  function onTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (!open && (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ')) {
+      event.preventDefault();
+      setFocusIdx(SHARE_MODES.indexOf(mode));
+      setOpen(true);
+    }
+  }
+
   return (
-    <label className={`cw-share-select ${shareMeta[mode].className}`}>
-      <Icon name={shareMeta[mode].icon} />
-      <select value={mode} onChange={(event) => onChange(event.target.value as ShareMode)}>
-        {(Object.keys(shareMeta) as ShareMode[]).map((key) => (
-          <option key={key} value={key}>{t(`share.${key}.label`)}</option>
-        ))}
-      </select>
-    </label>
+    <div ref={wrapRef} className="cw-share-select-wrap">
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`cw-share-select ${shareMeta[mode].className}`}
+        style={width != null ? { width } : undefined}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={toggle}
+        onKeyDown={onTriggerKeyDown}
+      >
+        <Icon name={shareMeta[mode].icon} />
+        <span>{t(`share.${mode}.label`)}</span>
+        <span className="cw-share-select-caret" aria-hidden="true" />
+      </button>
+      <span ref={measureRef} className="cw-share-select cw-share-select-measure" aria-hidden="true">
+        <Icon name={shareMeta[mode].icon} />
+        <span>{t(`share.${mode}.label`)}</span>
+        <span className="cw-share-select-caret" aria-hidden="true" />
+      </span>
+      {open && (
+        <ul role="listbox" className="cw-share-select-panel">
+          {SHARE_MODES.map((key, idx) => (
+            <li
+              key={key}
+              role="option"
+              aria-selected={key === mode}
+              className={
+                'cw-share-select-option' +
+                (key === mode ? ' is-selected' : '') +
+                (idx === focusIdx ? ' is-focused' : '')
+              }
+              onMouseMove={() => setFocusIdx(idx)}
+              onClick={() => commit(key)}
+            >
+              <Icon name={shareMeta[key].icon} />
+              <span>{t(`share.${key}.label`)}</span>
+              {key === mode && <span className="cw-share-select-check" aria-hidden="true">✓</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 

--- a/app/src/components/uiPrimitives.tsx
+++ b/app/src/components/uiPrimitives.tsx
@@ -90,6 +90,9 @@ export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mo
       options={options}
       triggerClassName="cw-share-trigger"
       adaptiveWidth
+      // The share dropdown belongs to the session — keep its panel inside the
+      // chat surface so it doesn't drift over the adjacent members column.
+      boundary=".cw-chat-surface"
     />
   );
 }

--- a/app/src/components/uiPrimitives.tsx
+++ b/app/src/components/uiPrimitives.tsx
@@ -117,8 +117,7 @@ export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mo
       document.removeEventListener('mousedown', onPointerDown);
       document.removeEventListener('keydown', onKeyDown);
     };
-    // commit is defined in the closure and depends on `mode`/`onChange`; the
-    // effect re-binds on every focusIdx change so Enter targets the right row.
+    // `commit` is a stable closure here; effect re-binds per focusIdx so Enter targets the right row.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, focusIdx]);
 
@@ -176,7 +175,7 @@ export function ShareSelect({ mode, onChange }: { mode: ShareMode; onChange: (mo
                 (key === mode ? ' is-selected' : '') +
                 (idx === focusIdx ? ' is-focused' : '')
               }
-              onMouseMove={() => setFocusIdx(idx)}
+              onMouseEnter={() => setFocusIdx(idx)}
               onClick={() => commit(key)}
             >
               <Icon name={shareMeta[key].icon} />

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Icon } from '@/components/Icon';
 import { IconButton } from '@/components/uiPrimitives';
+import { Select } from '@/components/Select';
 import { MarkdownRenderer } from '@/components/chat/MarkdownRenderer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { summarizeCron } from '@/components/SchedulePicker';
@@ -841,9 +842,7 @@ function FilterSelect<T extends string>({
   return (
     <label className="cw-runs-filter">
       <span>{label}</span>
-      <select value={value} onChange={(e) => onChange(e.target.value as T)}>
-        {options.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-      </select>
+      <Select value={value} onChange={onChange} options={options} triggerClassName="cw-runs-filter-trigger" ariaLabel={label} />
     </label>
   );
 }

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -839,11 +839,15 @@ function FilterSelect<T extends string>({
   onChange: (v: T) => void;
   options: FilterOption<T>[];
 }) {
+  // Not a <label>: a <label> wrapping the Select's trigger <button> re-dispatches
+  // real (trusted) clicks to that button, so picking an option (which closes the
+  // panel) re-fires the trigger and reopens it. The accessible name comes from
+  // the Select's ariaLabel instead.
   return (
-    <label className="cw-runs-filter">
+    <span className="cw-runs-filter">
       <span>{label}</span>
       <Select value={value} onChange={onChange} options={options} triggerClassName="cw-runs-filter-trigger" ariaLabel={label} />
-    </label>
+    </span>
   );
 }
 

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -835,9 +835,12 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 }
 
 .cw-select-panel {
-  position: absolute;
-  left: 0;
-  min-width: 100%;
+  /* Portaled to <body> and pinned to the trigger in viewport coords (top/left/
+     min-width/max-height set inline by Select.tsx). Fixed positioning frees it
+     from any overflow:hidden / transformed ancestor that used to clip or shove
+     the surrounding layout. */
+  position: fixed;
+  max-width: calc(100vw - 16px);
   max-height: 280px;
   overflow-y: auto;
   list-style: none;
@@ -849,7 +852,9 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   border: 1px solid var(--cw-border);
   border-radius: 8px;
   box-shadow: 0 8px 20px rgba(40, 30, 20, 0.08);
-  z-index: 50;
+  /* Above the dialog backdrop (70) so a Select used inside a dialog still
+     overlays it; below toast/tooltip-tier layers. */
+  z-index: 90;
   /* A dropdown is a control, not document text — don't let rows be drag-selected.
      The -webkit- prefix is required for Safari < 16.4. */
   -webkit-user-select: none;
@@ -858,14 +863,13 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
      including group headers — never show the I-beam. */
   cursor: default;
 }
-/* Placement: below the trigger by default, flipped above when there isn't
-   room below (computed in JS, mirrors what a native <select> does). */
+/* Placement direction (below by default, flipped above when there's no room) is
+   computed in JS and applied via top/left inline; the class only selects the
+   matching open animation. */
 .cw-select-panel.is-below {
-  top: calc(100% + 6px);
   animation: cw-select-pop-down 90ms ease-out;
 }
 .cw-select-panel.is-above {
-  bottom: calc(100% + 6px);
   animation: cw-select-pop-up 90ms ease-out;
 }
 @keyframes cw-select-pop-down {

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -517,11 +517,10 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
 .cw-file-folder { background: oklch(0.96 0.018 150); color: var(--cw-icon-recap); }
 .cw-file-sheet { background: oklch(0.96 0.018 150); color: var(--cw-cozy-sage); }
 .cw-file-image { background: oklch(0.965 0.018 45); color: var(--cw-cozy-clay); }
-.cw-share-pill, .cw-share-select { display: inline-flex; align-items: center; gap: 6px; min-height: 30px; border-radius: var(--cw-radius-full); border: 1px solid var(--cw-border); background: var(--cw-bg); color: var(--cw-fg-2); padding: 4px 9px; font-size: 12px; }
-.cw-share-select select { border: 0; outline: 0; background: transparent; color: inherit; }
-.cw-share-pill.private, .cw-share-select.private { background: var(--cw-share-private-bg); border-color: var(--cw-share-private-border); color: var(--cw-share-private-fg); }
-.cw-share-pill.readonly, .cw-share-select.readonly { background: var(--cw-share-readonly-bg); border-color: var(--cw-share-readonly-border); color: var(--cw-share-readonly-fg); }
-.cw-share-pill.chat, .cw-share-select.chat { background: var(--cw-share-chat-bg); border-color: var(--cw-share-chat-border); color: var(--cw-share-chat-fg); }
+.cw-share-pill { display: inline-flex; align-items: center; gap: 6px; min-height: 30px; border-radius: var(--cw-radius-full); border: 1px solid var(--cw-border); background: var(--cw-bg); color: var(--cw-fg-2); padding: 4px 9px; font-size: 12px; }
+.cw-share-pill.private { background: var(--cw-share-private-bg); border-color: var(--cw-share-private-border); color: var(--cw-share-private-fg); }
+.cw-share-pill.readonly { background: var(--cw-share-readonly-bg); border-color: var(--cw-share-readonly-border); color: var(--cw-share-readonly-fg); }
+.cw-share-pill.chat { background: var(--cw-share-chat-bg); border-color: var(--cw-share-chat-border); color: var(--cw-share-chat-fg); }
 .cw-avatar-app { display: inline-grid; place-items: center; width: 30px; height: 30px; border-radius: var(--cw-radius-full); color: white; font-size: 10px; font-weight: 700; flex: 0 0 auto; }
 .cw-avatar-app.small { width: 22px; height: 22px; font-size: 9px; }
 .cw-avatar-stack { display: inline-flex; align-items: center; }
@@ -730,8 +729,7 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   background: var(--cw-paper-3);
   color: var(--cw-ink-3);
 }
-.cw-share-pill,
-.cw-share-select {
+.cw-share-pill {
   min-height: 20px;
   padding: 2px 8px 2px 7px;
   gap: 5px;
@@ -741,16 +739,55 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
 }
 
 /* ─────────────────────────────────────────────────────────────────
-   ShareSelect — custom dropdown (replaces native <select>)
-   - trigger width transitions to the *current* label's intrinsic
-     width via a hidden measurement clone (.cw-share-select-measure)
-   - panel is positioned absolutely below; min-width: 100% keeps it
-     at least as wide as the trigger
+   Select — generic custom dropdown (button trigger + listbox panel).
+   Behavior/structure only; each consumer styles its own trigger via a
+   class passed to <Select triggerClassName>. No colors baked in here.
+   - adaptiveWidth transitions the trigger to the current label's
+     intrinsic width via a hidden measurement clone (.cw-select-measure)
+   - panel is positioned below; min-width: 100% keeps it ≥ the trigger
    ───────────────────────────────────────────────────────────────── */
-.cw-share-select-wrap { position: relative; display: inline-block; }
+.cw-select-wrap {
+  position: relative;
+  display: inline-block;
+  /* A select is a control, not document text — never drag-select it.
+     The -webkit- prefix is required for Safari < 16.4. */
+  -webkit-user-select: none;
+  user-select: none;
+}
 
-button.cw-share-select {
-  cursor: pointer;
+/* Native-dropdown mode: a transparent real <select> overlays our (visual-only)
+   trigger, so the OS draws the dropdown while our trigger keeps its look. */
+.cw-select-wrap--native > button { pointer-events: none; }
+.cw-select-native-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  /* Stop the <select>'s intrinsic (longest-option) width from leaking into the
+     inline-block wrapper's auto size, which would defeat the adaptive trigger. */
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  font: inherit;
+  cursor: default;
+}
+.cw-select-wrap--native:focus-within > button {
+  outline: 2px solid var(--cw-accent);
+  outline-offset: 2px;
+}
+
+/* Layout shared by the trigger button AND the measurement clone <span>, so
+   their boxes match. Element-qualified rules below are button-only. */
+.cw-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+button.cw-select {
+  /* Default arrow cursor, like a native <select> trigger. */
+  cursor: default;
   font-family: inherit;
   /* Keep the label on one line while the width transition runs;
      without this the text wraps to two lines for a few frames. */
@@ -761,14 +798,15 @@ button.cw-share-select {
               color 150ms ease-out,
               border-color 150ms ease-out;
 }
-button.cw-share-select:focus-visible {
+button.cw-select:disabled { cursor: not-allowed; opacity: 0.55; }
+button.cw-select:focus-visible {
   outline: 2px solid var(--cw-accent);
   outline-offset: 2px;
 }
-.cw-share-select > span { display: inline-flex; align-items: center; }
+.cw-select > span { display: inline-flex; align-items: center; }
 
 /* CSS border-triangle caret — font-independent, currentColor aware. */
-.cw-share-select-caret {
+.cw-select-caret {
   display: inline-block;
   width: 0; height: 0;
   margin-left: 4px;
@@ -778,7 +816,7 @@ button.cw-share-select:focus-visible {
   opacity: 0.65;
   transform: translateY(1px);
 }
-button.cw-share-select[aria-expanded="true"] .cw-share-select-caret {
+button.cw-select[aria-expanded="true"] .cw-select-caret {
   border-top: 0;
   border-bottom: 5px solid currentColor;
   transform: translateY(-1px);
@@ -786,7 +824,7 @@ button.cw-share-select[aria-expanded="true"] .cw-share-select-caret {
 
 /* Measurement clone — same box as the trigger so its intrinsic width
    is the value the real button should be set to. */
-.cw-share-select-measure {
+.cw-select-measure {
   position: absolute !important;
   left: -9999px !important;
   top: 0 !important;
@@ -796,43 +834,117 @@ button.cw-share-select[aria-expanded="true"] .cw-share-select-caret {
   width: max-content !important;
 }
 
-.cw-share-select-panel {
+.cw-select-panel {
   position: absolute;
-  top: calc(100% + 6px);
   left: 0;
   min-width: 100%;
+  max-height: 280px;
+  overflow-y: auto;
   list-style: none;
   margin: 0;
-  padding: 4px;
+  /* Horizontal padding insets each row, so the hover/selection highlight is a
+     rounded bar with a margin from the panel edge (not full-bleed). */
+  padding: 4px 6px;
   background: var(--cw-bg);
   border: 1px solid var(--cw-border);
   border-radius: 8px;
   box-shadow: 0 8px 20px rgba(40, 30, 20, 0.08);
   z-index: 50;
-  animation: cw-share-select-pop 90ms ease-out;
+  /* A dropdown is a control, not document text — don't let rows be drag-selected.
+     The -webkit- prefix is required for Safari < 16.4. */
+  -webkit-user-select: none;
+  user-select: none;
+  /* Default arrow cursor everywhere inside (cursor inherits), so text rows —
+     including group headers — never show the I-beam. */
+  cursor: default;
 }
-@keyframes cw-share-select-pop {
+/* Placement: below the trigger by default, flipped above when there isn't
+   room below (computed in JS, mirrors what a native <select> does). */
+.cw-select-panel.is-below {
+  top: calc(100% + 6px);
+  animation: cw-select-pop-down 90ms ease-out;
+}
+.cw-select-panel.is-above {
+  bottom: calc(100% + 6px);
+  animation: cw-select-pop-up 90ms ease-out;
+}
+@keyframes cw-select-pop-down {
   from { opacity: 0; transform: translateY(-2px); }
   to   { opacity: 1; transform: translateY(0); }
 }
-
-.cw-share-select-option {
-  display: flex; align-items: center; gap: 8px;
-  padding: 6px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-  white-space: nowrap;
-  font-size: 12px;
-  color: var(--cw-fg-2);
+@keyframes cw-select-pop-up {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
-.cw-share-select-option:hover,
-.cw-share-select-option.is-focused { background: var(--cw-bg-subtle); }
-.cw-share-select-option.is-selected { font-weight: 600; color: var(--cw-fg-1); }
-.cw-share-select-check {
+
+/* Group header: a subtle, medium-grey label (matching a native macOS dropdown
+   <optgroup>), with its options indented beneath to convey the hierarchy.
+   Sticks to the top while its options scroll under it. */
+.cw-select-group-label {
+  position: sticky;
+  top: -4px;
+  padding: 6px 12px 2px;
+  background: var(--cw-bg);
+  /* Same size and weight as an option row; only the light grey sets it apart. */
+  font-size: 13px;
+  font-weight: 400;
+  /* Very light grey (same as a disabled option) — a quiet section label. */
+  color: oklch(0.72 0.006 60);
+}
+/* Indent options under a group header to show the hierarchy (native parity). */
+.cw-select-panel.is-grouped .cw-select-option { padding-left: 26px; }
+
+.cw-select-option {
+  display: flex; align-items: center; gap: 7px;
+  /* Tight rows; border-radius makes the inset hover/selection bar rounded. */
+  padding: 4px 10px;
+  border-radius: 7px;
+  /* Default arrow cursor throughout the dropdown (like a native list). */
+  cursor: default;
+  white-space: nowrap;
+  font-size: 13px;
+  /* Strong, near-ink text so a disabled (grey) row clearly stands apart. */
+  color: var(--cw-fg-1, var(--cw-ink));
+}
+/* Only the hovered / keyboard-navigated row gets a background — a solid accent
+   bar with white text. The selected value is marked by the check alone (no
+   background), so "what's selected" (state) and "what's under the cursor"
+   (interaction) stay visually separate. */
+.cw-select-option:hover,
+.cw-select-option.is-focused { background: var(--cw-accent); color: #fff; }
+/* Disabled: a very light grey so it plainly reads as unavailable — crisp (no
+   opacity wash, no strikethrough), not-allowed cursor, and no hover highlight.
+   Listed after :hover so a disabled row never picks up the accent bar/text. */
+.cw-select-option.is-disabled {
+  color: oklch(0.72 0.006 60);
+}
+.cw-select-option.is-disabled:hover,
+.cw-select-option.is-disabled.is-focused { background: transparent; }
+.cw-select-check {
   margin-left: auto;
   color: var(--cw-accent);
   font-weight: 700;
 }
+/* On the highlighted row the check turns white to stay visible on the bar. */
+.cw-select-option:hover .cw-select-check,
+.cw-select-option.is-focused .cw-select-check { color: #fff; }
+
+/* ShareSelect trigger — pill chip + share-mode colors layered on the
+   generic <Select>. Domain styling lives here, not in .cw-select. */
+.cw-select.cw-share-trigger {
+  min-height: 20px;
+  padding: 2px 8px 2px 7px;
+  gap: 5px;
+  border: 1px solid var(--cw-border);
+  border-radius: var(--cw-radius-full);
+  background: var(--cw-bg);
+  color: var(--cw-fg-2);
+  font-size: 10px;
+  font-weight: 500;
+}
+.cw-select.cw-share-trigger.private { background: var(--cw-share-private-bg); border-color: var(--cw-share-private-border); color: var(--cw-share-private-fg); }
+.cw-select.cw-share-trigger.readonly { background: var(--cw-share-readonly-bg); border-color: var(--cw-share-readonly-border); color: var(--cw-share-readonly-fg); }
+.cw-select.cw-share-trigger.chat { background: var(--cw-share-chat-bg); border-color: var(--cw-share-chat-border); color: var(--cw-share-chat-fg); }
 
 .cw-file-browser {
   border-radius: 12px;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1333,7 +1333,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   padding: 0 10px;
   font-size: 12px;
 }
-.cw-model-picker select { border: 0; outline: 0; background: transparent; color: inherit; cursor: pointer; font-size: 12px; }
+.cw-model-picker-trigger { border: 0; background: transparent; color: inherit; font-size: 12px; }
 
 /* Project home — "new conversation" surface */
 .cw-project-hero.is-slim { align-items: center; padding-bottom: var(--cw-space-4); margin-bottom: var(--cw-space-5); }
@@ -3270,7 +3270,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   font-size: 12px;
   color: var(--cw-ink-3);
 }
-.cw-runs-filter select {
+.cw-runs-filter-trigger {
   border: 1px solid var(--cw-line);
   background: var(--cw-paper-2);
   border-radius: var(--cw-radius-sm);
@@ -4014,8 +4014,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 
 /* SchedulePicker — Google Calendar-style recurrence builder. */
 .cw-schedule-picker { display: flex; flex-direction: column; gap: 10px; }
-.cw-schedule-picker input,
-.cw-schedule-picker select {
+.cw-schedule-picker input {
   border: 1px solid var(--cw-line);
   border-radius: var(--cw-radius-sm);
   background: var(--cw-paper-2);
@@ -4024,12 +4023,23 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   color: var(--cw-ink);
   font-family: inherit;
 }
-.cw-schedule-picker input:focus,
-.cw-schedule-picker select:focus {
+.cw-schedule-picker input:focus {
   outline: none;
   border-color: var(--cw-accent);
   box-shadow: 0 0 0 3px var(--cw-selected-ring);
 }
+/* Schedule selects use <Select>; style its trigger like the inputs and let it
+   fill the row, with the caret pushed to the right edge. */
+.cw-sched-select {
+  width: 100%;
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-sm);
+  background: var(--cw-paper-2);
+  padding: 6px 10px;
+  font-size: 13px;
+  color: var(--cw-ink);
+}
+.cw-sched-select .cw-select-caret { margin-left: auto; }
 .cw-schedule-picker input:disabled {
   background: var(--cw-paper-3);
   color: var(--cw-ink-3);

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -740,6 +740,100 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   font-weight: 500;
 }
 
+/* ─────────────────────────────────────────────────────────────────
+   ShareSelect — custom dropdown (replaces native <select>)
+   - trigger width transitions to the *current* label's intrinsic
+     width via a hidden measurement clone (.cw-share-select-measure)
+   - panel is positioned absolutely below; min-width: 100% keeps it
+     at least as wide as the trigger
+   ───────────────────────────────────────────────────────────────── */
+.cw-share-select-wrap { position: relative; display: inline-block; }
+
+button.cw-share-select {
+  cursor: pointer;
+  font-family: inherit;
+  /* Keep the label on one line while the width transition runs;
+     without this the text wraps to two lines for a few frames. */
+  white-space: nowrap;
+  overflow: hidden;
+  transition: width 150ms ease-out,
+              background-color 150ms ease-out,
+              color 150ms ease-out,
+              border-color 150ms ease-out;
+}
+button.cw-share-select:focus-visible {
+  outline: 2px solid var(--cw-accent);
+  outline-offset: 2px;
+}
+.cw-share-select > span { display: inline-flex; align-items: center; }
+
+/* CSS border-triangle caret — font-independent, currentColor aware. */
+.cw-share-select-caret {
+  display: inline-block;
+  width: 0; height: 0;
+  margin-left: 4px;
+  border: 4px solid transparent;
+  border-top: 5px solid currentColor;
+  border-bottom: 0;
+  opacity: 0.65;
+  transform: translateY(1px);
+}
+button.cw-share-select[aria-expanded="true"] .cw-share-select-caret {
+  border-top: 0;
+  border-bottom: 5px solid currentColor;
+  transform: translateY(-1px);
+}
+
+/* Measurement clone — same box as the trigger so its intrinsic width
+   is the value the real button should be set to. */
+.cw-share-select-measure {
+  position: absolute !important;
+  left: -9999px !important;
+  top: 0 !important;
+  visibility: hidden !important;
+  pointer-events: none;
+  transition: none !important;
+  width: max-content !important;
+}
+
+.cw-share-select-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 100%;
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  background: var(--cw-bg);
+  border: 1px solid var(--cw-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(40, 30, 20, 0.08);
+  z-index: 50;
+  animation: cw-share-select-pop 90ms ease-out;
+}
+@keyframes cw-share-select-pop {
+  from { opacity: 0; transform: translateY(-2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.cw-share-select-option {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--cw-fg-2);
+}
+.cw-share-select-option:hover,
+.cw-share-select-option.is-focused { background: var(--cw-bg-subtle); }
+.cw-share-select-option.is-selected { font-weight: 600; color: var(--cw-fg-1); }
+.cw-share-select-check {
+  margin-left: auto;
+  color: var(--cw-accent);
+  font-weight: 700;
+}
+
 .cw-file-browser {
   border-radius: 12px;
   border-color: var(--cw-line);


### PR DESCRIPTION
## Summary
Extract ShareSelect's bespoke dropdown into a **reusable, app-wide `<Select>` component**, and refactor `ShareSelect` to consume it. The component keeps the *functional* core (adaptive trigger width, custom listbox, keyboard/a11y, collision-aware positioning) generic and leaves per-consumer styling open, so other "pick one value" surfaces can adopt it.

> Originally branched off `feat/i18n` (#128, now merged); rebased onto `main`. Uses `useTranslation('common')` + the `share.*` keys from there.

## Why
The native `<select>` locked the trigger to the widest option's width (a long empty tail for short labels), and its dropdown/option/disabled rendering is OS-drawn and unstyleable. ShareSelect solved this with a custom dropdown — this PR generalizes that solution so it isn't ShareSelect-only.

## `<Select>` API
```tsx
type SelectOption<T> = { value: T; label: string; icon?: IconName; className?: string; disabled?: boolean };
type SelectGroup<T>  = { label?: string; options: SelectOption<T>[] };

<Select
  value={value}
  onChange={setValue}
  options={flatOrGrouped}
  renderTrigger?   // escape hatch
  renderOption?    // escape hatch
  triggerClassName?  // per-consumer trigger look (no styling baked in)
  adaptiveWidth?     // default false
  nativeDropdown?    // default false → our panel
  boundary?          // CSS selector: confine the panel inside this ancestor
  ariaLabel? disabled? placeholder?
/>
```

## Behavior
- **Two modes, default = our panel.** `nativeDropdown` keeps our trigger but overlays a transparent real `<select>` so the **OS draws the menu** (native mobile pickers); omitted → our custom listbox panel.
- **Keyboard** handled on the trigger's `onKeyDown` (a document listener would re-read the opening keypress and close the panel): open on Enter/Space/↓; ↑/↓ wrap, skipping disabled; Home/End; **typeahead** (type-to-jump, disabled-skipping); Enter/Space commit; Esc/Tab close; outside-click dismiss.
- **State vs interaction split:** selected value shows a check only (no background); hover / keyboard-nav draws the accent bar. Nothing is pre-highlighted on open (`kbActive`).
- **Adaptive trigger width** via a hidden measurement clone + `ResizeObserver` (re-measures on label/locale change without the component knowing i18n).
- **Portaled, collision-aware panel.** The panel is portaled to `document.body` and positioned `fixed`, so an `overflow:hidden`/flex ancestor can no longer clip it or shove the surrounding layout. Placement is computed against a collision box = **`boundary` container ∩ viewport**: it flips above only when it won't fit below, shifts left when it would overrun the right edge, and caps the height to ~9.5 rows (a half-row "peek", à la MUI). `boundary` (a CSS selector matched via `trigger.closest`) keeps the panel inside a logical pane — ShareSelect confines its dropdown to the chat surface so it never drifts over the members column. Omitted → viewport only.
- **Grouped or flat options**, disabled options, non-string (e.g. numeric) values.
- **A11y:** `role=listbox/option`, `aria-haspopup/expanded/controls/activedescendant/selected/disabled`. Text is non-selectable (`-webkit-user-select` incl. Safari) with a default cursor throughout.

## ShareSelect
Now maps share modes → `<Select>` options + `triggerClassName="cw-share-trigger"` + `boundary=".cw-chat-surface"`; its pill shape and per-mode colors live in `.cw-share-trigger`. **Public API unchanged** — `<ShareSelect mode onChange />`.

## Adopters (in this PR)
All remaining native `<select>` surfaces now use `<Select>`:
- **ShareSelect** — adaptive pill + per-mode colors (custom panel), confined to the chat surface.
- **Automation runs filter** — status / trigger-kind. (Wrapper is a `<span>`, not a `<label>`: a `<label>` re-dispatches trusted clicks to the trigger `<button>`, so picking an option reopened the panel; the accessible name comes from `ariaLabel`.)
- **Composer model picker** — grouped by provider.
- **Schedule picker** — unit / monthly mode / nth / weekday (numeric + dynamic-value options); number/time/text inputs unchanged.

A `className` prop was added to `<Select>` to size the wrapper as a flex/grid item (e.g. the schedule selects fill their row). Per-consumer trigger looks live in `cw-share-trigger` / `cw-runs-filter-trigger` / `cw-model-picker-trigger` / `cw-sched-select`.

## Test plan
- [x] `pnpm lint` (tsc) clean
- [x] `pnpm test:unit` 67/67 — incl. 12 new `<Select>` behavior tests (`Select.test.tsx`: open/close, mouse + keyboard selection, typeahead, disabled skip, grouping, outside-click, numeric values, aria). Pixel placement (portal coords / collision / boundary) is left to e2e — jsdom has no layout.
- [x] `pnpm build` clean
- [x] Manual (driven via Chrome DevTools): adaptive width across labels/locales; keyboard open/nav/typeahead/Home-End/commit/Esc/Tab; outside-click; placement flip-up near viewport bottom; horizontal shift-in near the right edge; `boundary` keeps the share panel inside the chat surface (no longer spills into the members column); opening no longer shifts the session content; grouped + disabled + numeric; `nativeDropdown` opens the OS menu with our trigger; non-selectable text + default cursor; ShareSelect parity (colors, pill, all behaviors); runs filter closes on a real-mouse selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
