### PR TITLE
Add per-agent descriptions to the composer (EN/KO)

### DIFF
--- a/app/src/components/chat/ComposerAgentPicker.tsx
+++ b/app/src/components/chat/ComposerAgentPicker.tsx
@@ -78,18 +78,22 @@ export function ComposerAgentPicker({
       />
       {AGENT_SURFACES.map((agent) => {
         const isActive = agent.id === value;
+        const description = t(`agent.${agent.id}.description`);
         return (
           <button
             key={agent.id}
             type="button"
             aria-pressed={isActive}
+            aria-label={`${agent.label} — ${description}`}
             data-agent={agent.id}
-            title={t(`agent.${agent.id}.description`)}
             className={`cw-agent-tab${isActive ? ' is-active' : ''}`}
             onClick={() => onChange(agent.id)}
           >
             <Icon name={agent.icon} size={15} />
             <span>{agent.label}</span>
+            <span className="cw-agent-tab-pop" role="tooltip" aria-hidden>
+              {description}
+            </span>
           </button>
         );
       })}

--- a/app/src/components/chat/ComposerAgentPicker.tsx
+++ b/app/src/components/chat/ComposerAgentPicker.tsx
@@ -84,6 +84,7 @@ export function ComposerAgentPicker({
             type="button"
             aria-pressed={isActive}
             data-agent={agent.id}
+            title={t(`agent.${agent.id}.description`)}
             className={`cw-agent-tab${isActive ? ' is-active' : ''}`}
             onClick={() => onChange(agent.id)}
           >

--- a/app/src/components/settings/ProjectModelChainsEditor.tsx
+++ b/app/src/components/settings/ProjectModelChainsEditor.tsx
@@ -118,12 +118,17 @@ export function ProjectModelChainsEditor({
               }}
             >
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
-                <b style={{ fontSize: 13, color: 'var(--cw-ink)' }}>
-                  {label}
-                  {isDefault && (
-                    <span style={{ marginLeft: 8, fontSize: 11, color: 'var(--cw-ink-4)', fontWeight: 400 }}>{t('chains_editor.default')}</span>
-                  )}
-                </b>
+                <div>
+                  <b style={{ fontSize: 13, color: 'var(--cw-ink)' }}>
+                    {label}
+                    {isDefault && (
+                      <span style={{ marginLeft: 8, fontSize: 11, color: 'var(--cw-ink-4)', fontWeight: 400 }}>{t('chains_editor.default')}</span>
+                    )}
+                  </b>
+                  <div style={{ marginTop: 2, fontSize: 11, color: 'var(--cw-ink-4)' }}>
+                    {t(`agent.${type}.description`, { ns: 'automation' })}
+                  </div>
+                </div>
                 {editable && !isDefault && (
                   <button
                     type="button"

--- a/app/src/i18n/locales/en/automation.json
+++ b/app/src/i18n/locales/en/automation.json
@@ -61,6 +61,7 @@
     "coworker": {
       "placeholder": "Describe a task to run…",
       "greeting": "Coworker helps you get it done",
+      "description": "Makes the documents and files you need.",
       "prompts": [
         { "label": "This week's progress summary", "seedText": "Summarize this week's progress and draft a report" },
         { "label": "Tidy up meeting notes", "seedText": "Organize today's meeting notes around action items" },
@@ -70,6 +71,7 @@
     "speedwagon": {
       "placeholder": "What are you curious about?",
       "greeting": "Speedwagon finds answers in your files",
+      "description": "Answers your questions using your project's files and the web.",
       "prompts": [
         { "label": "Summarize project files", "seedText": "Summarize the key contents of the project files" },
         { "label": "Find a specific fact", "seedText": "Find all the revenue-related figures across the documents" },
@@ -79,6 +81,7 @@
     "deep-research": {
       "placeholder": "What should I research?",
       "greeting": "Deep Research digs in deep",
+      "description": "Researches a topic in depth across the web and writes you a report.",
       "prompts": [
         { "label": "Market trend research", "seedText": "Research recent trends in the market where KlientCo operates" },
         { "label": "Competitor analysis", "seedText": "Compare and analyze the strategies of three major competitors" },
@@ -88,6 +91,7 @@
     "buddy": {
       "placeholder": "Talk to me freely…",
       "greeting": "Chat freely with Buddy",
+      "description": "A general chat for anything else, from quick questions to ideas.",
       "prompts": [
         { "label": "Brainstorm ideas", "seedText": "Throw out 10 quick ideas for the Q3 campaign" },
         { "label": "Explain terms", "seedText": "Explain these domain terms in simple language" },

--- a/app/src/i18n/locales/ko/automation.json
+++ b/app/src/i18n/locales/ko/automation.json
@@ -61,6 +61,7 @@
     "coworker": {
       "placeholder": "실행할 작업을 적어줘…",
       "greeting": "Coworker가 실행을 도와줘요",
+      "description": "필요한 문서와 파일을 만들어 줍니다.",
       "prompts": [
         { "label": "이번 주 진행 요약", "seedText": "이번 주 진행 상황을 정리해서 보고서 초안 만들어줘" },
         { "label": "회의 메모 정리", "seedText": "오늘 회의록을 액션 아이템 중심으로 정리해줘" },
@@ -70,6 +71,7 @@
     "speedwagon": {
       "placeholder": "무엇이 궁금해?",
       "greeting": "Speedwagon이 파일에서 답을 찾아줘요",
+      "description": "올린 문서와 웹에서 답을 찾아 줍니다.",
       "prompts": [
         { "label": "프로젝트 파일 요약", "seedText": "프로젝트 파일들의 핵심 내용을 요약해줘" },
         { "label": "특정 사실 찾기", "seedText": "문서들에서 매출 관련 수치를 모두 찾아줘" },
@@ -79,6 +81,7 @@
     "deep-research": {
       "placeholder": "무엇을 조사할까?",
       "greeting": "Deep Research가 깊이 파고들어요",
+      "description": "웹에서 주제를 심층 조사해 보고서를 써 줍니다.",
       "prompts": [
         { "label": "시장 동향 조사", "seedText": "KlientCo가 있는 시장의 최근 동향을 조사해줘" },
         { "label": "경쟁사 분석", "seedText": "주요 경쟁사 3곳의 전략을 비교 분석해줘" },
@@ -88,6 +91,7 @@
     "buddy": {
       "placeholder": "편하게 말 걸어줘…",
       "greeting": "Buddy와 자유롭게 대화해요",
+      "description": "무엇이든 가볍게 물어보고 함께 생각해요.",
       "prompts": [
         { "label": "아이디어 발산", "seedText": "Q3 캠페인 아이디어 10개만 빠르게 던져줘" },
         { "label": "용어 풀이", "seedText": "이 도메인 용어들을 쉽게 설명해줘" },

--- a/app/src/i18n/locales/ko/automation.json
+++ b/app/src/i18n/locales/ko/automation.json
@@ -61,7 +61,7 @@
     "coworker": {
       "placeholder": "실행할 작업을 적어줘…",
       "greeting": "Coworker가 실행을 도와줘요",
-      "description": "필요한 문서와 파일을 만들어 줍니다.",
+      "description": "작업에 필요한 문서와 파일을 만듭니다.",
       "prompts": [
         { "label": "이번 주 진행 요약", "seedText": "이번 주 진행 상황을 정리해서 보고서 초안 만들어줘" },
         { "label": "회의 메모 정리", "seedText": "오늘 회의록을 액션 아이템 중심으로 정리해줘" },
@@ -71,7 +71,7 @@
     "speedwagon": {
       "placeholder": "무엇이 궁금해?",
       "greeting": "Speedwagon이 파일에서 답을 찾아줘요",
-      "description": "올린 문서와 웹에서 답을 찾아 줍니다.",
+      "description": "문서와 웹에서 답을 찾습니다.",
       "prompts": [
         { "label": "프로젝트 파일 요약", "seedText": "프로젝트 파일들의 핵심 내용을 요약해줘" },
         { "label": "특정 사실 찾기", "seedText": "문서들에서 매출 관련 수치를 모두 찾아줘" },
@@ -81,7 +81,7 @@
     "deep-research": {
       "placeholder": "무엇을 조사할까?",
       "greeting": "Deep Research가 깊이 파고들어요",
-      "description": "웹에서 주제를 심층 조사해 보고서를 써 줍니다.",
+      "description": "웹을 심층 조사해 보고서를 작성합니다.",
       "prompts": [
         { "label": "시장 동향 조사", "seedText": "KlientCo가 있는 시장의 최근 동향을 조사해줘" },
         { "label": "경쟁사 분석", "seedText": "주요 경쟁사 3곳의 전략을 비교 분석해줘" },
@@ -91,7 +91,7 @@
     "buddy": {
       "placeholder": "편하게 말 걸어줘…",
       "greeting": "Buddy와 자유롭게 대화해요",
-      "description": "무엇이든 가볍게 물어보고 함께 생각해요.",
+      "description": "무엇이든 가볍게 묻고 이야기합니다.",
       "prompts": [
         { "label": "아이디어 발산", "seedText": "Q3 캠페인 아이디어 10개만 빠르게 던져줘" },
         { "label": "용어 풀이", "seedText": "이 도메인 용어들을 쉽게 설명해줘" },

--- a/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
@@ -614,6 +614,7 @@ function AutomationSettingsPage() {
             style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start' }}
           >
             <ComposerAgentPicker value={agentId} onChange={setAgentId} standalone />
+            <p className="cw-agent-pick-desc">{t(`agent.${agentId}.description`)}</p>
             <ComposerModelPicker
               catalog={catalog.data}
               agentType={agentId}

--- a/app/src/routes/_app.projects.$projectSlug.automation.new.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.new.tsx
@@ -211,6 +211,7 @@ function NewAutomationPage() {
               style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start' }}
             >
               <ComposerAgentPicker value={agentId} onChange={setAgentId} standalone />
+              <p className="cw-agent-pick-desc">{t(`agent.${agentId}.description`)}</p>
               <ComposerModelPicker
                 catalog={catalog.data}
                 agentType={agentId}

--- a/app/src/routes/_app.projects.$projectSlug.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.index.tsx
@@ -58,6 +58,7 @@ function ProjectHome() {
   // Agent copy (greeting/placeholder/suggested prompts) is i18n'd in the
   // `automation` namespace, keyed by the agent surface id.
   const agentGreeting = tAgent(`agent.${selectedAgentId}.greeting`);
+  const agentDescription = tAgent(`agent.${selectedAgentId}.description`);
   const agentPlaceholder = tAgent(`agent.${selectedAgentId}.placeholder`);
   const agentPrompts = tAgent(`agent.${selectedAgentId}.prompts`, {
     returnObjects: true,
@@ -146,6 +147,9 @@ function ProjectHome() {
       <div className="cw-home-blank">
         <p className="cw-home-greeting">
           {agentGreeting}
+        </p>
+        <p className="cw-home-agent-desc">
+          {agentDescription}
         </p>
 
         <div

--- a/app/src/routes/_app.projects.$projectSlug.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.index.tsx
@@ -58,7 +58,6 @@ function ProjectHome() {
   // Agent copy (greeting/placeholder/suggested prompts) is i18n'd in the
   // `automation` namespace, keyed by the agent surface id.
   const agentGreeting = tAgent(`agent.${selectedAgentId}.greeting`);
-  const agentDescription = tAgent(`agent.${selectedAgentId}.description`);
   const agentPlaceholder = tAgent(`agent.${selectedAgentId}.placeholder`);
   const agentPrompts = tAgent(`agent.${selectedAgentId}.prompts`, {
     returnObjects: true,
@@ -147,9 +146,6 @@ function ProjectHome() {
       <div className="cw-home-blank">
         <p className="cw-home-greeting">
           {agentGreeting}
-        </p>
-        <p className="cw-home-agent-desc">
-          {agentDescription}
         </p>
 
         <div

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -40,7 +40,7 @@ import { ToolCallDetails } from '@/components/chat/ToolCallDetails';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/sessions/$sessionPrefix')({
   // CopyToSharedDialog + ConfirmDialog mounted inside → `dialogs`.
-  loader: () => loadNs('session', 'dialogs'),
+  loader: () => loadNs('session', 'dialogs', 'automation'),
   component: SessionPage,
 });
 
@@ -922,7 +922,7 @@ function SessionPage() {
                 <span
                   className="cw-session-agent-chip"
                   data-agent={activeAgent.id}
-                  title={t('chat.agent_chip')}
+                  title={t(`automation:agent.${activeAgent.id}.description`)}
                 >
                   <Icon name={activeAgent.icon} size={13} />
                   <span>{activeAgent.label}</span>

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1566,6 +1566,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 .cw-home-blank .cw-home-composer-box { width: 100%; }
 .cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); font-weight: 500; }
 .cw-home-agent-desc { margin: -8px 0 0; text-align: center; font-size: var(--cw-text-sm); color: var(--cw-fg-3); max-width: 34rem; }
+.cw-agent-pick-desc { margin: -4px 0 0; font-size: var(--cw-text-sm); color: var(--cw-fg-3); }
 .cw-suggested-prompts {
   display: flex;
   flex-wrap: wrap;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1568,7 +1568,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 .cw-home-blank .cw-agent-composer-wrap { width: 100%; }
 .cw-home-blank .cw-home-composer-box { width: 100%; }
 .cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); font-weight: 500; }
-.cw-agent-pick-desc { margin: -4px 0 0; font-size: var(--cw-text-sm); color: var(--cw-fg-3); }
+.cw-agent-pick-desc { margin: -4px 0 0; max-width: 38ch; font-size: var(--cw-text-sm); color: var(--cw-fg-3); line-height: 1.4; }
 .cw-suggested-prompts {
   display: flex;
   flex-wrap: wrap;
@@ -1813,7 +1813,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   left: 50%;
   z-index: 60;
   width: max-content;
-  max-width: 256px;
+  max-width: 240px;
   transform: translateX(-50%) translateY(3px);
   padding: 8px 11px;
   border-radius: 10px;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1565,6 +1565,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 .cw-home-blank .cw-agent-composer-wrap { width: 100%; }
 .cw-home-blank .cw-home-composer-box { width: 100%; }
 .cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); font-weight: 500; }
+.cw-home-agent-desc { margin: -8px 0 0; text-align: center; font-size: var(--cw-text-sm); color: var(--cw-fg-3); max-width: 34rem; }
 .cw-suggested-prompts {
   display: flex;
   flex-wrap: wrap;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1568,7 +1568,7 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 .cw-home-blank .cw-agent-composer-wrap { width: 100%; }
 .cw-home-blank .cw-home-composer-box { width: 100%; }
 .cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); font-weight: 500; }
-.cw-agent-pick-desc { margin: -4px 0 0; max-width: 38ch; font-size: var(--cw-text-sm); color: var(--cw-fg-3); line-height: 1.4; }
+.cw-agent-pick-desc { margin: -4px 0 0; max-width: 480px; font-size: var(--cw-text-sm); color: var(--cw-fg-3); line-height: 1.4; }
 .cw-suggested-prompts {
   display: flex;
   flex-wrap: wrap;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -1562,10 +1562,12 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   margin: 0 auto;
   padding: 0 16px;
 }
+/* Extra room between the greeting and the composer so the agent-tab hover
+   popover (which floats above the tabs) clears the greeting line above it. */
+.cw-home-blank > .cw-home-greeting { margin-bottom: 56px; }
 .cw-home-blank .cw-agent-composer-wrap { width: 100%; }
 .cw-home-blank .cw-home-composer-box { width: 100%; }
 .cw-home-greeting { margin: 0; text-align: center; font-size: var(--cw-text-lg); color: var(--cw-fg-2); font-weight: 500; }
-.cw-home-agent-desc { margin: -8px 0 0; text-align: center; font-size: var(--cw-text-sm); color: var(--cw-fg-3); max-width: 34rem; }
 .cw-agent-pick-desc { margin: -4px 0 0; font-size: var(--cw-text-sm); color: var(--cw-fg-3); }
 .cw-suggested-prompts {
   display: flex;
@@ -1799,6 +1801,54 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   font-weight: 600;
   border-radius: 14px 14px 0 0;
   margin-bottom: -1px;
+}
+
+/* Hover/focus popover: a command-style card floating above the hovered tab, with
+   a small arrow pointing down at it, so the description reads as belonging to that
+   specific agent (not a detached line of body text). Sits above the tabs (not
+   below) to clear the composer box. Shown on hover and on keyboard focus. */
+.cw-agent-tab-pop {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 60;
+  width: max-content;
+  max-width: 256px;
+  transform: translateX(-50%) translateY(3px);
+  padding: 8px 11px;
+  border-radius: 10px;
+  background: var(--cw-paper);
+  border: 1px solid var(--cw-agent-accent);
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.16);
+  color: var(--cw-fg-2);
+  font-size: 12px;
+  font-weight: 450;
+  line-height: 1.4;
+  text-align: center;
+  white-space: normal;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 120ms ease, transform 120ms ease, visibility 0s linear 120ms;
+}
+/* Down-pointing arrow on the card's bottom edge (outside the card), pointing at
+   the tab below. The card is centred on its tab (translateX(-50%)) and the arrow
+   shares that centre, so the arrow always lands on the hovered tab. */
+.cw-agent-tab-pop::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 7px solid transparent;
+  border-top-color: var(--cw-agent-accent);
+}
+.cw-agent-tab:hover .cw-agent-tab-pop,
+.cw-agent-tab:focus-visible .cw-agent-tab-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+  transition: opacity 120ms ease, transform 120ms ease;
 }
 
 /* Standalone variant: the picker stands on its own (no composer box beneath),


### PR DESCRIPTION
## What

This PR closes #160. It adds a short, plain-language description for each of the four agent surfaces (Coworker, Speedwagon, Deep Research, Buddy) so a user picking a mode understands what it does. Today the picker shows only a brand label and an icon, and the only per-agent copy is a casual greeting; there is no explanation of what each agent is for.

Frontend-only, EN and KO, no backend change. The agent's meaning is client-side copy, so it lives in the `automation` i18n namespace rather than the model catalog API.

## Copy

One `agent.<id>.description` key per agent, in `en/automation.json` and `ko/automation.json`. Written for non-technical users: brief, no jargon, parallel between EN and KO.

**Coworker**
- EN: Makes the documents and files you need.
- KO: 작업에 필요한 문서와 파일을 만듭니다.

**Speedwagon**
- EN: Answers your questions using your project's files and the web.
- KO: 문서와 웹에서 답을 찾습니다.

**Deep Research**
- EN: Researches a topic in depth across the web and writes you a report.
- KO: 웹을 심층 조사해 보고서를 작성합니다.

**Buddy**
- EN: A general chat for anything else, from quick questions to ideas.
- KO: 무엇이든 가볍게 묻고 이야기합니다.

Copy is grounded in what each agent actually does in the `test_case` suite: Coworker builds documents/sheets/slides/charts, Speedwagon answers from the project corpus and the web with sources, Deep Research runs multi-hop web research into a report, and Buddy is the general fallback chat.

## Where it shows

- **Project home composer (primary surface).** Hovering or focusing an agent tab in `ComposerAgentPicker` shows a small command-style card floating above that tab, with an arrow pointing down at it, so the description reads as belonging to that specific agent rather than as a detached line of body text. The card is keyboard-reachable (`:focus-visible`).
- **Session header chip tooltip.** Inside a running session the agent chip's tooltip now shows the agent's description instead of the generic "Session agent" label, so the explanation is reachable mid-session too. The session route now also loads the `automation` namespace to resolve it.
- **Automation new/edit forms.** When you pick which agent an automation runs as, the description shows as an inline line under the agent picker, above the model picker, so the choice is explained without a hover.
- **Project settings, model recommendations.** Each agent card in the recommendation-chain editor shows its description under the heading (resolved cross-namespace from `automation`).

## Verification 

- `tsc --noEmit` clean, `vite build` clean, both locale JSON files valid.

## Screenshots (sample)

<img width="932" height="423" alt="스크린샷 2026-06-15 오후 4 01 01" src="https://github.com/user-attachments/assets/edd6ce37-74c0-4941-ad40-ed31bfa65cc5" />
<img width="970" height="512" alt="스크린샷 2026-06-15 오후 4 01 13" src="https://github.com/user-attachments/assets/7419fb6d-de59-4857-9841-ffa404b2b90a" />

