### PR TITLE
Better scrolls on session pages

### DIFF
--- a/app/src/i18n/locales/en/session.json
+++ b/app/src/i18n/locales/en/session.json
@@ -17,6 +17,7 @@
     "composer_placeholder": "Message Cowork and the team…",
     "composer_hint": "Enter to send · Reference files with @filename",
     "new_message": "New message",
+    "scroll_to_bottom": "Scroll to bottom",
     "title_fallback": "…"
   },
   "chat": {

--- a/app/src/i18n/locales/en/session.json
+++ b/app/src/i18n/locales/en/session.json
@@ -16,6 +16,7 @@
     "send_aria": "Send",
     "composer_placeholder": "Message Cowork and the team…",
     "composer_hint": "Enter to send · Reference files with @filename",
+    "new_message": "New message",
     "title_fallback": "…"
   },
   "chat": {

--- a/app/src/i18n/locales/ko/session.json
+++ b/app/src/i18n/locales/ko/session.json
@@ -16,6 +16,7 @@
     "send_aria": "전송",
     "composer_placeholder": "Cowork와 팀에 메시지 보내기…",
     "composer_hint": "Enter로 전송 · @파일명으로 파일 참조",
+    "new_message": "새 메시지",
     "title_fallback": "…"
   },
   "chat": {

--- a/app/src/i18n/locales/ko/session.json
+++ b/app/src/i18n/locales/ko/session.json
@@ -17,6 +17,7 @@
     "composer_placeholder": "Cowork와 팀에 메시지 보내기…",
     "composer_hint": "Enter로 전송 · @파일명으로 파일 참조",
     "new_message": "새 메시지",
+    "scroll_to_bottom": "맨 아래로",
     "title_fallback": "…"
   },
   "chat": {

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -92,6 +92,9 @@ function SessionPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Set when the local user sends a message — the next scroll effect jumps to
+  // the bottom instantly, regardless of how far up the user has scrolled.
+  const forceScrollRef = useRef(false);
 
   // WS 구동: seq 순서로 정렬된 outputs 맵 (catch-up + live 멱등 병합용)
   const wsOutputsRef = useRef<Map<number, MessageOutput>>(new Map());
@@ -142,6 +145,7 @@ function SessionPage() {
     optimisticUserIdRef.current = null;
     currentRunIdRef.current = null;
     doneRunIdsRef.current.clear();
+    forceScrollRef.current = false;
   }
 
   // After messages load, mark-read side effect has run on the backend — sync badge in session list.
@@ -159,6 +163,14 @@ function SessionPage() {
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
+
+    // Own send — jump to the bottom immediately, even if scrolled far up.
+    if (forceScrollRef.current) {
+      forceScrollRef.current = false;
+      messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
+      return;
+    }
+
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     if (distanceFromBottom <= 700) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -221,6 +233,7 @@ function SessionPage() {
       status: 'done',
       attachments: attachmentPaths.length > 0 ? attachmentPaths : undefined,
     };
+    forceScrollRef.current = true;
     setLiveMessages((prev) => [...prev, userMsg]);
     setStreaming(true);
     streamingRef.current = true;

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -123,6 +123,9 @@ function SessionPage() {
   const [streaming, setStreaming] = useState(false);
   // "New message arrived while scrolled up" pill above the composer.
   const [showNewMsgPill, setShowNewMsgPill] = useState(false);
+  // Ghost scroll-to-bottom button — visible whenever scrolled past the
+  // auto-follow threshold, regardless of new messages.
+  const [showScrollDown, setShowScrollDown] = useState(false);
   const [copyToShared, setCopyToShared] = useState<{ scope: DirentScope; paths: string[] } | null>(null);
 
   type PendingAttachment = {
@@ -146,6 +149,7 @@ function SessionPage() {
     streamingRef.current = false;
     setPendingAttachments([]);
     setShowNewMsgPill(false);
+    setShowScrollDown(false);
     wsOutputsRef.current.clear();
     maxSeqRef.current = -1;
     optimisticUserIdRef.current = null;
@@ -196,14 +200,17 @@ function SessionPage() {
     }
   }, [allMessages.length, streaming]);
 
-  // Dismiss the pill once the user scrolls back near the bottom themselves.
+  // Track scroll position: dismiss the pill once the user is back near the
+  // bottom, and toggle the ghost scroll-down button past the follow threshold.
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
     const onScroll = () => {
-      if (el.scrollHeight - el.scrollTop - el.clientHeight <= 40) {
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom <= 40) {
         setShowNewMsgPill(false);
       }
+      setShowScrollDown(distanceFromBottom > 700);
     };
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => el.removeEventListener('scroll', onScroll);
@@ -635,12 +642,25 @@ function SessionPage() {
           <div ref={messagesEndRef} />
         </div>
 
-        {showNewMsgPill && (
+        {(showNewMsgPill || showScrollDown) && (
           <div className="cw-new-msg-anchor">
-            <button type="button" className="cw-new-msg-pill" onClick={scrollToBottom}>
-              <Icon name="chevron" size={12} />
-              {t('ui.new_message')}
-            </button>
+            {showNewMsgPill && (
+              <button type="button" className="cw-new-msg-pill" onClick={scrollToBottom}>
+                <Icon name="chevron" size={12} />
+                {t('ui.new_message')}
+              </button>
+            )}
+            {showScrollDown && (
+              <button
+                type="button"
+                className="cw-scroll-down-btn"
+                aria-label={t('ui.scroll_to_bottom')}
+                title={t('ui.scroll_to_bottom')}
+                onClick={scrollToBottom}
+              >
+                <Icon name="chevron" size={14} />
+              </button>
+            )}
           </div>
         )}
 

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -121,6 +121,8 @@ function SessionPage() {
   const [composerText, setComposerText] = useState('');
   const [liveMessages, setLiveMessages] = useState<Message[]>([]);
   const [streaming, setStreaming] = useState(false);
+  // "New message arrived while scrolled up" pill above the composer.
+  const [showNewMsgPill, setShowNewMsgPill] = useState(false);
   const [copyToShared, setCopyToShared] = useState<{ scope: DirentScope; paths: string[] } | null>(null);
 
   type PendingAttachment = {
@@ -143,6 +145,7 @@ function SessionPage() {
     setStreaming(false);
     streamingRef.current = false;
     setPendingAttachments([]);
+    setShowNewMsgPill(false);
     wsOutputsRef.current.clear();
     maxSeqRef.current = -1;
     optimisticUserIdRef.current = null;
@@ -174,6 +177,7 @@ function SessionPage() {
     if (forceScrollRef.current) {
       forceScrollRef.current = false;
       messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
+      setShowNewMsgPill(false);
       return;
     }
 
@@ -186,8 +190,29 @@ function SessionPage() {
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     if (distanceFromBottom <= 700) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    } else if (allMessages.length > prevCount) {
+      // Scrolled too far up to auto-follow — surface a "new message" pill instead.
+      setShowNewMsgPill(true);
     }
   }, [allMessages.length, streaming]);
+
+  // Dismiss the pill once the user scrolls back near the bottom themselves.
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      if (el.scrollHeight - el.scrollTop - el.clientHeight <= 40) {
+        setShowNewMsgPill(false);
+      }
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    setShowNewMsgPill(false);
+    messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
+  }, []);
 
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
@@ -609,6 +634,15 @@ function SessionPage() {
           )}
           <div ref={messagesEndRef} />
         </div>
+
+        {showNewMsgPill && (
+          <div className="cw-new-msg-anchor">
+            <button type="button" className="cw-new-msg-pill" onClick={scrollToBottom}>
+              <Icon name="chevron" size={12} />
+              {t('ui.new_message')}
+            </button>
+          </div>
+        )}
 
         <form className="cw-composer" onSubmit={(e) => { e.preventDefault(); void send(); }}>
           {pendingAttachments.length > 0 && (

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -95,6 +95,9 @@ function SessionPage() {
   // Set when the local user sends a message — the next scroll effect jumps to
   // the bottom instantly, regardless of how far up the user has scrolled.
   const forceScrollRef = useRef(false);
+  // Previous message count, to distinguish "new message arrived" from the
+  // initial history load / refetch (no pill on first render of a session).
+  const prevMsgCountRef = useRef(0);
 
   // WS 구동: seq 순서로 정렬된 outputs 맵 (catch-up + live 멱등 병합용)
   const wsOutputsRef = useRef<Map<number, MessageOutput>>(new Map());
@@ -146,6 +149,7 @@ function SessionPage() {
     currentRunIdRef.current = null;
     doneRunIdsRef.current.clear();
     forceScrollRef.current = false;
+    prevMsgCountRef.current = 0;
   }
 
   // After messages load, mark-read side effect has run on the backend — sync badge in session list.
@@ -163,10 +167,18 @@ function SessionPage() {
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
+    const prevCount = prevMsgCountRef.current;
+    prevMsgCountRef.current = allMessages.length;
 
     // Own send — jump to the bottom immediately, even if scrolled far up.
     if (forceScrollRef.current) {
       forceScrollRef.current = false;
+      messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
+      return;
+    }
+
+    // Initial history load (refresh / session entry) — start at the bottom.
+    if (prevCount === 0) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
       return;
     }

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -160,7 +160,7 @@ function SessionPage() {
     const el = scrollContainerRef.current;
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distanceFromBottom <= 150) {
+    if (distanceFromBottom <= 700) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
   }, [allMessages.length, streaming]);

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -171,6 +171,23 @@ function SessionPage() {
     ...liveMessages,
   ], [history.data, liveMessages]);
 
+  // Total rendered-content size. Streaming updates grow a live bubble in place
+  // (body text, tool calls, tool results) without changing the message count,
+  // so the auto-follow effect below also keys off this to keep re-checking
+  // while content grows. `+ 1` per tool call counts its appearance; results
+  // count by length so their arrival is visible even on short outputs.
+  const contentVersion = useMemo(
+    () =>
+      allMessages.reduce(
+        (n, m) =>
+          n +
+          m.body.length +
+          (m.toolCalls?.reduce((a, tc) => a + 1 + (tc.result?.length ?? 0), 0) ?? 0),
+        0,
+      ),
+    [allMessages],
+  );
+
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
@@ -198,7 +215,7 @@ function SessionPage() {
       // Scrolled too far up to auto-follow — surface a "new message" pill instead.
       setShowNewMsgPill(true);
     }
-  }, [allMessages.length, streaming]);
+  }, [allMessages.length, streaming, contentVersion]);
 
   // Track scroll position: dismiss the pill once the user is back near the
   // bottom, and toggle the ghost scroll-down button past the follow threshold.

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1147,6 +1147,33 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   from { opacity: 0; transform: translateX(-50%) translateY(6px); }
   to { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
+/* Ghost scroll-to-bottom button — right end above the composer, shown whenever
+   the user is scrolled past the auto-follow threshold. */
+.cw-scroll-down-btn {
+  position: absolute;
+  right: 58px;
+  bottom: 12px;
+  z-index: 5;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--cw-border);
+  border-radius: 50%;
+  background: color-mix(in oklch, var(--cw-paper), transparent 30%);
+  backdrop-filter: blur(4px);
+  color: var(--cw-fg-3);
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: background 120ms, color 120ms;
+  animation: cw-fade-up 160ms ease-out;
+}
+.cw-scroll-down-btn:hover { background: var(--cw-paper); color: var(--cw-fg-1); }
+@keyframes cw-fade-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
 .cw-home-composer small {
   text-align: center;
   color: var(--cw-fg-4);

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1110,6 +1110,43 @@ button:disabled { cursor: not-allowed; opacity: .48; transform: none !important;
   color: var(--cw-fg-4);
   font-size: 11px;
 }
+/* "New message" pill — floats just above the composer when a message arrives
+   while the user is scrolled up past the auto-follow threshold. */
+.cw-new-msg-anchor {
+  position: relative;
+  height: 0;
+  width: 100%;
+  max-width: 920px;
+  margin: 0 auto;
+}
+.cw-new-msg-pill {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--cw-primary);
+  color: var(--cw-fg-on-primary, white);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  transition: background 120ms, transform 120ms;
+  animation: cw-pill-in 160ms ease-out;
+}
+.cw-new-msg-pill:hover { background: var(--cw-primary-hover, var(--cw-primary)); }
+@keyframes cw-pill-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(6px); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
 .cw-home-composer small {
   text-align: center;
   color: var(--cw-fg-4);


### PR DESCRIPTION
## Related PR
#134 : This PR continues from the [comment](https://github.com/brekkylab/agent-k/pull/134#issuecomment-4622397584) in #134. We have changed the auto-scroll criteria applied in that PR.(And added several other scroll-related features.)

## Changes
- **Widened auto-follow threshold** (150px → 700px): new messages smooth auto-scroll only when within 700px of the bottom
- **Instant jump on own send**: sending a message scrolls straight to the bottom (no animation), even if scrolled far up
- **Start at the bottom on session entry/refresh**: first history load jumps instantly to the latest message
- **New-message pill**: when a message arrives while scrolled far up, a pill appears centered above the composer — click jumps instantly to the bottom; auto-dismissed when the user scrolls back near the bottom
<img width="768" height="145" alt="image" src="https://github.com/user-attachments/assets/d90e9017-76d1-4694-8590-278232da968e" />

- **Ghost scroll-down button**: a translucent circular button appears at the right end above the composer whenever scrolled past 700px — click jumps instantly to the bottom
<img width="220" height="101" alt="image" src="https://github.com/user-attachments/assets/84ca6032-c81e-4aeb-afce-a3b927820c9a" />

- Misc: new i18n keys (`new_message`, `scroll_to_bottom` en/ko), related CSS (`.cw-new-msg-pill`, `.cw-scroll-down-btn`)