### PR TITLE
feat(session): paginate message history by turn with seq cursors

### DIFF
--- a/app/src/api/backend-types.ts
+++ b/app/src/api/backend-types.ts
@@ -104,6 +104,8 @@ export type BackendMessageSender =
   | { kind: 'agent'; name: string };
 
 export interface SessionMessageItem {
+  /** Session-global insertion order — stable identity across paginated windows. */
+  seq: number;
   message: AiloyMessage;
   sender: BackendMessageSender;
   created_at: string;

--- a/app/src/api/messages.ts
+++ b/app/src/api/messages.ts
@@ -1,5 +1,5 @@
 import { request } from './client';
-import type { AiloyMessage, AiloyPart, AiloyToolCall, MessageOutput, SessionMessageList } from './backend-types';
+import type { AiloyMessage, AiloyPart, AiloyToolCall, MessageOutput, SessionMessageItem, SessionMessageList } from './backend-types';
 import { aiMessageText, collapseToolMessages } from './transformers';
 import type { Message } from '@/domain/types';
 
@@ -8,9 +8,31 @@ export interface SubagentUpdate {
   text: string;
 }
 
-export async function listMessages(sessionId: string): Promise<Message[]> {
-  const raw = await request<SessionMessageList>(`/sessions/${sessionId}/messages`);
-  return collapseToolMessages(raw.items, sessionId);
+/**
+ * Keyset pagination in TURN units. `limit`+`beforeSeq` = newest turns below
+ * the cursor (immutable windows); `afterSeq` = tail catch-up. Omit all for
+ * full history; items are oldest→newest. Returns RAW items so callers can
+ * merge windows before collapsing tool messages.
+ */
+export async function listMessageItems(
+  sessionId: string,
+  opts?: { limit?: number; beforeSeq?: number; afterSeq?: number },
+): Promise<SessionMessageItem[]> {
+  const params = new URLSearchParams();
+  if (opts?.limit !== undefined) params.set('limit', String(opts.limit));
+  if (opts?.beforeSeq !== undefined) params.set('before_seq', String(opts.beforeSeq));
+  if (opts?.afterSeq !== undefined) params.set('after_seq', String(opts.afterSeq));
+  const qs = params.toString();
+  const raw = await request<SessionMessageList>(`/sessions/${sessionId}/messages${qs ? `?${qs}` : ''}`);
+  return raw.items;
+}
+
+/** Single-window convenience: fetch + collapse in one go (non-paginated callers). */
+export async function listMessages(
+  sessionId: string,
+  opts?: { limit?: number; beforeSeq?: number; afterSeq?: number },
+): Promise<Message[]> {
+  return collapseToolMessages(await listMessageItems(sessionId, opts), sessionId);
 }
 
 export interface RunAck {

--- a/app/src/api/transformers.ts
+++ b/app/src/api/transformers.ts
@@ -163,7 +163,6 @@ export function aiMessageText(contents: AiloyPart[] | undefined): string {
 export function toMessageItem(
   item: SessionMessageItem,
   sessionId: string,
-  idx: number,
 ): Message {
   const a = item.message;
   const sender: MessageSender = item.sender.kind === 'user'
@@ -182,7 +181,8 @@ export function toMessageItem(
   const body = extractText(a.contents);
 
   return {
-    id: a.id || `${sessionId}-h-${idx}`,
+    // seq fallback (ailoy ids are tool-call-only) is stable across window changes.
+    id: a.id || `${sessionId}-h-${item.seq}`,
     sessionId,
     sender,
     createdAt: item.created_at,
@@ -218,7 +218,7 @@ export function collapseToolMessages(
 
   const messages: Message[] = [];
 
-  for (const [idx, it] of items.entries()) {
+  for (const it of items) {
     if (it.message.role === 'tool') {
       const toolCallId = it.message.id;
       const toolName = toolCallId ? toolCallNames.get(toolCallId) : undefined;
@@ -230,7 +230,7 @@ export function collapseToolMessages(
         ? it.sender.name
         : toolName ?? 'tool';
       messages.push({
-        id: toolCallId || `${sessionId}-tool-${idx}`,
+        id: toolCallId || `${sessionId}-tool-${it.seq}`,
         sessionId,
         sender: { kind: 'agent' as const, name: senderName },
         createdAt: it.created_at,
@@ -240,7 +240,7 @@ export function collapseToolMessages(
       continue;
     }
 
-    const baseMsg = toMessageItem(it, sessionId, idx);
+    const baseMsg = toMessageItem(it, sessionId);
     if (baseMsg.toolCalls) {
       messages.push({
         ...baseMsg,

--- a/app/src/i18n/locales/en/session.json
+++ b/app/src/i18n/locales/en/session.json
@@ -14,6 +14,7 @@
   "ui": {
     "ai_responding": "AI is responding…",
     "response_delayed": "Response is taking longer than usual… You can stop it anytime with Esc.",
+    "loading_history": "Loading earlier messages…",
     "attach_file": "Attach file",
     "self_label": "Me",
     "tool_running": "Running…",

--- a/app/src/i18n/locales/ko/session.json
+++ b/app/src/i18n/locales/ko/session.json
@@ -14,6 +14,7 @@
   "ui": {
     "ai_responding": "AI 답변 중…",
     "response_delayed": "응답이 평소보다 지연되고 있습니다… Esc로 언제든 중지할 수 있어요.",
+    "loading_history": "이전 메시지를 불러오는 중…",
     "attach_file": "파일 첨부",
     "self_label": "나",
     "tool_running": "실행 중…",

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -6,7 +6,7 @@ import { createFileRoute, useLocation, useNavigate } from '@tanstack/react-route
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { localizedNoun } from '@/i18n';
-import { getSession, updateSessionShareMode } from '@/api/sessions';
+import { getSession, markSessionRead, updateSessionShareMode } from '@/api/sessions';
 import { listMessageItems, sendMessage, stopRun, getRunActive, deriveStreamState } from '@/api/messages';
 import { appWs } from '@/api/ws';
 import type { AppWsEvent } from '@/api/ws';
@@ -106,11 +106,6 @@ function SessionPage() {
       return { newer: 0 };
     },
     enabled: Boolean(session.data && currentUser),
-    // Refetch on every entry so the backend's mark-read side effect runs, which
-    // clears the sidebar unread badge via the dataUpdatedAt effect below. Without
-    // this, the QueryClient's default 30s staleTime kept re-entries within that
-    // window from triggering mark-read and the badge stayed visible.
-    staleTime: 0,
   });
   // Stable reference for the WS handler effect deps (stable identity in v5).
   const { fetchPreviousPage } = history;
@@ -235,22 +230,25 @@ function SessionPage() {
     didInitialScrollRef.current = false;
   }
 
-  // After messages load, mark-read side effect has run on the backend — zero this
-  // session's unread badge directly in every cached session list (any origin filter)
-  // instead of refetching whole lists on each session entry.
+  // On entering a session, mark it read on the server with a lightweight POST
+  // (no history refetch) and zero its unread badge directly in every cached
+  // session list (any origin filter). Keyed on sessionId so it fires once per
+  // entry instead of on every message page fetch.
   useEffect(() => {
-    if (history.isSuccess && sessionId) {
-      void queryClient.cancelQueries({ queryKey: ['sessions', projectSlug] });
-      queryClient.setQueriesData<Session[]>({ queryKey: ['sessions', projectSlug] }, (old) => {
-        if (!old?.some((s) => s.id === sessionId && s.unreadCount > 0)) return old;
-        return old.map((s) => (s.id === sessionId ? { ...s, unreadCount: 0 } : s));
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ['sessions', projectSlug],
-        refetchType: 'none',
-      });
-    }
-  }, [history.isSuccess, history.dataUpdatedAt, projectSlug, sessionId, queryClient]);
+    if (!sessionId) return;
+    void markSessionRead(sessionId).catch(() => {});
+    // Cancel + zero + invalidate-without-refetch so an in-flight session-list
+    // fetch can't clobber the optimistic unread reset.
+    void queryClient.cancelQueries({ queryKey: ['sessions', projectSlug] });
+    queryClient.setQueriesData<Session[]>({ queryKey: ['sessions', projectSlug] }, (old) => {
+      if (!old?.some((s) => s.id === sessionId && s.unreadCount > 0)) return old;
+      return old.map((s) => (s.id === sessionId ? { ...s, unreadCount: 0 } : s));
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ['sessions', projectSlug],
+      refetchType: 'none',
+    });
+  }, [sessionId, projectSlug, queryClient]);
 
   // Merge pages oldest→newest, collapse once so tool_call/result pairs span
   // window boundaries; seq dedupe absorbs overlap from stale after_seq refetches.

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -1,13 +1,13 @@
 // Session — markup mirrors app-live SessionPage. Chat surface (head + messages
 // + composer) + right side (members, references, access, artifact).
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createFileRoute, useLocation, useNavigate } from '@tanstack/react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { localizedNoun } from '@/i18n';
 import { getSession, updateSessionShareMode } from '@/api/sessions';
-import { listMessages, sendMessage, stopRun, getRunActive, deriveStreamState } from '@/api/messages';
+import { listMessageItems, sendMessage, stopRun, getRunActive, deriveStreamState } from '@/api/messages';
 import { appWs } from '@/api/ws';
 import type { AppWsEvent } from '@/api/ws';
 import type { MessageOutput } from '@/api/backend-types';
@@ -20,7 +20,7 @@ import { getModelCatalog, modelLabel } from '@/api/models';
 import { useAuthStore } from '@/stores/auth';
 import { useToastStore } from '@/components/Toast';
 import { MarkdownRenderer } from '@/components/chat/MarkdownRenderer';
-import { AI_USER, SUBAGENT_PREFIX } from '@/api/transformers';
+import { AI_USER, SUBAGENT_PREFIX, collapseToolMessages } from '@/api/transformers';
 import { formatMessageTime, formatMessageTimeFull } from '@/lib/formatMessageTime';
 import type { Message, Session, ShareMode, User } from '@/domain/types';
 import { ApiError } from '@/api/client';
@@ -46,6 +46,12 @@ export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sess
 function stripSubagentPrefix(name: string): string {
   return name.startsWith(SUBAGENT_PREFIX) ? name.slice(SUBAGENT_PREFIX.length) : name;
 }
+
+// History page size in TURNS (a user message + the agent responses after it).
+const MESSAGES_PAGE_TURNS = 10;
+
+// null = initial (latest window); older = before_seq page; newer = after_seq tail.
+type HistoryPageParam = { older: number } | { newer: number } | null;
 
 function SessionPage() {
   const { projectSlug, sessionPrefix } = Route.useParams();
@@ -74,9 +80,31 @@ function SessionPage() {
   const projectId = project.data?.id ?? '';
   const sessionId = session.data?.id ?? '';
 
-  const history = useQuery({
-    queryKey: ['messages', sessionId],
-    queryFn: () => listMessages(sessionId),
+  // Progressive history: latest turn window first, older pages via before_seq.
+  // Cursors anchor on immutable seqs, so runs only need a tail fetch — no full
+  // refetch. The 'window' suffix avoids clashing with other ['messages', id] caches.
+  const history = useInfiniteQuery({
+    queryKey: ['messages', sessionId, 'window'],
+    queryFn: ({ pageParam }) => {
+      const p = pageParam as HistoryPageParam;
+      return p && 'newer' in p
+        ? listMessageItems(sessionId, { afterSeq: p.newer })
+        : listMessageItems(sessionId, { limit: MESSAGES_PAGE_TURNS, beforeSeq: p?.older });
+    },
+    initialPageParam: null as HistoryPageParam,
+    // User-message count == turn count; a short page means we hit the start.
+    getNextPageParam: (lastPage): HistoryPageParam | undefined =>
+      lastPage.filter((i) => i.sender.kind === 'user').length < MESSAGES_PAGE_TURNS
+        ? undefined
+        : { older: lastPage[0].seq },
+    // Newer side (tail catch-up). Cursor from the first non-empty page —
+    // empty tail pages pile up at pages[0].
+    getPreviousPageParam: (_firstPage, allPages): HistoryPageParam => {
+      for (const page of allPages) {
+        if (page.length) return { newer: page[page.length - 1].seq };
+      }
+      return { newer: 0 };
+    },
     enabled: Boolean(session.data && currentUser),
     // Refetch on every entry so the backend's mark-read side effect runs, which
     // clears the sidebar unread badge via the dataUpdatedAt effect below. Without
@@ -84,6 +112,8 @@ function SessionPage() {
     // window from triggering mark-read and the badge stayed visible.
     staleTime: 0,
   });
+  // Stable reference for the WS handler effect deps (stable identity in v5).
+  const { fetchPreviousPage } = history;
 
   // Agent chip — transient preview state from home. Persist it after router state
   // is cleared, but reset it when this route instance moves to another session.
@@ -111,6 +141,10 @@ function SessionPage() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Scroll anchor for older-page prepends — restored so the view doesn't jump.
+  const prependAnchorRef = useRef<{ height: number; top: number } | null>(null);
+  // Whether the one-time scroll-to-bottom on session entry has run.
+  const didInitialScrollRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   // Set when the local user sends a message — the next scroll effect jumps to
@@ -197,6 +231,8 @@ function SessionPage() {
     doneRunIdsRef.current.clear();
     forceScrollRef.current = false;
     prevMsgCountRef.current = 0;
+    prependAnchorRef.current = null;
+    didInitialScrollRef.current = false;
   }
 
   // After messages load, mark-read side effect has run on the backend — zero this
@@ -216,10 +252,23 @@ function SessionPage() {
     }
   }, [history.isSuccess, history.dataUpdatedAt, projectSlug, sessionId, queryClient]);
 
+  // Merge pages oldest→newest, collapse once so tool_call/result pairs span
+  // window boundaries; seq dedupe absorbs overlap from stale after_seq refetches.
+  const historyMessages = useMemo<Message[]>(() => {
+    const pages = history.data?.pages ?? [];
+    const seen = new Set<number>();
+    const merged = [...pages].reverse().flat().filter((it) => {
+      if (seen.has(it.seq)) return false;
+      seen.add(it.seq);
+      return true;
+    });
+    return collapseToolMessages(merged, sessionId);
+  }, [history.data, sessionId]);
+
   const allMessages = useMemo<Message[]>(() => [
-    ...(history.data ?? []),
+    ...historyMessages,
     ...liveMessages,
-  ], [history.data, liveMessages]);
+  ], [historyMessages, liveMessages]);
 
   // Total rendered-content size. Streaming updates grow a live bubble in place
   // (body text, tool calls, tool results) without changing the message count,
@@ -287,6 +336,43 @@ function SessionPage() {
     setShowNewMsgPill(false);
     messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
   }, []);
+
+  // ── Progressive history scroll behavior ─────────────────────────────────
+  const loadOlderIfNeeded = useCallback(() => {
+    const el = scrollContainerRef.current;
+    if (!el || !didInitialScrollRef.current) return;
+    if (el.scrollTop > 120) return;
+    if (!history.hasNextPage || history.isFetchingNextPage) return;
+    prependAnchorRef.current = { height: el.scrollHeight, top: el.scrollTop };
+    void history.fetchNextPage();
+  }, [history.hasNextPage, history.isFetchingNextPage, history.fetchNextPage]);
+
+  // Restore scroll position after a prepend (must run before paint).
+  useLayoutEffect(() => {
+    const anchor = prependAnchorRef.current;
+    const el = scrollContainerRef.current;
+    if (!anchor || !el) return;
+    prependAnchorRef.current = null;
+    el.scrollTop = anchor.top + (el.scrollHeight - anchor.height);
+  }, [historyMessages.length]);
+
+  // Start at the bottom (newest messages) on session entry.
+  useLayoutEffect(() => {
+    if (didInitialScrollRef.current || !history.isSuccess) return;
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    didInitialScrollRef.current = true;
+    el.scrollTop = el.scrollHeight;
+  }, [history.isSuccess, historyMessages.length]);
+
+  // Keep fetching older pages until the list is scrollable (no scroll events otherwise).
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el || !didInitialScrollRef.current) return;
+    if (el.scrollHeight > el.clientHeight) return;
+    if (!history.hasNextPage || history.isFetchingNextPage) return;
+    void history.fetchNextPage();
+  }, [historyMessages.length, history.hasNextPage, history.isFetchingNextPage, history.fetchNextPage]);
 
   // Auto-grow the composer textarea + drive the compact↔expanded layout flip.
   // Reset to auto first so deleting lines shrinks the box; overflow stays hidden
@@ -720,10 +806,10 @@ function SessionPage() {
           showToast(t('toast.run_stopped'));
         }
 
-        // Done: refetch history → clear liveMessages → stop streaming → invalidate
+        // Done: tail catch-up → clear liveMessages → stop streaming → invalidate.
         void (async () => {
           if (sessionId) {
-            await queryClient.refetchQueries({ queryKey: ['messages', sessionId] });
+            await fetchPreviousPage();
           }
           setLiveMessages([]);
           wsOutputsRef.current.clear();
@@ -742,24 +828,26 @@ function SessionPage() {
 
       if (event.type === 'agent_run_idle') {
         // The server has no active run for this session (completed before we
-        // subscribed, or server restarted). resyncSession re-requests this on every
-        // entry, so refetch history once to surface any persisted messages and reset
-        // streaming state — covers navigating away mid-run and returning after done.
+        // subscribed, or server restarted). Clear the inactivity watchdog
+        // unconditionally; only reset run state + tail catch-up when we were
+        // actually streaming, so a bare idle on entry doesn't force a refetch.
         if (wsInactivityTimerRef.current) {
           clearTimeout(wsInactivityTimerRef.current);
           wsInactivityTimerRef.current = null;
         }
         setRunDelayed(false);
-        void queryClient.refetchQueries({ queryKey: ['messages', sessionId] });
-        setLiveMessages([]);
-        wsOutputsRef.current.clear();
-        maxSeqRef.current = -1;
-        optimisticUserIdRef.current = null;
-        currentRunIdRef.current = null;
-        setStreaming(false);
-        streamingRef.current = false;
-        setOwnedRunId(null);
-        setStopping(false);
+        if (streamingRef.current) {
+          void fetchPreviousPage();
+          setLiveMessages([]);
+          wsOutputsRef.current.clear();
+          maxSeqRef.current = -1;
+          optimisticUserIdRef.current = null;
+          currentRunIdRef.current = null;
+          setStreaming(false);
+          streamingRef.current = false;
+          setOwnedRunId(null);
+          setStopping(false);
+        }
       }
     });
 
@@ -770,7 +858,7 @@ function SessionPage() {
         wsInactivityTimerRef.current = null;
       }
     };
-  }, [sessionId, sessionPrefix, projectSlug, projectId, queryClient, showToast, t, armWatchdog]);
+  }, [sessionId, sessionPrefix, projectSlug, projectId, queryClient, showToast, t, armWatchdog, fetchPreviousPage]);
 
   const shareMutation = useMutation({
     mutationFn: (mode: ShareMode) => updateSessionShareMode(sessionPrefix, mode),
@@ -864,8 +952,11 @@ function SessionPage() {
           </div>
         </div>
 
-        <div className="cw-messages-scroll" ref={scrollContainerRef}>
+        <div className="cw-messages-scroll" ref={scrollContainerRef} onScroll={loadOlderIfNeeded}>
         <div className="cw-messages">
+          {history.isFetchingNextPage && (
+            <div className="cw-history-loading" aria-live="polite">{t('ui.loading_history')}</div>
+          )}
           {allMessages.map((msg) => (
             <MessageBubble
               key={msg.id}

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -148,6 +148,9 @@ function SessionPage() {
   // Previous message count, to distinguish "new message arrived" from the
   // initial history load / refetch (no pill on first render of a session).
   const prevMsgCountRef = useRef(0);
+  // Id of the first rendered message. When it changes the list grew from the
+  // top (older-page prepend), not the tail — used to suppress auto-follow there.
+  const prevFirstIdRef = useRef<string | undefined>(undefined);
 
   // WS-driven: outputs map keyed by seq (for idempotent catch-up + live merging)
   const wsOutputsRef = useRef<Map<number, MessageOutput>>(new Map());
@@ -226,6 +229,7 @@ function SessionPage() {
     doneRunIdsRef.current.clear();
     forceScrollRef.current = false;
     prevMsgCountRef.current = 0;
+    prevFirstIdRef.current = undefined;
     prependAnchorRef.current = null;
     didInitialScrollRef.current = false;
   }
@@ -290,6 +294,9 @@ function SessionPage() {
     if (!el) return;
     const prevCount = prevMsgCountRef.current;
     prevMsgCountRef.current = allMessages.length;
+    const prevFirstId = prevFirstIdRef.current;
+    const firstId = allMessages[0]?.id;
+    prevFirstIdRef.current = firstId;
 
     // Own send — jump to the bottom immediately, even if scrolled far up.
     if (forceScrollRef.current) {
@@ -302,6 +309,13 @@ function SessionPage() {
     // Initial history load (refresh / session entry) — start at the bottom.
     if (prevCount === 0) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'instant' });
+      return;
+    }
+
+    // Older-page prepend grows the list from the top (first id changes), not
+    // the tail. The prepend-restore layout effect already keeps the viewport
+    // anchored, so don't mistake it for a new tail message and auto-follow.
+    if (firstId !== undefined && firstId !== prevFirstId) {
       return;
     }
 
@@ -369,6 +383,10 @@ function SessionPage() {
     if (!el || !didInitialScrollRef.current) return;
     if (el.scrollHeight > el.clientHeight) return;
     if (!history.hasNextPage || history.isFetchingNextPage) return;
+    // Anchor so the prepend-restore effect repositions the viewport. The list
+    // isn't scrollable yet (scrollTop 0), so the restore clamps to the bottom,
+    // keeping the newest messages in view while older context backfills above.
+    prependAnchorRef.current = { height: el.scrollHeight, top: el.scrollTop };
     void history.fetchNextPage();
   }, [historyMessages.length, history.hasNextPage, history.isFetchingNextPage, history.fetchNextPage]);
 

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -544,6 +544,9 @@ function SessionPage() {
     setLiveMessages((prev) => [...prev, userMsg]);
     setStreaming(true);
     streamingRef.current = true;
+    // Keep the composer focused for the next message — covers the send-button
+    // click path too (Enter already leaves focus in the textarea).
+    composerRef.current?.focus();
 
     try {
       const ack = await sendMessage(sessionId, text, attachmentPaths.length > 0 ? attachmentPaths : undefined);
@@ -1038,7 +1041,6 @@ function SessionPage() {
               onChange={(e) => setComposerText(e.target.value)}
               onKeyDown={handleComposerKeyDown}
               placeholder={t('ui.composer_placeholder')}
-              disabled={streaming}
               rows={1}
             />
             <div className="cw-composer-actions">

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -330,6 +330,7 @@ body.is-resizing-sidebar .cw-app-shell[data-sidebar-mode="hidden"] .cw-sidebar-a
    wide screens the bubble column can stay narrow without dragging the
    scrollbar inward with it. */
 .cw-messages-scroll { flex: 1; min-height: 0; overflow-y: auto; width: 100%; }
+.cw-history-loading { text-align: center; color: var(--cw-fg-4); font-size: 12px; padding: 6px 0 2px; }
 .cw-messages { padding: 24px 28px 24px; width: 100%; max-width: 860px; margin: 0 auto; }
 .cw-message-meta { display: flex; align-items: center; gap: 8px; font-size: 12px; }
 .cw-message-meta span { border: 1px solid var(--cw-border); color: var(--cw-fg-3); border-radius: var(--cw-radius-sm); padding: 1px 5px; font-size: 10px; }

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -743,12 +743,31 @@ pub async fn fork_session(
 
 // ── Messages ──────────────────────────────────────────────────────────────────
 
-/// GET /sessions/{session_id}/messages
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct MessageHistoryQuery {
+    /// Max TURNS below the cursor. Omit for everything; ignored with `after_seq`.
+    pub limit: Option<u32>,
+    /// Keyset cursor for older pages: only messages with `seq < before_seq`.
+    pub before_seq: Option<i64>,
+    /// Tail catch-up: messages with `seq > after_seq`. Exclusive with `before_seq`.
+    pub after_seq: Option<i64>,
+}
+
+/// GET /sessions/{session_id}/messages?limit=...&before_seq=...|after_seq=...
+/// Items are returned in ascending (oldest→newest) order within the window.
 pub async fn get_message_history(
     State(state): State<Arc<AppState>>,
     Extension(auth_user): Extension<AuthUser>,
     Path(session_ref): Path<String>,
+    axum::extract::Query(q): axum::extract::Query<MessageHistoryQuery>,
 ) -> ApiResult<Json<SessionMessageListResponse>> {
+    if q.before_seq.is_some() && q.after_seq.is_some() {
+        return Err(AppError::bad_request(
+            "before_seq and after_seq are mutually exclusive",
+        ));
+    }
+
     let session_id = resolve_session_id(&state, &session_ref).await?;
     let (_session, _access) = state
         .repository
@@ -757,11 +776,18 @@ pub async fn get_message_history(
         .map_err(|e| AppError::internal(e.to_string()))?
         .ok_or_else(|| AppError::not_found("session not found or access denied"))?;
 
-    let rows = state
-        .repository
-        .get_messages(session_id)
-        .await
-        .map_err(|e| AppError::internal(e.to_string()))?;
+    let rows = match q.after_seq {
+        Some(after_seq) => state
+            .repository
+            .get_messages_after(session_id, after_seq)
+            .await
+            .map_err(|e| AppError::internal(e.to_string()))?,
+        None => state
+            .repository
+            .get_messages_window(session_id, q.limit, q.before_seq)
+            .await
+            .map_err(|e| AppError::internal(e.to_string()))?,
+    };
 
     let items = rows
         .into_iter()
@@ -779,6 +805,7 @@ pub async fn get_message_history(
                 },
             };
             Ok(SessionMessageResponse {
+                seq: r.seq,
                 message: r.message,
                 sender,
                 created_at: r.created_at,
@@ -788,11 +815,14 @@ pub async fn get_message_history(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Auto-mark all messages as read for this user
-    let _ = state
-        .repository
-        .mark_session_read(session_id, auth_user.id)
-        .await;
+    // Mark read only when the client is at the tail (no before_seq) —
+    // paging older history must not clear unread.
+    if q.before_seq.is_none() {
+        let _ = state
+            .repository
+            .mark_session_read(session_id, auth_user.id)
+            .await;
+    }
 
     Ok(Json(SessionMessageListResponse { items }))
 }

--- a/backend/src/model/session.rs
+++ b/backend/src/model/session.rs
@@ -102,6 +102,8 @@ pub enum MessageSender {
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 pub struct SessionMessageResponse {
+    /// Session-global insertion order — stable client identity across windows.
+    pub seq: i64,
     pub message: Message,
     pub sender: MessageSender,
     pub created_at: DateTime<Utc>,

--- a/backend/src/repository/session.rs
+++ b/backend/src/repository/session.rs
@@ -94,6 +94,9 @@ impl DbSenderKind {
 
 #[derive(Debug, Clone)]
 pub struct DbSessionMessage {
+    /// Session-global insertion order — stable client identity (ailoy
+    /// `Message.id` is tool-call-only).
+    pub seq: i64,
     pub message: Message,
     pub sender_kind: DbSenderKind,
     pub sender_name: Option<String>,
@@ -606,61 +609,119 @@ impl SqliteRepository {
     }
 
     pub async fn get_messages(&self, session_id: Uuid) -> RepositoryResult<Vec<DbSessionMessage>> {
+        self.get_messages_window(session_id, None, None).await
+    }
+
+    /// Keyset window in TURN units (a user message + the agent/tool messages
+    /// after it): the newest `limit` turns with `seq < before_seq`, ascending.
+    /// `before_seq=None` = from the end; `limit=None` = everything below the
+    /// cursor. Windows are immutable under appends and never split a turn.
+    pub async fn get_messages_window(
+        &self,
+        session_id: Uuid,
+        limit: Option<u32>,
+        before_seq: Option<i64>,
+    ) -> RepositoryResult<Vec<DbSessionMessage>> {
+        // turn_id = cumulative user-message count. Rows before the first user
+        // message (turn_id 0) clamp into the oldest turn; `top` clamps the same
+        // way so a user-message-free history reads as one turn.
         let rows = sqlx::query(
-            "SELECT message_json, sender_kind, sender_name, sender_user_id, created_at, attachments, artifacts \
-             FROM session_messages WHERE session_id = ? ORDER BY seq ASC;",
+            "WITH numbered AS (
+                 SELECT seq, message_json, sender_kind, sender_name, sender_user_id, \
+                        created_at, attachments, artifacts, \
+                        SUM(CASE WHEN sender_kind = 'user' THEN 1 ELSE 0 END) \
+                            OVER (ORDER BY seq) AS turn_id
+                 FROM session_messages
+                 WHERE session_id = ?1 AND (?2 IS NULL OR seq < ?2)
+             ),
+             bounds AS (
+                 SELECT CASE WHEN COALESCE(MAX(turn_id), 0) < 1 THEN 1 ELSE MAX(turn_id) END AS top
+                 FROM numbered
+             )
+             SELECT seq, message_json, sender_kind, sender_name, sender_user_id, \
+                    created_at, attachments, artifacts
+             FROM numbered, bounds
+             WHERE ?3 IS NULL OR MAX(turn_id, 1) > top - ?3
+             ORDER BY seq ASC;",
         )
         .bind(session_id.to_string())
+        .bind(before_seq)
+        .bind(limit.map(i64::from))
         .fetch_all(&self.pool)
         .await?;
 
         rows.into_iter()
-            .map(|row| {
-                let json = row.get::<String, _>("message_json");
-                let message = serde_json::from_str::<Message>(&json)
-                    .map_err(crate::repository::RepositoryError::Serialization)?;
+            .map(Self::row_to_db_session_message)
+            .collect()
+    }
 
-                let kind_str: String = row.get("sender_kind");
-                let sender_kind = DbSenderKind::from_str(&kind_str).ok_or_else(|| {
+    /// Tail catch-up: every message with `seq > after_seq`, ascending.
+    /// Appends are whole turns, so no turn-window logic is needed.
+    pub async fn get_messages_after(
+        &self,
+        session_id: Uuid,
+        after_seq: i64,
+    ) -> RepositoryResult<Vec<DbSessionMessage>> {
+        let rows = sqlx::query(
+            "SELECT seq, message_json, sender_kind, sender_name, sender_user_id, \
+                    created_at, attachments, artifacts \
+             FROM session_messages WHERE session_id = ? AND seq > ? ORDER BY seq ASC;",
+        )
+        .bind(session_id.to_string())
+        .bind(after_seq)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(Self::row_to_db_session_message)
+            .collect()
+    }
+
+    fn row_to_db_session_message(
+        row: sqlx::sqlite::SqliteRow,
+    ) -> RepositoryResult<DbSessionMessage> {
+        let json = row.get::<String, _>("message_json");
+        let message = serde_json::from_str::<Message>(&json)
+            .map_err(crate::repository::RepositoryError::Serialization)?;
+
+        let kind_str: String = row.get("sender_kind");
+        let sender_kind = DbSenderKind::from_str(&kind_str).ok_or_else(|| {
+            crate::repository::RepositoryError::InvalidData(format!(
+                "invalid sender_kind: {kind_str}"
+            ))
+        })?;
+
+        let sender_name: Option<String> = row.get("sender_name");
+        let sender_user_id: Option<Uuid> = row
+            .try_get::<Option<String>, _>("sender_user_id")
+            .unwrap_or(None)
+            .map(|s| {
+                Uuid::parse_str(&s).map_err(|_| {
                     crate::repository::RepositoryError::InvalidData(format!(
-                        "invalid sender_kind: {kind_str}"
+                        "invalid sender_user_id uuid: {s}"
                     ))
-                })?;
-
-                let sender_name: Option<String> = row.get("sender_name");
-                let sender_user_id: Option<Uuid> = row
-                    .try_get::<Option<String>, _>("sender_user_id")
-                    .unwrap_or(None)
-                    .map(|s| {
-                        Uuid::parse_str(&s).map_err(|_| {
-                            crate::repository::RepositoryError::InvalidData(format!(
-                                "invalid sender_user_id uuid: {s}"
-                            ))
-                        })
-                    })
-                    .transpose()?;
-                let created_at =
-                    Self::parse_timestamp(row.get("created_at"), "session_messages.created_at")?;
-
-                let attachments_json: String = row.try_get("attachments").unwrap_or_default();
-                let attachments: Vec<String> =
-                    serde_json::from_str(&attachments_json).unwrap_or_default();
-
-                let artifacts_json: String = row.try_get("artifacts").unwrap_or_default();
-                let artifacts: Vec<String> =
-                    serde_json::from_str(&artifacts_json).unwrap_or_default();
-
-                Ok(DbSessionMessage {
-                    message,
-                    sender_kind,
-                    sender_name,
-                    sender_user_id,
-                    created_at,
-                    attachments,
-                    artifacts,
                 })
             })
-            .collect()
+            .transpose()?;
+        let created_at =
+            Self::parse_timestamp(row.get("created_at"), "session_messages.created_at")?;
+
+        let attachments_json: String = row.try_get("attachments").unwrap_or_default();
+        let attachments: Vec<String> = serde_json::from_str(&attachments_json).unwrap_or_default();
+
+        let artifacts_json: String = row.try_get("artifacts").unwrap_or_default();
+        let artifacts: Vec<String> = serde_json::from_str(&artifacts_json).unwrap_or_default();
+
+        Ok(DbSessionMessage {
+            seq: row.get::<i64, _>("seq"),
+            message,
+            sender_kind,
+            sender_name,
+            sender_user_id,
+            created_at,
+            attachments,
+            artifacts,
+        })
     }
 
     /// Remove an artifact path from all messages in a session.

--- a/backend/tests/session_messages_test.rs
+++ b/backend/tests/session_messages_test.rs
@@ -810,3 +810,336 @@ fn inject_then_re_inject_is_idempotent_on_text_prefix() {
         "original text must remain as prefix: {text}"
     );
 }
+
+// ── reverse-indexed pagination ────────────────────────────────────────────────
+
+fn history_texts(body: &serde_json::Value) -> Vec<String> {
+    body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| {
+            i["message"]["contents"][0]["text"]
+                .as_str()
+                .unwrap_or("")
+                .to_string()
+        })
+        .collect()
+}
+
+/// text → seq map from a full-history response, for building cursor queries.
+fn history_seqs(body: &serde_json::Value) -> std::collections::HashMap<String, i64> {
+    body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| {
+            (
+                i["message"]["contents"][0]["text"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_string(),
+                i["seq"].as_i64().unwrap(),
+            )
+        })
+        .collect()
+}
+
+/// GET messages?limit=&before_seq=/after_seq= pages by keyset cursor in TURN
+/// units, returning each window in ascending order. Omitting all params
+/// returns everything. (Every message here is a user message, so turns ==
+/// messages.)
+#[tokio::test]
+async fn get_message_history_supports_reverse_window() {
+    let (app, repo, _state) = common::make_app_repo_state().await;
+
+    let username = format!("user_{}", Uuid::new_v4().simple());
+    let user_info = signup(&app, &username, "Password123!").await;
+    let user_id = Uuid::parse_str(user_info["id"].as_str().unwrap()).unwrap();
+    let token = login(&app, &username, "Password123!").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let project_id = Uuid::parse_str(project["id"].as_str().unwrap()).unwrap();
+
+    let session = repo.create_session(project_id, user_id).await.unwrap();
+    let msgs: Vec<Message> = (0..5)
+        .map(|i| Message::new(Role::User).with_contents([Part::text(format!("m{i}"))]))
+        .collect();
+    repo.append_messages(session.id, &common::to_new_msgs(&msgs, user_id))
+        .await
+        .unwrap();
+
+    // Full fetch first to learn each message's seq for cursor queries.
+    let (_, full) = authed(
+        &app,
+        "GET",
+        &format!("/sessions/{}/messages", session.id),
+        &token,
+        None,
+    )
+    .await;
+    let seqs = history_seqs(&full);
+
+    for (query, expected) in [
+        ("?limit=2".to_string(), vec!["m3", "m4"]),
+        (
+            format!("?limit=2&before_seq={}", seqs["m3"]),
+            vec!["m1", "m2"],
+        ),
+        (format!("?before_seq={}", seqs["m1"]), vec!["m0"]),
+        ("?limit=10".to_string(), vec!["m0", "m1", "m2", "m3", "m4"]),
+        (String::new(), vec!["m0", "m1", "m2", "m3", "m4"]),
+        (format!("?after_seq={}", seqs["m2"]), vec!["m3", "m4"]),
+    ] {
+        let (status, body) = authed(
+            &app,
+            "GET",
+            &format!("/sessions/{}/messages{query}", session.id),
+            &token,
+            None,
+        )
+        .await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "history failed ({query}): {body}"
+        );
+        assert_eq!(
+            history_texts(&body),
+            expected,
+            "unexpected window for {query}: {body}"
+        );
+    }
+
+    // before_seq and after_seq are mutually exclusive.
+    let (status, _) = authed(
+        &app,
+        "GET",
+        &format!(
+            "/sessions/{}/messages?before_seq={}&after_seq={}",
+            session.id, seqs["m3"], seqs["m1"]
+        ),
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        axum::http::StatusCode::BAD_REQUEST,
+        "both cursors must be rejected"
+    );
+}
+
+/// Turns are the pagination unit: a user message plus the agent messages that
+/// follow it never get split across windows, and messages preceding the first
+/// user message ride along with the oldest turn.
+#[tokio::test]
+async fn get_message_history_windows_are_whole_turns() {
+    let (app, repo, _state) = common::make_app_repo_state().await;
+
+    let username = format!("user_{}", Uuid::new_v4().simple());
+    let user_info = signup(&app, &username, "Password123!").await;
+    let user_id = Uuid::parse_str(user_info["id"].as_str().unwrap()).unwrap();
+    let token = login(&app, &username, "Password123!").await;
+    let project = common::get_personal_project(&app, &token).await;
+    let project_id = Uuid::parse_str(project["id"].as_str().unwrap()).unwrap();
+
+    // pre (agent) | u0 a0 a0b | u1 a1 | u2  →  3 turns, preamble rides with turn 1.
+    let session = repo.create_session(project_id, user_id).await.unwrap();
+    let msgs = vec![
+        Message::new(Role::Assistant).with_contents([Part::text("pre")]),
+        Message::new(Role::User).with_contents([Part::text("u0")]),
+        Message::new(Role::Assistant).with_contents([Part::text("a0")]),
+        Message::new(Role::Assistant).with_contents([Part::text("a0b")]),
+        Message::new(Role::User).with_contents([Part::text("u1")]),
+        Message::new(Role::Assistant).with_contents([Part::text("a1")]),
+        Message::new(Role::User).with_contents([Part::text("u2")]),
+    ];
+    repo.append_messages(session.id, &common::to_new_msgs(&msgs, user_id))
+        .await
+        .unwrap();
+
+    // Full fetch first to learn each message's seq for cursor queries.
+    let (_, full) = authed(
+        &app,
+        "GET",
+        &format!("/sessions/{}/messages", session.id),
+        &token,
+        None,
+    )
+    .await;
+    let seqs = history_seqs(&full);
+
+    for (query, expected) in [
+        ("?limit=1".to_string(), vec!["u2"]),
+        ("?limit=2".to_string(), vec!["u1", "a1", "u2"]),
+        (
+            format!("?limit=1&before_seq={}", seqs["u2"]),
+            vec!["u1", "a1"],
+        ),
+        (
+            format!("?limit=2&before_seq={}", seqs["u2"]),
+            vec!["pre", "u0", "a0", "a0b", "u1", "a1"],
+        ),
+        (
+            format!("?before_seq={}", seqs["u1"]),
+            vec!["pre", "u0", "a0", "a0b"],
+        ),
+        (
+            "?limit=9".to_string(),
+            vec!["pre", "u0", "a0", "a0b", "u1", "a1", "u2"],
+        ),
+        (format!("?before_seq={}", seqs["pre"]), vec![]),
+        // Tail catch-up: everything strictly after a0b, whole turns included.
+        (
+            format!("?after_seq={}", seqs["a0b"]),
+            vec!["u1", "a1", "u2"],
+        ),
+    ] {
+        let (status, body) = authed(
+            &app,
+            "GET",
+            &format!("/sessions/{}/messages{query}", session.id),
+            &token,
+            None,
+        )
+        .await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "history failed ({query}): {body}"
+        );
+        assert_eq!(
+            history_texts(&body),
+            expected,
+            "unexpected window for {query}: {body}"
+        );
+    }
+
+    // A history with no user message at all counts as a single turn.
+    let agent_only = repo.create_session(project_id, user_id).await.unwrap();
+    let msgs = vec![
+        Message::new(Role::Assistant).with_contents([Part::text("only-a")]),
+        Message::new(Role::Assistant).with_contents([Part::text("only-b")]),
+    ];
+    repo.append_messages(agent_only.id, &common::to_new_msgs(&msgs, user_id))
+        .await
+        .unwrap();
+    let (_, full) = authed(
+        &app,
+        "GET",
+        &format!("/sessions/{}/messages", agent_only.id),
+        &token,
+        None,
+    )
+    .await;
+    let seqs = history_seqs(&full);
+    for (query, expected) in [
+        ("?limit=3".to_string(), vec!["only-a", "only-b"]),
+        (format!("?before_seq={}", seqs["only-a"]), vec![]),
+    ] {
+        let (_, body) = authed(
+            &app,
+            "GET",
+            &format!("/sessions/{}/messages{query}", agent_only.id),
+            &token,
+            None,
+        )
+        .await;
+        assert_eq!(
+            history_texts(&body),
+            expected,
+            "unexpected agent-only window for {query}: {body}"
+        );
+    }
+}
+
+/// Paging through older history (before_seq) must NOT mark the session read;
+/// fetching the tail (no cursor, or after_seq) must.
+#[tokio::test]
+async fn reading_older_pages_does_not_mark_session_read() {
+    let (app, repo, _state) = common::make_app_repo_state().await;
+
+    let alice_info = signup(&app, "alice_page_read", "Password123!").await;
+    let alice_token = login(&app, "alice_page_read", "Password123!").await;
+    let alice_project = common::get_personal_project(&app, &alice_token).await;
+    let project_slug = alice_project["slug"].as_str().unwrap();
+    let project_id = Uuid::parse_str(alice_project["id"].as_str().unwrap()).unwrap();
+    let alice_id = Uuid::parse_str(alice_info["id"].as_str().unwrap()).unwrap();
+
+    signup(&app, "bob_page_read", "Password123!").await;
+    let bob_token = login(&app, "bob_page_read", "Password123!").await;
+    common::add_member(&app, &alice_token, project_slug, "bob_page_read").await;
+
+    let session = repo.create_session(project_id, alice_id).await.unwrap();
+    repo.update_session_share_mode(
+        session.id,
+        &agent_k_backend::repository::ShareMode::SharedChat,
+    )
+    .await
+    .unwrap();
+    let msgs: Vec<Message> = (0..3)
+        .map(|i| Message::new(Role::User).with_contents([Part::text(format!("m{i}"))]))
+        .collect();
+    repo.append_messages(session.id, &common::to_new_msgs(&msgs, alice_id))
+        .await
+        .unwrap();
+
+    let bob_unread = |app: axum::Router, token: String| async move {
+        let (_, body) = authed(
+            &app,
+            "GET",
+            &format!("/sessions/{}", session.id),
+            &token,
+            None,
+        )
+        .await;
+        body["unread_count"].as_i64().unwrap_or(-1)
+    };
+
+    assert!(
+        bob_unread(app.clone(), bob_token.clone()).await > 0,
+        "bob should start with unread messages"
+    );
+
+    // Older page (before_seq) — unread must survive. Read seqs via the repo,
+    // not GET (a cursorless GET would mark the session read).
+    let newest_seq = repo
+        .get_messages(session.id)
+        .await
+        .unwrap()
+        .last()
+        .unwrap()
+        .seq;
+    let (status, _) = authed(
+        &app,
+        "GET",
+        &format!(
+            "/sessions/{}/messages?limit=1&before_seq={newest_seq}",
+            session.id
+        ),
+        &bob_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(
+        bob_unread(app.clone(), bob_token.clone()).await > 0,
+        "before_seq page must not mark the session read"
+    );
+
+    // Newest window (no cursor) — marks read.
+    let (status, _) = authed(
+        &app,
+        "GET",
+        &format!("/sessions/{}/messages?limit=1", session.id),
+        &bob_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(
+        bob_unread(app.clone(), bob_token.clone()).await,
+        0,
+        "cursorless fetch must mark the session read"
+    );
+}


### PR DESCRIPTION
## Changes

- **`GET /sessions/{id}/messages` supports cursor-based pagination in turn units**
  (a user message + the agent/tool messages that follow it):
  - `limit` + `before_seq` — newest N turns below the cursor (older pages)
  - `after_seq` — tail catch-up with every message after the cursor
  - windows never split a turn and are immutable under appends
- **Responses carry `seq`** for stable client-side message identity across windows.
- **mark-read only fires on tail requests** (no `before_seq`) — paging older
  history doesn't clear unread.
- **Session page loads progressively**: latest turn window on entry (scrolled to
  bottom), and older pages load when the user scrolls within **120px of the top**
  of the message list (scroll position preserved across the prepend; pages also
  auto-fill while the list is shorter than the viewport).
- **Composer keeps focus after sending** — the textarea is no longer disabled while
  a run streams, so focus stays in the input (and you can draft the next message
  during the response); the send button and send guard still block the actual send
  until the run completes.

## Fetch flow
<img width="1010" height="540" alt="message-pagination-flow" src="https://github.com/user-attachments/assets/85ae4103-c700-4fa4-88f8-b7544bc15e3b" />

## Notes

- Pages merge oldest→newest and collapse tool messages once over the merged
  array, so `tool_call`/result pairs survive window boundaries; `seq` dedupe
  absorbs overlap from stale `after_seq` refetches.
- While streaming, the new turn renders via WS `liveMessages` only — the tail
  fetch happens after the run persists.

## Test plan

- [x] `cargo test` — cursor windows, whole-turn boundaries (incl. preamble &
  agent-only histories), `before_seq`+`after_seq` → 400, mark-read gating
- [x] `tsc --noEmit`
- [x] Manual test: Look into the network tab in browser dev tool during 'entering the seesion page', 'scrolling up to top', 'sending a new message(start a new turn)'

### API calls
#### Enter session page
Get messages with latest 10 turns. (seq: 27-60)
<details>
  <summary>Show</summary>
<img width="375" height="528" alt="스크린샷 2026-06-08 오전 11 08 38" src="https://github.com/user-attachments/assets/ab2328fb-c06e-473f-b880-32408a6c8019" />
</details>

#### Scroll up to top
Get messages of 10 turns _before_ the oldest message(seq: 27) that the page had
<details>
  <summary>Show</summary>
<img width="380" height="382" alt="스크린샷 2026-06-08 오전 11 09 15" src="https://github.com/user-attachments/assets/52716684-50c6-4159-91e6-04f5cf1f5dfa" />
</details>

#### New turn
Get all messages _after_ the newest message(seq: 60) that the page had
<details>
  <summary>Show</summary>
<img width="386" height="466" alt="스크린샷 2026-06-08 오전 11 10 25" src="https://github.com/user-attachments/assets/27e85401-33d1-41c0-9e8d-3ba15fe3445e" />
</details>
