### PR TITLE
fix(backend): make resolve-model test env-independent

### DIFF
--- a/backend/src/model/llm.rs
+++ b/backend/src/model/llm.rs
@@ -365,8 +365,11 @@ mod tests {
         }
         let pinned = resolve_model(Some("coworker"), Some("anthropic/claude-opus-4-8"));
         assert!(catalog_entry(&pinned).is_some());
-        // An unknown/empty pin is ignored, falling through to the chain.
-        let bogus = resolve_model(Some("buddy"), Some("openai/does-not-exist"));
+        // A pin whose provider is not configured is ignored, falling through to
+        // the chain. Use an unregistered provider so the case holds regardless of
+        // which API keys are present — a `<configured-provider>/<unknown>` pin
+        // resolves via the provider glob and would be honored as-is.
+        let bogus = resolve_model(Some("buddy"), Some("nonexistent/model"));
         assert!(catalog_entry(&bogus).is_some());
     }
 }


### PR DESCRIPTION
## Problem

`model::llm::tests::resolve_always_returns_a_catalogued_model` fails whenever the environment has an `OPENAI_API_KEY` set. It passes when that key is absent, so it passed in  #143.

## Root cause

The test's `bogus` case pins `openai/does-not-exist` and asserts the resolver ignores it and falls through to the chain:

```rust
let bogus = resolve_model(Some("buddy"), Some("openai/does-not-exist"));
assert!(catalog_entry(&bogus).is_some());
```

`provider_available` is a provider-level glob check: a provider is "available" when its API key is set, which ailoy reflects as an `openai/*` glob. So when `OPENAI_API_KEY` is present, `provider_available("openai/does-not-exist")` is `true`, the resolver honors the pin as documented ("an explicit pin if its provider is available"), and `openai/does-not-exist` — not in the catalog — is returned, failing the assertion.

The resolver behavior is correct and intentional. The test's `bogus` case is the problem: it isn't a provider-unavailable pin when an OpenAI key exists, so it never exercises the "unknown pin is ignored" path it claims to. This is not OpenAI-specific — any pin of the form `<configured-provider>/<not-in-catalog>` reproduces it (e.g. `anthropic/does-not-exist` when `ANTHROPIC_API_KEY` is set). OpenAI is just the case the test happened to hardcode.

## Fix

Pin a provider that is never registered (`nonexistent/model`), so the pin is ignored regardless of which API keys are present. Resolution then walks the buddy chain in order and returns the first entry whose provider is available, falling back to the chain's terminal entry (`moonshotai/kimi-k2.6`) when none are. Every chain entry is catalogued, so the result is always a real catalog entry — env-independent, as the test's comment promises. No production code changes; `resolve_model_in` is untouched.

## Verification

`cargo test -p agent-k-backend --lib resolve_always_returns_a_catalogued_model` passes both with and without provider keys in the environment.