### PR TITLE
Session title improvement

### DIFF
--- a/app/src/routes/_app.tsx
+++ b/app/src/routes/_app.tsx
@@ -9,6 +9,7 @@ import { useLayoutStore } from '@/stores/layout';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { appWs } from '@/api/ws';
 import type { Session } from '@/domain/types';
+import { shortSessionId } from '@/lib/sessionId';
 
 export const Route = createFileRoute('/_app')({
   beforeLoad: async ({ context }) => {
@@ -59,14 +60,14 @@ function AppShell() {
     appWs.connect(token);
     const unsub = appWs.subscribe((event) => {
       if (event.type === 'session_title_updated') {
+        // Detail query is keyed by the URL prefix (shortSessionId of the UUID) —
+        // patch it directly so the active session page picks up the title without
+        // a refetch. Lists are keyed by ['sessions', slug] (slug unknown here) so
+        // invalidate those.
         queryClient.setQueryData<Session | undefined>(
-          ['session', event.session_id],
+          ['session', shortSessionId(event.session_id)],
           (old) => (old ? { ...old, title: event.title } : old),
         );
-        // Session lists are keyed by ['sessions', slug]. We don't know the slug
-        // from the event (only UUID is carried), and the projects cache may not
-        // be warm yet on cold load. Invalidate all session list queries with the
-        // ['sessions'] prefix — safe because title updates are rare.
         void queryClient.invalidateQueries({ queryKey: ['sessions'] });
       }
     });

--- a/backend/src/model/llm.rs
+++ b/backend/src/model/llm.rs
@@ -197,6 +197,18 @@ pub fn resolve_model_in<S: AsRef<str>>(chain: &[S], pin: Option<&str>) -> String
         })
 }
 
+/// Model chain for session-title generation: Buddy's light chain, but with a
+/// cheaper Gemini lite variant. Resolved against runtime provider availability.
+pub fn resolve_title_model() -> String {
+    const TITLE_CHAIN: &[&str] = &[
+        "openai/gpt-5-nano",
+        "anthropic/claude-haiku-4-5",
+        "google/gemini-2.5-flash-lite",
+        "moonshotai/kimi-k2.6",
+    ];
+    resolve_model_in(TITLE_CHAIN, None)
+}
+
 /// Per-project recommendation-chain overrides, parsed from the
 /// `projects.recommended_chains` JSON column.
 #[derive(Debug, Default)]

--- a/backend/src/services/session_title.rs
+++ b/backend/src/services/session_title.rs
@@ -6,7 +6,6 @@ use ailoy::{
 };
 use futures_util::StreamExt;
 
-const TITLE_MODEL: &str = "openai/gpt-5.4-nano";
 pub const TITLE_MAX_LEN: usize = 60;
 const TITLE_TIMEOUT_SECS: u64 = 15;
 
@@ -21,12 +20,22 @@ pub async fn generate_session_title(first_user_text: &str) -> String {
 
     match result {
         Ok(Ok(title)) if !title.trim().is_empty() => sanitize_session_title(&title),
-        _ => sanitize_session_title(first_user_text),
+        Ok(Err(e)) => {
+            tracing::warn!("session title generation failed ({e}); using first message");
+            sanitize_session_title(first_user_text)
+        }
+        Err(_) => {
+            tracing::warn!(
+                "session title generation timed out after {TITLE_TIMEOUT_SECS}s; using first message"
+            );
+            sanitize_session_title(first_user_text)
+        }
+        Ok(Ok(_)) => sanitize_session_title(first_user_text),
     }
 }
 
 async fn call_llm_for_session_title(text: &str) -> Result<String, String> {
-    let mut agent = AgentBuilder::new(TITLE_MODEL)
+    let mut agent = AgentBuilder::new(&crate::model::resolve_title_model())
         .instruction(
             format!("You are a concise title generator. \
              Try to summarize user's question in a single short phrase (under {TITLE_MAX_LEN} characters). \


### PR DESCRIPTION
## Problem
New sessions only showed their auto-generated title after the first turn finished. The backend generates the title concurrently and broadcasts `session_title_updated`, but the WS handler patched the `['session', <uuid>]` query cache while the session page queries `['session', <prefix>]` (since #115's short-prefix URLs). The live update never hit the page — the title only appeared when `agent_run_done` invalidated the prefix-keyed query.

## Fix
In the `session_title_updated` handler, derive the prefix from the event's UUID with `shortSessionId(...)` and `setQueryData` the prefix-keyed query directly. Frontend-only, no refetch, no backend change; the prefix rule stays in one place (`shortSessionId`).

## Additional changes
### model chain for session title agent
The AI ​​model of the existing session title agent was fixed to `gpt-5.4-nano`; considering the lack of a provider for this, we applied a chain similar to the Model Selection function. The applied chain is hard-coded and consists of the (almost) cheapest non-deprecated components (excluding kimi).

## Test
- Start a new session → title appears as soon as it's generated, before the first response completes.
- `tsc` passes; backend unchanged.