### PR TITLE
fix(session): copy host artifacts/inputs on fork (#139)

### DIFF
--- a/backend/src/handlers/dirent.rs
+++ b/backend/src/handlers/dirent.rs
@@ -808,7 +808,7 @@ async fn find_available_name(parent: &Path, base_name: &str) -> PathBuf {
 /// untrusted input), and any symlink encountered is skipped, so a malicious
 /// symlink planted inside the source tree cannot escape `dst`'s subtree.
 // nosemgrep: rust.actix.path-traversal.tainted-path
-async fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+pub(crate) async fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     tokio::fs::create_dir_all(dst).await?;
     let mut rd = tokio::fs::read_dir(src).await?;
     while let Some(entry) = rd.next_entry().await? {

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -19,7 +19,9 @@ use uuid::Uuid;
 use crate::{
     auth::AuthUser,
     error::{ApiResult, AppError},
-    handlers::dirent::{DirentScope, enforce_scope_access, parse_dirent_path, scope_root},
+    handlers::dirent::{
+        DirentScope, copy_dir_recursive, enforce_scope_access, parse_dirent_path, scope_root,
+    },
     model::{
         CreateSessionRequest, MessageSender, SendMessageRequest, SendMessageResponse,
         SessionListResponse, SessionMessageListResponse, SessionMessageResponse, SessionResponse,
@@ -571,10 +573,24 @@ pub async fn fork_session(
         .mark_session_read(new_id, auth_user.id)
         .await;
 
-    // Pre-create host dirs for the forked session.
+    // Mirror the source session's host files into the fork so the snapshot matches
+    // the VM upper.ext4 clone. shared/ is project-level and intentionally excluded.
+    let (src_inputs, _, src_artifacts) = session_dirs(&state, source.project_id, source_session_id);
     let (new_inputs, _, new_artifacts) = session_dirs(&state, source.project_id, new_id);
-    for d in [&new_inputs, &new_artifacts] {
-        let _ = tokio::fs::create_dir_all(d).await;
+    for (src, dst) in [(&src_inputs, &new_inputs), (&src_artifacts, &new_artifacts)] {
+        let res = if tokio::fs::try_exists(src).await.unwrap_or(false) {
+            copy_dir_recursive(src, dst).await
+        } else {
+            tokio::fs::create_dir_all(dst).await
+        };
+        if let Err(e) = res {
+            tracing::warn!(
+                source = %source_session_id,
+                fork = %new_id,
+                dir = ?dst,
+                "failed to copy session dir on fork: {e}",
+            );
+        }
     }
 
     let source_cfg = SandboxConfig {

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -482,7 +482,11 @@ pub async fn update_session(
     // [R2-4] share_mode downgrade to private: evict non-creator subscribers immediately
     // instead of waiting for Task D's 60-second poll.
     if payload.share_mode == ShareMode::Private && session.share_mode != ShareMode::Private {
-        if let Ok(members) = state.repository.list_project_members(session.project_id).await {
+        if let Ok(members) = state
+            .repository
+            .list_project_members(session.project_id)
+            .await
+        {
             for (member, _) in members {
                 if member.id == session.creator_id {
                     continue;

--- a/backend/tests/session_test.rs
+++ b/backend/tests/session_test.rs
@@ -667,6 +667,160 @@ async fn fork_readonly_member_can_fork() {
     );
 }
 
+// ── fork: fork_copies_host_files ─────────────────────────────────────────────
+
+/// Forking a session with files in `artifacts/` and `inputs/` must produce a
+/// fork whose host directories contain the same files (snapshot semantics).
+/// Subsequent changes to the source must not appear in the fork.
+#[tokio::test]
+async fn fork_copies_host_files() {
+    dotenvy::dotenv().ok();
+    common::setup_provider().await;
+
+    let (app, repo, state) = common::make_app_repo_state().await;
+
+    let alice_info = common::signup(&app, "alice", "password123").await;
+    let alice_token = common::login(&app, "alice", "password123").await;
+    let alice_project = common::get_personal_project(&app, &alice_token).await;
+    let project_id = Uuid::parse_str(alice_project["id"].as_str().unwrap()).unwrap();
+    let alice_id = Uuid::parse_str(alice_info["id"].as_str().unwrap()).unwrap();
+
+    let source = repo.create_session(project_id, alice_id).await.unwrap();
+
+    // Pre-populate the source session's host dirs to simulate a session that
+    // produced files.
+    let session_root = state
+        .data_root
+        .join("projects")
+        .join(project_id.to_string())
+        .join("sessions")
+        .join(source.id.to_string());
+    let src_artifacts = session_root.join("artifacts");
+    let src_inputs = session_root.join("inputs");
+    tokio::fs::create_dir_all(&src_artifacts).await.unwrap();
+    tokio::fs::create_dir_all(&src_inputs).await.unwrap();
+    tokio::fs::write(src_artifacts.join("chart.png"), b"fake-png-data")
+        .await
+        .unwrap();
+    tokio::fs::write(src_artifacts.join("report.md"), b"# Report")
+        .await
+        .unwrap();
+    tokio::fs::write(src_inputs.join("data.csv"), b"a,b\n1,2")
+        .await
+        .unwrap();
+
+    let (status, body) = common::authed(
+        &app,
+        "POST",
+        &format!("/sessions/{}/fork", source.id),
+        &alice_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "fork must return 201: {body}");
+
+    let fork_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    let fork_root = state
+        .data_root
+        .join("projects")
+        .join(project_id.to_string())
+        .join("sessions")
+        .join(fork_id.to_string());
+    let fork_artifacts = fork_root.join("artifacts");
+    let fork_inputs = fork_root.join("inputs");
+
+    // Both artifact files must be present in the fork.
+    assert!(
+        fork_artifacts.join("chart.png").exists(),
+        "chart.png must be copied to fork artifacts"
+    );
+    assert!(
+        fork_artifacts.join("report.md").exists(),
+        "report.md must be copied to fork artifacts"
+    );
+    assert_eq!(
+        tokio::fs::read(fork_artifacts.join("chart.png"))
+            .await
+            .unwrap(),
+        b"fake-png-data",
+        "artifact content must match source"
+    );
+
+    // Input file must be present in the fork.
+    assert!(
+        fork_inputs.join("data.csv").exists(),
+        "data.csv must be copied to fork inputs"
+    );
+    assert_eq!(
+        tokio::fs::read(fork_inputs.join("data.csv")).await.unwrap(),
+        b"a,b\n1,2",
+        "input content must match source"
+    );
+
+    // Snapshot independence: adding a file to the source after the fork must
+    // not appear in the fork's directory.
+    tokio::fs::write(src_artifacts.join("post_fork.txt"), b"new")
+        .await
+        .unwrap();
+    assert!(
+        !fork_artifacts.join("post_fork.txt").exists(),
+        "files added to source after fork must not appear in fork"
+    );
+}
+
+// ── fork: fork_empty_session_succeeds ────────────────────────────────────────
+
+/// Forking a session that never created any files must still succeed and must
+/// produce empty (but present) `artifacts/` and `inputs/` directories.
+#[tokio::test]
+async fn fork_empty_session_succeeds() {
+    dotenvy::dotenv().ok();
+    common::setup_provider().await;
+
+    let (app, repo, state) = common::make_app_repo_state().await;
+
+    let alice_info = common::signup(&app, "alice", "password123").await;
+    let alice_token = common::login(&app, "alice", "password123").await;
+    let alice_project = common::get_personal_project(&app, &alice_token).await;
+    let project_id = Uuid::parse_str(alice_project["id"].as_str().unwrap()).unwrap();
+    let alice_id = Uuid::parse_str(alice_info["id"].as_str().unwrap()).unwrap();
+
+    // Source session has no host dirs at all (never ran the agent).
+    let source = repo.create_session(project_id, alice_id).await.unwrap();
+
+    let (status, body) = common::authed(
+        &app,
+        "POST",
+        &format!("/sessions/{}/fork", source.id),
+        &alice_token,
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "fork of empty session must return 201: {body}"
+    );
+
+    let fork_id = Uuid::parse_str(body["id"].as_str().unwrap()).unwrap();
+    let fork_root = state
+        .data_root
+        .join("projects")
+        .join(project_id.to_string())
+        .join("sessions")
+        .join(fork_id.to_string());
+
+    // Directories must exist (even if empty) so the agent can bind-mount them.
+    assert!(
+        fork_root.join("artifacts").is_dir(),
+        "fork artifacts dir must exist even when source had none"
+    );
+    assert!(
+        fork_root.join("inputs").is_dir(),
+        "fork inputs dir must exist even when source had none"
+    );
+}
+
 // ── session CRUD ──────────────────────────────────────────────────────────────
 
 /// DELETE /sessions/{id} returns 404 for an unknown session.


### PR DESCRIPTION
## Summary

Fixes #139. `POST /sessions/{id}/fork` was creating **empty** `artifacts/` and `inputs/` host directories for the forked session. Since the coworker agent bind-mounts those host paths over `/workspace/artifacts` and `/workspace/artifacts`, any files produced by the source session were invisible inside the fork — and the UI artifacts panel showed an empty folder.

- **Root cause**: `fork_session` called `create_dir_all` on fresh empty paths instead of copying the source session's files.
- **Fix**: recursively copy the source session's `artifacts/` and `inputs/` host directories into the fork immediately before sandbox creation, matching the point-in-time snapshot semantics of the `upper.ext4` clone. `shared/` is project-level and intentionally excluded.

## Changes

| File | Change |
|------|--------|
| `backend/src/handlers/dirent.rs` | Expose existing `copy_dir_recursive` as `pub(crate)` — no logic change |
| `backend/src/handlers/session.rs` | Replace empty `create_dir_all` loop with per-directory recursive copy; falls back to `create_dir_all` when the source dir is absent (e.g. session never ran) |
| `backend/tests/session_test.rs` | Add two new tests (see below) |

## New Tests

**`fork_copies_host_files`**
- Seeds the source session's `artifacts/` and `inputs/` with real files.
- Asserts the forked session's host directories contain the same files with matching content.
- Asserts snapshot independence: a file added to the source *after* the fork does not appear in the fork.

**`fork_empty_session_succeeds`**
- Forks a session whose host directories were never created.
- Asserts the fork still returns `201` and that empty `artifacts/` and `inputs/` directories are created (required for bind-mount).

## Test plan

- [x] `cargo test fork_copies_host_files` passes
- [x] `cargo test fork_empty_session_succeeds` passes
- [x] Fork a real session with artifacts in the UI — artifacts panel shows files in the forked session
- [x] Verify files added to the source after forking do not appear in the fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)