### PR TITLE
fix(models): use callable Gemini 3 Flash id (gemini-3-flash-preview)

### DIFF
--- a/app/scripts/seed_automation_demo.py
+++ b/app/scripts/seed_automation_demo.py
@@ -114,7 +114,7 @@ def main() -> None:
             AUTO_A2, PROJECT_KLIENT, "Weekly digest",
             "주간 핵심 결정 정리 (금요일 발송)",
             json.dumps(["이번 주 핵심 결정 사항을 정리해줘."], ensure_ascii=False),
-            1, "speedwagon", "google/gemini-3-flash", OLIVE_ID, ts(2), ts(2),
+            1, "speedwagon", "google/gemini-3-flash-preview", OLIVE_ID, ts(2), ts(2),
         ),
         (
             AUTO_A3, PROJECT_KLIENT, "On-call ping",
@@ -185,7 +185,7 @@ def main() -> None:
         (SESS_A2_1, PROJECT_KLIENT, OLIVE_ID, "private",
          f"Weekly digest · schedule · {title_ts(50)}",
          None, None, ts(50), ts(75), "automation",
-         "speedwagon", "google/gemini-3-flash"),
+         "speedwagon", "google/gemini-3-flash-preview"),
         (SESS_A3_1, PROJECT_KLIENT, OLIVE_ID, "private",
          f"On-call ping · webhook · {title_ts(40)}",
          None, None, ts(40), ts(60), "automation",

--- a/backend/src/model/llm.rs
+++ b/backend/src/model/llm.rs
@@ -73,7 +73,7 @@ impl AgentType {
             AgentType::Coworker | AgentType::Speedwagon => &[
                 "openai/gpt-5.4-mini",
                 "anthropic/claude-sonnet-4-6",
-                "google/gemini-3-flash",
+                "google/gemini-3-flash-preview",
                 "moonshotai/kimi-k2.6",
             ],
             AgentType::DeepResearch => &[
@@ -131,7 +131,9 @@ pub const CATALOG: &[ModelInfo] = &[
         tier: ModelTier::Standard,
     },
     ModelInfo {
-        id: "google/gemini-3-flash",
+        // Preview is the only callable Gemini 3 Flash id (bare `gemini-3-flash`
+        // 404s); label stays clean so users don't see "preview".
+        id: "google/gemini-3-flash-preview",
         label: "Gemini 3 Flash",
         tier: ModelTier::Standard,
     },

--- a/backend/src/model/llm.rs
+++ b/backend/src/model/llm.rs
@@ -131,8 +131,6 @@ pub const CATALOG: &[ModelInfo] = &[
         tier: ModelTier::Standard,
     },
     ModelInfo {
-        // Preview is the only callable Gemini 3 Flash id (bare `gemini-3-flash`
-        // 404s); label stays clean so users don't see "preview".
         id: "google/gemini-3-flash-preview",
         label: "Gemini 3 Flash",
         tier: ModelTier::Standard,


### PR DESCRIPTION
## Problem

The model catalog and the Coworker/Speedwagon recommendation chain reference `google/gemini-3-flash`, but the Gemini API does not accept that id. Every call returns 404:

> models/gemini-3-flash is not found for API version v1beta, or is not supported for generateContent.

`gemini-3-flash` is the standard-tier google slot of the shared Coworker/Speedwagon chain, so resolution selects it whenever the google entry wins (recommended, or explicitly pinned), and the run then 404s. The id was introduced in #143.

## Fix

Use the callable id `google/gemini-3-flash-preview`. The Gemini 3 Flash model is currently Preview, and the bare `gemini-3-flash` does not resolve. Changed in the catalog, the recommendation chain, and the automation demo seed script.

The internal id and the user-facing label are split on purpose: the id carries `-preview` (what the API needs), while the picker label stays `Gemini 3 Flash` so users do not see "preview".

## Verified

Against the live Gemini API: bare `gemini-3-flash` returns 404 on every call, while `gemini-3-flash-preview` resolves and runs. A FinanceBench corpus-QA probe answered 12/12 questions on `gemini-3-flash-preview` and 0/12 (all 404) on `gemini-3-flash`.

## Note

#165 includes a `speedwagon_chain_uses_gemini_3_1_flash_lite` test (renamed there from `speedwagon_chain_uses_gemini_2_5_flash`) that asserts the Coworker chain contains the literal `google/gemini-3-flash`. After this PR lands, that id becomes `google/gemini-3-flash-preview`, so whichever of the two merges second must update that assertion.

