### PR TITLE
fix(docling-sys): bundle hf_xet so Xet-backed model downloads work

### DIFF
--- a/docling-sys/build.rs
+++ b/docling-sys/build.rs
@@ -14,7 +14,6 @@ const PYINSTALLER_ARGS: &[&str] = &[
     "--collect-all=docling_core",
     "--collect-all=docling_ibm_models",
     "--collect-all=docling_parse",
-    "--exclude-module=hf_xet",
     "--exclude-module=faker",
     "--exclude-module=tree_sitter",
     "--exclude-module=tree_sitter_typescript",


### PR DESCRIPTION
## Problem

PDF ingest through `docling-sys` failed for every PDF on any machine with a cold HuggingFace model cache. MD/TXT ingest was fine. The error surfaced as `docling conversion failed`, and the underlying `run_docling` stderr was `ModuleNotFoundError: No module named 'hf_xet'` followed by `ValueError: To use optimized download using Xet storage, you need to install the hf_xet package`.

## Root cause

`build.rs` passed `--exclude-module=hf_xet` to PyInstaller to slim the bundle (alongside `faker` and the `tree_sitter` modules). That dropped the native `hf_xet/hf_xet.abi3.so` but left the `hf_xet-1.4.3.dist-info` metadata in the bundle.

huggingface_hub's `is_package_available("hf_xet")` checks only `importlib.metadata.version()`, so the leftover dist-info made it report `hf_xet` as present. The download then took the Xet path and called `from hf_xet import download_files`, which raised `ModuleNotFoundError` because the actual module was absent. The `snapshot_download` batch path (which docling uses to fetch its layout model) raises on that import failure rather than falling back to HTTP, so the whole conversion died before parsing any PDF.

This is not triggered by any external HuggingFace change and is not specific to a particular PDF. It reproduces deterministically whenever `run_docling` downloads a model with an empty cache.

## Why it went unnoticed

The only test that exercises real PDF conversion is `translate_pdf_from_financebench` in `translator/mod.rs`, and it is gated three ways: `#[ignore]`, `#[cfg(feature = "internal")]`, and a dependency on the internal FinanceBench example dataset. It is effectively manual-only and never runs in CI. Every automated document test uses MD/TXT, which never downloads a model. So the PDF path had not been exercised on a cold cache until now.

## Fix

Drop `--exclude-module=hf_xet`. The bundle now includes the real `.so`, so both the availability check and the Xet download path work as intended. `hf_xet` was already in `uv.lock` and the venv, so no dependency change is needed. Cost is bundle size: the `hf_xet` native extension adds about 6.8 MB.

## Verification

Rebuilt the bundle and confirmed `_internal/hf_xet/hf_xet.abi3.so` is present. Ran `run_docling` directly with a cold HF cache (moved `~/.cache/huggingface` aside) and no `HF_HUB_DISABLE_XET` workaround: the PDF converts to markdown (exit 0) and `~/.cache/huggingface/xet/` chunk cache is created, confirming `hf_xet` loads and the Xet client runs.