### PR TITLE
Improve sidebar session list

### DIFF
--- a/app/src/api/sessions.ts
+++ b/app/src/api/sessions.ts
@@ -49,6 +49,11 @@ export async function deleteSession(sessionId: string): Promise<void> {
   await request(`/sessions/${sessionId}`, { method: 'DELETE' });
 }
 
+// Marks the session read without fetching its history (sidebar "Mark as read").
+export async function markSessionRead(sessionId: string): Promise<void> {
+  await request(`/sessions/${sessionId}/read`, { method: 'POST' });
+}
+
 // User-facing label is "Duplicate" (the action clones the entire session
 // — messages + sandbox); the backend endpoint is still `/fork` since that
 // is the internal mechanism name.

--- a/app/src/api/sessions.ts
+++ b/app/src/api/sessions.ts
@@ -1,10 +1,12 @@
 import { request } from './client';
 import type { BackendSession } from './backend-types';
 import { toSession } from './transformers';
-import type { Session, ShareMode } from '@/domain/types';
+import type { Session, SessionOrigin, ShareMode } from '@/domain/types';
 
-export async function listSessions(projectRef: string): Promise<Session[]> {
-  const res = await request<{ items: BackendSession[] }>(`/sessions?project_ref=${encodeURIComponent(projectRef)}`);
+export async function listSessions(projectRef: string, origin?: SessionOrigin): Promise<Session[]> {
+  const params = new URLSearchParams({ project_ref: projectRef });
+  if (origin) params.set('origin', origin);
+  const res = await request<{ items: BackendSession[] }>(`/sessions?${params.toString()}`);
   return res.items.map(toSession);
 }
 

--- a/app/src/components/SessionCardMenu.tsx
+++ b/app/src/components/SessionCardMenu.tsx
@@ -10,6 +10,8 @@ import { Icon } from './Icon';
 import { useDialogEscape } from '@/lib/useDialogEscape';
 
 interface SessionCardMenuProps {
+  onMarkRead?: () => void;
+  markReadDisabled?: boolean;
   onDuplicate?: () => void;
   duplicateDisabled?: boolean;
   onDelete?: () => void;
@@ -17,9 +19,9 @@ interface SessionCardMenuProps {
 
 interface MenuRect { top: number; left: number; }
 
-export function SessionCardMenu({ onDuplicate, duplicateDisabled, onDelete }: SessionCardMenuProps) {
+export function SessionCardMenu({ onMarkRead, markReadDisabled, onDuplicate, duplicateDisabled, onDelete }: SessionCardMenuProps) {
   const { t } = useTranslation('session');
-  const hasActions = Boolean(onDuplicate || onDelete);
+  const hasActions = Boolean(onMarkRead || onDuplicate || onDelete);
   const [open, setOpen] = useState(false);
   const [rect, setRect] = useState<MenuRect | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -106,6 +108,42 @@ export function SessionCardMenu({ onDuplicate, duplicateDisabled, onDelete }: Se
             zIndex: 100,
           }}
         >
+          {onMarkRead && (
+            <button
+              type="button"
+              role="menuitem"
+              disabled={markReadDisabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (markReadDisabled) return;
+                setOpen(false);
+                onMarkRead();
+              }}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                width: '100%',
+                textAlign: 'left',
+                padding: '7px 10px',
+                border: 0,
+                background: 'transparent',
+                color: markReadDisabled ? 'var(--cw-ink-4)' : 'var(--cw-ink-1)',
+                fontSize: 12.5,
+                borderRadius: 'var(--cw-radius-sm)',
+                cursor: markReadDisabled ? 'not-allowed' : 'pointer',
+                opacity: markReadDisabled ? 0.6 : 1,
+              }}
+              onMouseEnter={(e) => {
+                if (markReadDisabled) return;
+                (e.currentTarget as HTMLButtonElement).style.background = 'var(--cw-paper-3)';
+              }}
+              onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+            >
+              <Icon name="check" size={13} />
+              {t('menu.mark_read')}
+            </button>
+          )}
           {onDuplicate && (
             <button
               type="button"

--- a/app/src/components/SessionsOverlay.tsx
+++ b/app/src/components/SessionsOverlay.tsx
@@ -24,7 +24,7 @@ export function SessionsOverlay({ projectSlug, onClose }: { projectSlug: string;
   const currentUser = useAuthStore((s) => s.currentUser);
 
   const project = useQuery({ queryKey: ['project', projectSlug], queryFn: () => getProject(projectSlug) });
-  const sessions = useQuery({ queryKey: ['sessions', projectSlug], queryFn: () => listSessions(projectSlug) });
+  const sessions = useQuery({ queryKey: ['sessions', projectSlug, 'user'], queryFn: () => listSessions(projectSlug, 'user') });
 
   // Move focus to the close button on mount so keyboard users can dismiss immediately.
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -37,7 +37,7 @@ export function SessionsOverlay({ projectSlug, onClose }: { projectSlug: string;
   const [pendingDelete, setPendingDelete] = useState<Session | null>(null);
   const deleteMutation = useSessionDelete(projectSlug, { onDeleted: () => setPendingDelete(null) });
 
-  const sessionList = (sessions.data ?? []).filter((s) => s.origin === 'user');
+  const sessionList = sessions.data ?? [];
 
   // Render via portal to document.body so `position: fixed` is relative to the
   // viewport — not the sidebar (whose transform would otherwise trap it).

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -237,8 +237,8 @@ export function Sidebar() {
   const activeProject = (projectsQuery.data ?? []).find((p) => p.slug === activeProjectSlug);
 
   const sessionsQuery = useQuery({
-    queryKey: ['sessions', activeProjectSlug],
-    queryFn: () => listSessions(activeProjectSlug!),
+    queryKey: ['sessions', activeProjectSlug, 'user'],
+    queryFn: () => listSessions(activeProjectSlug!, 'user'),
     enabled: Boolean(activeProjectSlug),
   });
 
@@ -476,7 +476,7 @@ export function Sidebar() {
               onViewAll={() => setSessionsOverlayOpen(true)}
             />
             <div className="cw-sessions-list" data-expanded={sessionsExpanded ? 'true' : 'false'}>
-              {(sessionsQuery.data ?? []).filter((s) => s.origin === 'user').map((session) => {
+              {(sessionsQuery.data ?? []).map((session) => {
                 const canDelete = canAdministerSession(session, activeProject, currentUser);
                 return (
                   <div

--- a/app/src/components/layout/Sidebar.tsx
+++ b/app/src/components/layout/Sidebar.tsx
@@ -6,11 +6,11 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import logoMark from '@/assets/logo-mark.svg';
 import { listProjects } from '@/api/projects';
-import { listSessions } from '@/api/sessions';
+import { listSessions, markSessionRead } from '@/api/sessions';
 import { Icon } from '@/components/Icon';
 import { Avatar, IconPocket } from '@/components/uiPrimitives';
 import { useAuthStore } from '@/stores/auth';
@@ -346,6 +346,18 @@ export function Sidebar() {
 
   const duplicateMutation = useDuplicateSession(activeProjectSlug ?? '');
 
+  // Mark a session read from the ⋯ menu — zero its unread badge directly in
+  // every cached session list (mirrors the on-entry update in the session page).
+  const markReadMutation = useMutation({
+    mutationFn: (sessionId: string) => markSessionRead(sessionId),
+    onSuccess: (_data, sessionId) => {
+      queryClient.setQueriesData<Session[]>({ queryKey: ['sessions', activeProjectSlug] }, (old) => {
+        if (!old?.some((s) => s.id === sessionId && s.unreadCount > 0)) return old;
+        return old.map((s) => (s.id === sessionId ? { ...s, unreadCount: 0 } : s));
+      });
+    },
+  });
+
   function openProject(slug: string) {
     navigate({ to: '/projects/$projectSlug', params: { projectSlug: slug } });
   }
@@ -511,6 +523,8 @@ export function Sidebar() {
                     {session.isAutoAppend && <span className="auto-dot">●</span>}
                     <span className="cw-session-menu-wrap">
                       <SessionCardMenu
+                        onMarkRead={() => markReadMutation.mutate(session.id)}
+                        markReadDisabled={session.unreadCount === 0}
                         onDuplicate={() => setPendingDuplicate(session)}
                         duplicateDisabled={!session.lastMessageAt}
                         onDelete={canDelete ? () => setPendingDelete(session) : undefined}

--- a/app/src/i18n/locales/en/session.json
+++ b/app/src/i18n/locales/en/session.json
@@ -46,6 +46,7 @@
   "artifacts_header": "Artifacts",
   "menu": {
     "options": "Session options",
+    "mark_read": "Mark as read",
     "duplicate": "Duplicate session",
     "delete": "Delete session"
   },

--- a/app/src/i18n/locales/ko/session.json
+++ b/app/src/i18n/locales/ko/session.json
@@ -46,6 +46,7 @@
   "artifacts_header": "산출물",
   "menu": {
     "options": "세션 옵션",
+    "mark_read": "읽음으로 표시",
     "duplicate": "세션 복제",
     "delete": "세션 삭제"
   },

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -204,9 +204,14 @@ function SessionPage() {
   // instead of refetching whole lists on each session entry.
   useEffect(() => {
     if (history.isSuccess && sessionId) {
+      void queryClient.cancelQueries({ queryKey: ['sessions', projectSlug] });
       queryClient.setQueriesData<Session[]>({ queryKey: ['sessions', projectSlug] }, (old) => {
         if (!old?.some((s) => s.id === sessionId && s.unreadCount > 0)) return old;
         return old.map((s) => (s.id === sessionId ? { ...s, unreadCount: 0 } : s));
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['sessions', projectSlug],
+        refetchType: 'none',
       });
     }
   }, [history.isSuccess, history.dataUpdatedAt, projectSlug, sessionId, queryClient]);

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -22,7 +22,7 @@ import { useToastStore } from '@/components/Toast';
 import { MarkdownRenderer } from '@/components/chat/MarkdownRenderer';
 import { AI_USER, SUBAGENT_PREFIX } from '@/api/transformers';
 import { formatMessageTime, formatMessageTimeFull } from '@/lib/formatMessageTime';
-import type { Message, ShareMode, User } from '@/domain/types';
+import type { Message, Session, ShareMode, User } from '@/domain/types';
 import { ApiError } from '@/api/client';
 import { SessionTitleText } from '@/components/SessionTitleText';
 import { ArtifactsPanel } from '@/components/ArtifactsPanel';
@@ -199,12 +199,17 @@ function SessionPage() {
     prevMsgCountRef.current = 0;
   }
 
-  // After messages load, mark-read side effect has run on the backend — sync badge in session list.
+  // After messages load, mark-read side effect has run on the backend — zero this
+  // session's unread badge directly in every cached session list (any origin filter)
+  // instead of refetching whole lists on each session entry.
   useEffect(() => {
-    if (history.isSuccess) {
-      void queryClient.invalidateQueries({ queryKey: ['sessions', projectSlug] });
+    if (history.isSuccess && sessionId) {
+      queryClient.setQueriesData<Session[]>({ queryKey: ['sessions', projectSlug] }, (old) => {
+        if (!old?.some((s) => s.id === sessionId && s.unreadCount > 0)) return old;
+        return old.map((s) => (s.id === sessionId ? { ...s, unreadCount: 0 } : s));
+      });
     }
-  }, [history.isSuccess, history.dataUpdatedAt, projectSlug, queryClient]);
+  }, [history.isSuccess, history.dataUpdatedAt, projectSlug, sessionId, queryClient]);
 
   const allMessages = useMemo<Message[]>(() => [
     ...(history.data ?? []),

--- a/app/src/routes/_app.projects.index.tsx
+++ b/app/src/routes/_app.projects.index.tsx
@@ -66,9 +66,9 @@ function ProjectCard({ project, isActive, onOpen }: { project: Project; isActive
   const { t } = useTranslation(['project', 'common', 'members']);
   const currentUser = useAuthStore((s) => s.currentUser);
   const members = useQuery({ queryKey: ['members', project.slug], queryFn: () => listMembers(project.slug) });
-  const sessions = useQuery({ queryKey: ['sessions', project.slug], queryFn: () => listSessions(project.slug) });
+  const sessions = useQuery({ queryKey: ['sessions', project.slug, 'user'], queryFn: () => listSessions(project.slug, 'user') });
   const isOwner = currentUser?.id === project.ownerId;
-  const userSessions = (sessions.data ?? []).filter((s) => s.origin === 'user');
+  const userSessions = sessions.data ?? [];
   const latestRaw = latestUpdated(userSessions);
   const latest = latestRaw === 'new' ? t('card.latest_new') : latestRaw;
   const memberUsers: User[] = members.data ?? [];

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -797,6 +797,30 @@ pub async fn get_message_history(
     Ok(Json(SessionMessageListResponse { items }))
 }
 
+/// POST /sessions/{session_id}/read — mark the session read without fetching
+/// history (e.g. the sidebar "Mark as read" action).
+pub async fn mark_session_read(
+    State(state): State<Arc<AppState>>,
+    Extension(auth_user): Extension<AuthUser>,
+    Path(session_ref): Path<String>,
+) -> ApiResult<StatusCode> {
+    let session_id = resolve_session_id(&state, &session_ref).await?;
+    state
+        .repository
+        .get_session_with_authz(session_id, auth_user.id)
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?
+        .ok_or_else(|| AppError::not_found("session not found or access denied"))?;
+
+    state
+        .repository
+        .mark_session_read(session_id, auth_user.id)
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// DELETE /sessions/{session_id}/messages — creator or project owner
 pub async fn clear_message_history(
     State(state): State<Arc<AppState>>,

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -26,7 +26,9 @@ use crate::{
         SessionListResponse, SessionMessageListResponse, SessionMessageResponse, SessionResponse,
         UpdateSessionRequest,
     },
-    repository::{DbSenderKind, NewSessionMessage, PrefixLookup, SessionAccess, ShareMode},
+    repository::{
+        DbSenderKind, NewSessionMessage, PrefixLookup, SessionAccess, SessionOrigin, ShareMode,
+    },
     services::session_title::generate_session_title,
     state::AppState,
 };
@@ -454,9 +456,11 @@ pub async fn create_session(
 pub struct ListSessionsQuery {
     /// Project UUID, active slug, or retired slug — backend resolves all three.
     pub project_ref: Option<String>,
+    /// Filter by session origin (`user` or `automation`). Omit to list all.
+    pub origin: Option<SessionOrigin>,
 }
 
-/// GET /sessions?project_ref=...
+/// GET /sessions?project_ref=...&origin=...
 /// `project_ref` is optional — omit to list all sessions across projects the user can access.
 pub async fn list_sessions(
     State(state): State<Arc<AppState>>,
@@ -476,13 +480,13 @@ pub async fn list_sessions(
             }
             state
                 .repository
-                .list_sessions_in_project(project_id, auth_user.id)
+                .list_sessions_in_project(project_id, auth_user.id, q.origin)
                 .await
                 .map_err(|e| AppError::internal(e.to_string()))?
         }
         None => state
             .repository
-            .list_sessions_for_user(auth_user.id)
+            .list_sessions_for_user(auth_user.id, q.origin)
             .await
             .map_err(|e| AppError::internal(e.to_string()))?,
     };

--- a/backend/src/repository/session.rs
+++ b/backend/src/repository/session.rs
@@ -320,6 +320,7 @@ impl SqliteRepository {
     pub async fn list_sessions_for_user(
         &self,
         requesting_user_id: Uuid,
+        origin: Option<SessionOrigin>,
     ) -> RepositoryResult<Vec<DbSession>> {
         let uid = requesting_user_id.to_string();
         let rows = sqlx::query(
@@ -327,15 +328,17 @@ impl SqliteRepository {
                     s.last_message_at, s.last_message_snippet, s.agent_type, s.model, s.created_at, s.updated_at
              FROM sessions s
              JOIN projects p ON p.id = s.project_id
-             WHERE p.owner_id = ?1
+             WHERE (p.owner_id = ?1
                 OR (
                     EXISTS (SELECT 1 FROM project_members pm
                             WHERE pm.project_id = s.project_id AND pm.user_id = ?1)
                     AND (s.creator_id = ?1 OR s.share_mode != 'private')
-                )
+                ))
+               AND (?2 IS NULL OR s.origin = ?2)
              ORDER BY s.created_at DESC",
         )
         .bind(&uid)
+        .bind(origin.map(|o| o.as_str()))
         .fetch_all(&self.pool)
         .await?;
 
@@ -346,6 +349,7 @@ impl SqliteRepository {
         &self,
         project_id: Uuid,
         requesting_user_id: Uuid,
+        origin: Option<SessionOrigin>,
     ) -> RepositoryResult<Vec<DbSession>> {
         let pid = project_id.to_string();
         let uid = requesting_user_id.to_string();
@@ -364,10 +368,12 @@ impl SqliteRepository {
                        AND (s.creator_id = ?2 OR s.share_mode != 'private')
                    )
                )
+               AND (?3 IS NULL OR s.origin = ?3)
              ORDER BY COALESCE(s.last_message_at, s.created_at) DESC",
         )
         .bind(&pid)
         .bind(&uid)
+        .bind(origin.map(|o| o.as_str()))
         .fetch_all(&self.pool)
         .await?;
 

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -102,6 +102,10 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
                 .post(handlers::send_message)
                 .delete(handlers::clear_message_history),
         )
+        .api_route(
+            "/sessions/{session_id}/read",
+            post(handlers::mark_session_read),
+        )
         .api_route("/sessions/{session_id}/fork", post(handlers::fork_session))
         .api_route(
             "/sessions/{session_id}/runs/{run_id}/stop",

--- a/backend/tests/session_metadata_test.rs
+++ b/backend/tests/session_metadata_test.rs
@@ -286,6 +286,68 @@ async fn list_sessions_includes_metadata() {
     );
 }
 
+/// GET /sessions?origin=... filters by session origin; omitting it returns all.
+#[tokio::test]
+async fn list_sessions_filters_by_origin() {
+    let (app, repo, _state) = common::make_app_repo_state().await;
+
+    let alice_info = common::signup(&app, "alice_origin", "Password123!").await;
+    let alice_token = common::login(&app, "alice_origin", "Password123!").await;
+    let alice_project = common::get_personal_project(&app, &alice_token).await;
+    let project_slug = alice_project["slug"].as_str().unwrap();
+    let project_id = Uuid::parse_str(alice_project["id"].as_str().unwrap()).unwrap();
+    let alice_id = Uuid::parse_str(alice_info["id"].as_str().unwrap()).unwrap();
+
+    let user_session = repo.create_session(project_id, alice_id).await.unwrap();
+    let automation_session = repo
+        .create_session_with_origin(
+            project_id,
+            alice_id,
+            agent_k_backend::repository::SessionOrigin::Automation,
+        )
+        .await
+        .unwrap();
+
+    for (query, expected_ids) in [
+        (
+            format!("/sessions?project_ref={project_slug}&origin=user"),
+            vec![user_session.id],
+        ),
+        (
+            format!("/sessions?project_ref={project_slug}&origin=automation"),
+            vec![automation_session.id],
+        ),
+        (
+            format!("/sessions?project_ref={project_slug}"),
+            vec![user_session.id, automation_session.id],
+        ),
+    ] {
+        let (status, body) = common::authed(&app, "GET", &query, &alice_token, None).await;
+        assert_eq!(status, StatusCode::OK, "list sessions failed ({query}): {body}");
+        let mut got: Vec<String> = body["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|i| i["id"].as_str().unwrap().to_string())
+            .collect();
+        got.sort();
+        let mut expected: Vec<String> = expected_ids.iter().map(|id| id.to_string()).collect();
+        expected.sort();
+        assert_eq!(got, expected, "unexpected sessions for {query}: {body}");
+    }
+
+    // Unknown origin values are rejected by query deserialization.
+    let (status, _) = common::authed(
+        &app,
+        "GET",
+        &format!("/sessions?project_ref={project_slug}&origin=bogus"),
+        &alice_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "bogus origin should be 400");
+}
+
 /// Forked session inherits the source title and starts with unread_count=0 for the forker.
 #[tokio::test]
 async fn fork_inherits_title_and_has_zero_unread() {


### PR DESCRIPTION
## Changes

- **`GET /sessions` now accepts `?origin=user|automation`** — the repository list
  queries filter by origin, so each surface fetches only the sessions it renders.
- **Sidebar / sessions overlay / project cards** switch to `['sessions', slug, 'user']`
  with the server-side `origin=user` filter, dropping client-side `origin` filtering.
- **Unread badge updates in place**: on session entry the selected session's
  `unreadCount` is zeroed directly via `setQueriesData` instead of invalidating
  (and refetching) every cached session list.
- **"Mark as read" in the sidebar session menu** — `POST /sessions/{id}/read`
  marks a session read without fetching history (reusing the existing
  `mark_session_read` repository call), and the badge is zeroed in place via the
  same `setQueriesData` path.

## Notes

- Existing `['sessions', slug]` prefix invalidations (create/delete/duplicate/run-done)
  still match the new origin-suffixed keys.

## Test plan

- [x] `cargo test` — including new `list_sessions_filters_by_origin`
  (user/automation/no filter/invalid → 400)
- [x] `tsc --noEmit`