### PR TITLE
Render tool-call inputs/results as structured rows

### DIFF
--- a/app/src/components/chat/ToolCallDetails.tsx
+++ b/app/src/components/chat/ToolCallDetails.tsx
@@ -1,0 +1,68 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { parseToolCallValue, classifyFieldValue } from '@/lib/toolCallFormat';
+import type { ToolCallInvocation } from '@/domain/types';
+
+/// Renders a parsed tool-call value as React rows — values are shown verbatim (no
+/// markdown parsing), mirroring the structure `valueToMarkdown` uses for copy.
+function ToolCallValueView({ value }: { value: unknown }) {
+  // Memoized so the JSON.parse (in parseToolCallValue) and per-field JSON.stringify
+  // (in classifyFieldValue) run once per value, not on every re-render. String values
+  // compare by value, so an unchanged result string is a cache hit.
+  const view = useMemo(() => {
+    const parsed = parseToolCallValue(value);
+    if (parsed.kind !== 'fields') return parsed;
+    return {
+      kind: 'fields' as const,
+      fields: parsed.fields.map((f) => ({ key: f.key, display: classifyFieldValue(f.value) })),
+    };
+  }, [value]);
+
+  if (view.kind === 'empty') return <p className="cw-toolcall-empty">(empty)</p>;
+  if (view.kind === 'raw') return <pre className="cw-toolcall-raw">{view.text}</pre>;
+  return (
+    <dl className="cw-toolcall-fields">
+      {view.fields.map(({ key, display }) => (
+        <div key={key} className={`cw-toolcall-field${display.kind === 'block' ? ' is-block' : ''}`}>
+          <dt>{key}</dt>
+          <dd>{
+            display.kind === 'block' ? <pre className="cw-toolcall-raw">{display.text}</pre>
+            : display.kind === 'code' ? <pre className="cw-toolcall-inline">{display.text}</pre>
+            : display.text
+          }</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+/// A collapsible tool-call. Inputs/results (and their parsing) are rendered lazily —
+/// only while expanded — so collapsed tool calls cost nothing to parse.
+export function ToolCallDetails({ tc, isStreaming }: { tc: ToolCallInvocation; isStreaming: boolean }) {
+  const { t } = useTranslation('session');
+  const [open, setOpen] = useState(false);
+  return (
+    <details
+      className="cw-toolcall"
+      onToggle={(e) => setOpen((e.currentTarget as HTMLDetailsElement).open)}
+    >
+      <summary>🔧 {tc.name}{tc.result === undefined && isStreaming ? ` · ${t('ui.tool_running')}` : ''}</summary>
+      {open && (
+        <>
+          {tc.arguments !== undefined && (
+            <div className="cw-toolcall-section">
+              <span className="cw-toolcall-section-label">Inputs</span>
+              <ToolCallValueView value={tc.arguments} />
+            </div>
+          )}
+          {tc.result !== undefined && (
+            <div className="cw-toolcall-section">
+              <span className="cw-toolcall-section-label">Results</span>
+              <ToolCallValueView value={tc.result} />
+            </div>
+          )}
+        </>
+      )}
+    </details>
+  );
+}

--- a/app/src/lib/toolCallFormat.test.ts
+++ b/app/src/lib/toolCallFormat.test.ts
@@ -84,4 +84,22 @@ describe('classifyFieldValue', () => {
   it('array → block with pretty-printed JSON', () => {
     expect(classifyFieldValue([1, 2])).toEqual({ kind: 'block', text: '[\n  1,\n  2\n]' });
   });
+
+  // Ambiguous empty values are rendered explicitly so they don't look like a
+  // blank/missing field.
+  it('empty string → explicit ""', () => {
+    expect(classifyFieldValue('')).toEqual({ kind: 'code', text: '""' });
+  });
+
+  it('empty object → inline {}', () => {
+    expect(classifyFieldValue({})).toEqual({ kind: 'inline', text: '{}' });
+  });
+
+  it('empty array → inline []', () => {
+    expect(classifyFieldValue([])).toEqual({ kind: 'inline', text: '[]' });
+  });
+
+  it('null → inline null', () => {
+    expect(classifyFieldValue(null)).toEqual({ kind: 'inline', text: 'null' });
+  });
 });

--- a/app/src/lib/toolCallFormat.test.ts
+++ b/app/src/lib/toolCallFormat.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { asPlainObject, parseToolCallValue, classifyFieldValue } from './toolCallFormat';
+
+describe('asPlainObject', () => {
+  it('returns plain objects as-is', () => {
+    const o = { a: 1 };
+    expect(asPlainObject(o)).toBe(o);
+  });
+
+  it('parses JSON-encoded objects', () => {
+    expect(asPlainObject('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('rejects arrays (top-level and JSON-encoded)', () => {
+    expect(asPlainObject([1, 2])).toBeNull();
+    expect(asPlainObject('[1,2]')).toBeNull();
+  });
+
+  it('rejects non-object scalars and plain strings', () => {
+    expect(asPlainObject('hello')).toBeNull();
+    expect(asPlainObject('42')).toBeNull(); // valid JSON, but a number
+    expect(asPlainObject(42)).toBeNull();
+    expect(asPlainObject(null)).toBeNull();
+  });
+
+  it('does not throw on invalid JSON strings', () => {
+    expect(asPlainObject('{not json')).toBeNull();
+  });
+});
+
+describe('parseToolCallValue', () => {
+  it('maps a plain object to fields', () => {
+    expect(parseToolCallValue({ path: '/a', limit: 5 })).toEqual({
+      kind: 'fields',
+      fields: [
+        { key: 'path', value: '/a' },
+        { key: 'limit', value: 5 },
+      ],
+    });
+  });
+
+  it('treats an empty object as empty', () => {
+    expect(parseToolCallValue({})).toEqual({ kind: 'empty' });
+  });
+
+  it('expands JSON-string objects into fields', () => {
+    expect(parseToolCallValue('{"a":1}')).toEqual({
+      kind: 'fields',
+      fields: [{ key: 'a', value: 1 }],
+    });
+  });
+
+  it('falls back to raw (pretty JSON) for arrays', () => {
+    expect(parseToolCallValue([1, 2])).toEqual({ kind: 'raw', text: '[\n  1,\n  2\n]' });
+  });
+
+  it('falls back to raw verbatim for plain strings', () => {
+    expect(parseToolCallValue('just text')).toEqual({ kind: 'raw', text: 'just text' });
+  });
+});
+
+describe('classifyFieldValue', () => {
+  it('single-line string → code', () => {
+    expect(classifyFieldValue('/path/to/x')).toEqual({ kind: 'code', text: '/path/to/x' });
+  });
+
+  it('multi-line string → block (verbatim)', () => {
+    expect(classifyFieldValue('a\nb')).toEqual({ kind: 'block', text: 'a\nb' });
+  });
+
+  it('number / boolean / null → inline', () => {
+    expect(classifyFieldValue(42)).toEqual({ kind: 'inline', text: '42' });
+    expect(classifyFieldValue(true)).toEqual({ kind: 'inline', text: 'true' });
+    expect(classifyFieldValue(null)).toEqual({ kind: 'inline', text: 'null' });
+  });
+
+  it('nested object → block with pretty-printed JSON (regression: not one-line)', () => {
+    const d = classifyFieldValue({ a: 1, b: { c: 2 } });
+    expect(d.kind).toBe('block');
+    expect(d.text).toBe('{\n  "a": 1,\n  "b": {\n    "c": 2\n  }\n}');
+  });
+
+  it('array → block with pretty-printed JSON', () => {
+    expect(classifyFieldValue([1, 2])).toEqual({ kind: 'block', text: '[\n  1,\n  2\n]' });
+  });
+});

--- a/app/src/lib/toolCallFormat.ts
+++ b/app/src/lib/toolCallFormat.ts
@@ -50,10 +50,16 @@ export type FieldDisplay =
 
 export function classifyFieldValue(value: unknown): FieldDisplay {
   if (typeof value === 'string') {
+    // Empty string would render as a blank value (just "key:"), indistinguishable
+    // from a missing/unrendered field — show it explicitly as "".
+    if (value === '') return { kind: 'code', text: '""' };
     return value.includes('\n') ? { kind: 'block', text: value } : { kind: 'code', text: value };
   }
   if (value !== null && typeof value === 'object') {
+    // Render empty containers explicitly as {} / [] instead of an empty pretty block.
+    const isEmpty = Array.isArray(value) ? value.length === 0 : Object.keys(value).length === 0;
+    if (isEmpty) return { kind: 'inline', text: Array.isArray(value) ? '[]' : '{}' };
     return { kind: 'block', text: JSON.stringify(value, null, 2) };
   }
-  return { kind: 'inline', text: JSON.stringify(value) };
+  return { kind: 'inline', text: JSON.stringify(value) }; // null → "null", numbers, booleans
 }

--- a/app/src/lib/toolCallFormat.ts
+++ b/app/src/lib/toolCallFormat.ts
@@ -1,0 +1,59 @@
+// Tool-call value formatting — parses a tool call's arguments/result into a
+// render-agnostic shape so the on-screen rows (ToolCallValueView) show structured
+// key/value pairs instead of raw JSON, and arbitrary values are never run through a
+// markdown parser. Pure & framework-free so it can be unit-tested in isolation.
+
+/// Coerces a value (or a JSON-encoded string) into a plain object, or null if it isn't one.
+export function asPlainObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* not JSON — fall through */
+    }
+  }
+  return null;
+}
+
+/// A tool-call value parsed once into a render-agnostic shape.
+export type ToolCallValue =
+  | { kind: 'fields'; fields: { key: string; value: unknown }[] }
+  | { kind: 'empty' }
+  | { kind: 'raw'; text: string };
+
+export function parseToolCallValue(value: unknown): ToolCallValue {
+  const obj = asPlainObject(value);
+  if (obj) {
+    const entries = Object.entries(obj);
+    if (entries.length === 0) return { kind: 'empty' };
+    return { kind: 'fields', fields: entries.map(([key, v]) => ({ key, value: v })) };
+  }
+  // Object coercion failed (rare — the message API rejects invalid JSON upstream).
+  return { kind: 'raw', text: typeof value === 'string' ? value : JSON.stringify(value, null, 2) };
+}
+
+/// How a single field value should be presented:
+///  - 'inline': a bare scalar (number/boolean/null) shown next to the key
+///  - 'code':   a single-line string shown as inline code (verbatim, no quotes)
+///  - 'block':  a multi-line string, or a nested object/array, shown as a block.
+///              Objects/arrays are pretty-printed so nesting stays readable.
+export type FieldDisplay =
+  | { kind: 'inline'; text: string }
+  | { kind: 'code'; text: string }
+  | { kind: 'block'; text: string };
+
+export function classifyFieldValue(value: unknown): FieldDisplay {
+  if (typeof value === 'string') {
+    return value.includes('\n') ? { kind: 'block', text: value } : { kind: 'code', text: value };
+  }
+  if (value !== null && typeof value === 'object') {
+    return { kind: 'block', text: JSON.stringify(value, null, 2) };
+  }
+  return { kind: 'inline', text: JSON.stringify(value) };
+}

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -36,6 +36,7 @@ import { loadNs } from '@/i18n/loader';
 import { useDuplicateSession } from '@/lib/useDuplicateSession';
 import { shortSessionId } from '@/lib/sessionId';
 import { resolveComposerKeyAction } from '@/lib/composerKeys';
+import { parseToolCallValue, classifyFieldValue } from '@/lib/toolCallFormat';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sessionPrefix')({
   // CopyToSharedDialog + ConfirmDialog mounted inside → `dialogs`.
@@ -1253,6 +1254,39 @@ function extractSubagentQuery(args: unknown): string {
   return '';
 }
 
+/// Renders a parsed tool-call value as React rows — values are shown verbatim (no
+/// markdown parsing), mirroring the structure `valueToMarkdown` uses for copy.
+function ToolCallValueView({ value }: { value: unknown }) {
+  // Memoized so the JSON.parse (in parseToolCallValue) and per-field JSON.stringify
+  // (in classifyFieldValue) run once per value, not on every re-render. String values
+  // compare by value, so an unchanged result string is a cache hit.
+  const view = useMemo(() => {
+    const parsed = parseToolCallValue(value);
+    if (parsed.kind !== 'fields') return parsed;
+    return {
+      kind: 'fields' as const,
+      fields: parsed.fields.map((f) => ({ key: f.key, display: classifyFieldValue(f.value) })),
+    };
+  }, [value]);
+
+  if (view.kind === 'empty') return <p className="cw-toolcall-empty">(empty)</p>;
+  if (view.kind === 'raw') return <pre className="cw-toolcall-raw">{view.text}</pre>;
+  return (
+    <dl className="cw-toolcall-fields">
+      {view.fields.map(({ key, display }) => (
+        <div key={key} className={`cw-toolcall-field${display.kind === 'block' ? ' is-block' : ''}`}>
+          <dt>{key}</dt>
+          <dd>{
+            display.kind === 'block' ? <pre className="cw-toolcall-raw">{display.text}</pre>
+            : display.kind === 'code' ? <pre className="cw-toolcall-inline">{display.text}</pre>
+            : display.text
+          }</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
 function MessageBubble({
   message,
   users,
@@ -1317,11 +1351,17 @@ function MessageBubble({
             <details key={tc.id} className="cw-toolcall">
               <summary>🔧 {tc.name}{tc.result === undefined && isStreaming ? ` · ${t('ui.tool_running')}` : ''}</summary>
               {tc.arguments !== undefined && (
-                <pre className="cw-toolcall-args">{typeof tc.arguments === 'string'
-                  ? tc.arguments
-                  : JSON.stringify(tc.arguments, null, 2)}</pre>
+                <div className="cw-toolcall-section">
+                  <span className="cw-toolcall-section-label">Inputs</span>
+                  <ToolCallValueView value={tc.arguments} />
+                </div>
               )}
-              {tc.result !== undefined && <pre className="cw-toolcall-result">{tc.result}</pre>}
+              {tc.result !== undefined && (
+                <div className="cw-toolcall-section">
+                  <span className="cw-toolcall-section-label">Results</span>
+                  <ToolCallValueView value={tc.result} />
+                </div>
+              )}
             </details>
           )
         )}

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -36,7 +36,7 @@ import { loadNs } from '@/i18n/loader';
 import { useDuplicateSession } from '@/lib/useDuplicateSession';
 import { shortSessionId } from '@/lib/sessionId';
 import { resolveComposerKeyAction } from '@/lib/composerKeys';
-import { parseToolCallValue, classifyFieldValue } from '@/lib/toolCallFormat';
+import { ToolCallDetails } from '@/components/chat/ToolCallDetails';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sessionPrefix')({
   // CopyToSharedDialog + ConfirmDialog mounted inside → `dialogs`.
@@ -1254,39 +1254,6 @@ function extractSubagentQuery(args: unknown): string {
   return '';
 }
 
-/// Renders a parsed tool-call value as React rows — values are shown verbatim (no
-/// markdown parsing), mirroring the structure `valueToMarkdown` uses for copy.
-function ToolCallValueView({ value }: { value: unknown }) {
-  // Memoized so the JSON.parse (in parseToolCallValue) and per-field JSON.stringify
-  // (in classifyFieldValue) run once per value, not on every re-render. String values
-  // compare by value, so an unchanged result string is a cache hit.
-  const view = useMemo(() => {
-    const parsed = parseToolCallValue(value);
-    if (parsed.kind !== 'fields') return parsed;
-    return {
-      kind: 'fields' as const,
-      fields: parsed.fields.map((f) => ({ key: f.key, display: classifyFieldValue(f.value) })),
-    };
-  }, [value]);
-
-  if (view.kind === 'empty') return <p className="cw-toolcall-empty">(empty)</p>;
-  if (view.kind === 'raw') return <pre className="cw-toolcall-raw">{view.text}</pre>;
-  return (
-    <dl className="cw-toolcall-fields">
-      {view.fields.map(({ key, display }) => (
-        <div key={key} className={`cw-toolcall-field${display.kind === 'block' ? ' is-block' : ''}`}>
-          <dt>{key}</dt>
-          <dd>{
-            display.kind === 'block' ? <pre className="cw-toolcall-raw">{display.text}</pre>
-            : display.kind === 'code' ? <pre className="cw-toolcall-inline">{display.text}</pre>
-            : display.text
-          }</dd>
-        </div>
-      ))}
-    </dl>
-  );
-}
-
 function MessageBubble({
   message,
   users,
@@ -1348,21 +1315,7 @@ function MessageBubble({
               {' '}{extractSubagentQuery(tc.arguments)}
             </div>
           ) : (
-            <details key={tc.id} className="cw-toolcall">
-              <summary>🔧 {tc.name}{tc.result === undefined && isStreaming ? ` · ${t('ui.tool_running')}` : ''}</summary>
-              {tc.arguments !== undefined && (
-                <div className="cw-toolcall-section">
-                  <span className="cw-toolcall-section-label">Inputs</span>
-                  <ToolCallValueView value={tc.arguments} />
-                </div>
-              )}
-              {tc.result !== undefined && (
-                <div className="cw-toolcall-section">
-                  <span className="cw-toolcall-section-label">Results</span>
-                  <ToolCallValueView value={tc.result} />
-                </div>
-              )}
-            </details>
+            <ToolCallDetails key={tc.id} tc={tc} isStreaming={isStreaming} />
           )
         )}
         {isAi && artifactPaths && artifactPaths.length > 0 && projectId && sessionId && onCopyToShared && onArtifactDeleted && (

--- a/app/src/styles/chat.css
+++ b/app/src/styles/chat.css
@@ -57,6 +57,10 @@
 
 /* Tool call collapsible — collapsed chip under the parent assistant message. */
 .cw-toolcall {
+  /* Collapsed: wrap the summary as a compact chip. Expanded: fill the bubble
+     (see [open] + the .cw-message-body:has() rule) so open tool calls line up. */
+  width: fit-content;
+  max-width: 100%;
   margin-top: 6px;
   border: 1px solid var(--cw-paper-4);
   border-radius: 6px;
@@ -65,6 +69,10 @@
   font-size: 11.5px;
   background: var(--cw-paper-2);
 }
+.cw-toolcall[open] { width: auto; }
+/* When any tool call in a bubble is expanded, stretch the bubble to its full
+   width so the open tool call (and any others) share one consistent width. */
+.cw-message-body:has(.cw-toolcall[open]) { width: min(560px, calc(100% - 44px)); }
 .cw-toolcall > summary {
   cursor: pointer;
   color: var(--cw-ink-3);
@@ -74,9 +82,17 @@
 .cw-toolcall > summary::-webkit-details-marker { display: none; }
 .cw-toolcall > summary::marker { display: none; }
 .cw-toolcall[open] > summary { color: var(--cw-ink); margin-bottom: 6px; }
-.cw-toolcall-args,
-.cw-toolcall-result {
-  margin: 4px 0;
+.cw-toolcall-section { margin: 4px 0; }
+.cw-toolcall-section-label {
+  display: block;
+  margin: 6px 0 3px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--cw-ink-4);
+}
+.cw-toolcall-raw {
+  margin: 0;
   padding: 6px 8px;
   background: var(--cw-paper-3);
   border-radius: 4px;
@@ -86,7 +102,34 @@
   overflow: auto;
   font-size: 11px;
 }
-.cw-toolcall-args { opacity: 0.85; }
+.cw-toolcall-empty { margin: 0; color: var(--cw-ink-4); font-style: italic; }
+.cw-toolcall-fields { margin: 0; display: flex; flex-direction: column; gap: 3px; }
+.cw-toolcall-field { display: flex; gap: 6px; align-items: baseline; }
+.cw-toolcall-field dt { flex: 0 0 auto; color: var(--cw-ink-3); font-weight: 600; }
+.cw-toolcall-field dt::after { content: ':'; }
+/* Single-line string value: a <pre> kept inline on the key's row (preserves the
+   raw text exactly, no quotes), wrapping if long. */
+.cw-toolcall-inline {
+  display: inline;
+  margin: 0;
+  background: var(--cw-paper-3);
+  font-family: inherit;
+  font-size: inherit;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.cw-toolcall-field dd {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  color: var(--cw-ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+/* Multi-line string value: key on its own line, value in a full-width <pre>. */
+.cw-toolcall-field.is-block { flex-direction: column; gap: 2px; align-items: stretch; }
+.cw-toolcall-field.is-block dd { width: 100%; }
+.cw-toolcall-field.is-block dd .cw-toolcall-raw { margin: 0; }
 
 /* Subagent mention — "@math <query>" inline line under parent assistant message. */
 .cw-subagent-call {


### PR DESCRIPTION
## Description
Improve how tool-call inputs/results are displayed, replacing the raw JSON dump with a structured view.

## Changes
  - raw JSON `<pre>` dump → structured key/value HTML rows. Values are rendered
    directly via React (never through a markdown parser), so arbitrary tool data
    can't be misinterpreted (no escaping/XSS issues).
  - Per-type rendering: nested objects/arrays are pretty-printed, single-line
    strings render inline, multi-line strings drop to a `<pre>` block.
  - Width: collapsed wraps its content as a compact chip; expanded fills the
    bubble's full width so open tool calls line up consistently.
  - Lazy rendering: inputs/results (and their JSON parsing) render only while
    expanded, so collapsed tool calls cost nothing. Parsing is memoized per value.
  - Extracted into `components/chat/ToolCallDetails.tsx`; pure formatting logic
    lives in `lib/toolCallFormat.ts` with unit tests.

- Parsing/classification extracted to `lib/toolCallFormat.ts`, memoized once per value.

## Tests
- frontend `tsc` + added unit tests(`app/src/lib/toolCallFormat.test.ts`) pass.

## Screenshots
See the tool call renderings in 'Examples' part of #178 
