### PR TITLE
Enhance automation

### DIFF
--- a/app/src/components/SchedulePicker.tsx
+++ b/app/src/components/SchedulePicker.tsx
@@ -4,26 +4,42 @@
 // intentionally not surfaced. croner is used backend-side, so we lean on
 // its `W#N` syntax for "the nth weekday of the month".
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { Icon } from '@/components/Icon';
 import { Select } from '@/components/Select';
+import { SegmentedControl } from '@/components/SegmentedControl';
 
 export type SchedulePickerValue = { expr: string; tz: string };
 
-type Unit = 'hour' | 'day' | 'week' | 'month' | 'custom';
+type Unit = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'custom';
 type MonthlyMode = 'day' | 'weekday';
+
+// cron's minute field is 0-59, so only divisors of 60 give an evenly-spaced
+// "every N minutes" — other steps drift across the hour boundary.
+const MINUTE_INTERVALS = [5, 10, 15, 20, 30];
+
+// cron's hour field is 0-23, so only divisors of 24 give an evenly-spaced
+// "every N hours" — other steps drift across the midnight boundary.
+const HOUR_INTERVALS = [1, 2, 3, 4, 6, 8, 12];
+
+// When the user clears every weekday chip, the schedule falls back to a single
+// implied weekday (shown in the UI with a distinct "implied" style).
+const WEEKDAY_FALLBACK = 1;  // Monday (0=Sun)
 
 interface State {
   unit: Unit;
-  interval: number;          // hour only
+  minuteInterval: number;    // for unit==='minute' (divisor of 60)
+  interval: number;          // for unit==='hour' (divisor of 24)
   hour: number;              // 0-23
   minute: number;            // 0-59
   weekdays: Set<number>;     // 0=Sun..6=Sat (for week)
   monthlyMode: MonthlyMode;  // for month
   dayOfMonth: number;        // for monthlyMode==='day'
+  lastDay: boolean;          // monthlyMode==='day' + last day of month (cron `L`)
   nth: number;               // 1..5 (for weekday mode)
+  nthLast: boolean;          // weekday mode + last occurrence in month (cron `<dow>L`)
   nthWeekday: number;        // 0..6 (for weekday mode)
   customExpr: string;
   tz: string;
@@ -33,30 +49,38 @@ function pad(n: number): string { return n.toString().padStart(2, '0'); }
 
 function defaultState(tz: string, expr: string): State {
   return {
-    unit: 'day', interval: 1, hour: 9, minute: 0,
+    unit: 'day', minuteInterval: 5, interval: 1,
+    hour: 9, minute: 0,
     weekdays: new Set([1, 2, 3, 4, 5]),
-    monthlyMode: 'day', dayOfMonth: 1, nth: 1, nthWeekday: 1,
+    monthlyMode: 'day', dayOfMonth: 1, lastDay: false, nth: 1, nthLast: false, nthWeekday: 1,
     customExpr: expr || '0 9 * * *', tz,
   };
 }
 
 export function specToCron(s: State): string {
   switch (s.unit) {
+    case 'minute':
+      return `*/${Math.max(1, s.minuteInterval)} * * * *`;
     case 'hour':
       return `0 */${Math.max(1, s.interval)} * * *`;
     case 'day':
       return `${s.minute} ${s.hour} * * *`;
     case 'week': {
+      // Empty selection is allowed in the UI; fall back to a single weekday
+      // (Monday) rather than "every day".
       const days = [...s.weekdays].sort((a, b) => a - b);
-      const list = days.length ? days.join(',') : '*';
+      const list = days.length ? days.join(',') : String(WEEKDAY_FALLBACK);
       return `${s.minute} ${s.hour} * * ${list}`;
     }
     case 'month':
       if (s.monthlyMode === 'day') {
-        return `${s.minute} ${s.hour} ${s.dayOfMonth} * *`;
+        return `${s.minute} ${s.hour} ${s.lastDay ? 'L' : s.dayOfMonth} * *`;
       }
-      // croner supports `<weekday>#<n>` for "nth weekday of month"
-      return `${s.minute} ${s.hour} * * ${s.nthWeekday}#${Math.max(1, Math.min(5, s.nth))}`;
+      // croner supports `<weekday>#<n>` for "nth weekday" and `<weekday>L` for
+      // "last weekday of month".
+      return s.nthLast
+        ? `${s.minute} ${s.hour} * * ${s.nthWeekday}L`
+        : `${s.minute} ${s.hour} * * ${s.nthWeekday}#${Math.max(1, Math.min(5, s.nth))}`;
     case 'custom':
       return s.customExpr;
   }
@@ -68,6 +92,15 @@ function parseCron(expr: string, tz: string): State {
   const parts = expr.trim().split(/\s+/);
   if (parts.length !== 5) return { ...fallback, unit: 'custom', customExpr: expr };
   const [m, h, dom, mon, dow] = parts;
+
+  // "*/N * * * *" → every N minutes; "* * * * *" → every minute
+  const minutely = /^\*\/(\d+)$/.exec(m);
+  if (minutely && h === '*' && dom === '*' && mon === '*' && dow === '*') {
+    return { ...fallback, unit: 'minute', minuteInterval: parseInt(minutely[1], 10) };
+  }
+  if (m === '*' && h === '*' && dom === '*' && mon === '*' && dow === '*') {
+    return { ...fallback, unit: 'minute', minuteInterval: 1 };
+  }
 
   // "0 */N * * *" → every N hours; "0 * * * *" → every 1 hour
   const hourly = /^\*\/(\d+)$/.exec(h);
@@ -96,6 +129,18 @@ function parseCron(expr: string, tz: string): State {
     };
   }
 
+  // "M H * * <dow>L" → the last <weekday> of the month.
+  const lastDow = /^(\d+)L$/.exec(dow);
+  if (mNum !== null && hNum !== null && dom === '*' && mon === '*' && lastDow) {
+    return {
+      ...fallback, unit: 'month',
+      hour: hNum, minute: mNum,
+      monthlyMode: 'weekday',
+      nthWeekday: parseInt(lastDow[1], 10),
+      nthLast: true,
+    };
+  }
+
   if (mNum !== null && hNum !== null && dom === '*' && mon === '*' && /^[\d,]+$/.test(dow)) {
     const set = new Set(dow.split(',').map(Number).filter((n) => n >= 0 && n <= 6));
     return { ...fallback, unit: 'week', hour: hNum, minute: mNum, weekdays: set };
@@ -110,15 +155,32 @@ function parseCron(expr: string, tz: string): State {
     };
   }
 
+  // "M H L * *" → the last day of the month.
+  if (mNum !== null && hNum !== null && dom === 'L' && mon === '*' && dow === '*') {
+    return {
+      ...fallback, unit: 'month',
+      hour: hNum, minute: mNum,
+      monthlyMode: 'day',
+      lastDay: true,
+    };
+  }
+
   return { ...fallback, unit: 'custom', customExpr: expr };
 }
 
 export function summarizeCron(expr: string, t: TFunction<'automation'>): string {
   const s = parseCron(expr, '');
-  const time = `${pad(s.hour)}:${pad(s.minute)}`;
-  const weekdayArr = t('sched.weekdays', { returnObjects: true }) as string[];
+  // On the hour → "9시" / "9 o'clock"; otherwise "09:30".
+  const fmtTime = (h: number, m: number) =>
+    (m === 0 ? t('sched.summary.oclock', { h }) : `${pad(h)}:${pad(m)}`);
+  const time = fmtTime(s.hour, s.minute);
+  const weekdayArr = t('sched.weekdays_short', { returnObjects: true }) as string[];
   const nthArr = t('sched.nth', { returnObjects: true }) as string[];
   switch (s.unit) {
+    case 'minute':
+      return s.minuteInterval === 1
+        ? t('sched.summary.every_minute')
+        : t('sched.summary.every_n_minutes', { n: s.minuteInterval });
     case 'hour':
       return s.interval === 1
         ? t('sched.summary.every_hour')
@@ -132,7 +194,15 @@ export function summarizeCron(expr: string, t: TFunction<'automation'>): string 
     }
     case 'month':
       if (s.monthlyMode === 'day') {
-        return t('sched.summary.monthly_day', { day: s.dayOfMonth, time });
+        return s.lastDay
+          ? t('sched.summary.monthly_last', { time })
+          : t('sched.summary.monthly_day', { day: s.dayOfMonth, time });
+      }
+      if (s.nthLast) {
+        return t('sched.summary.monthly_weekday_last', {
+          weekday: weekdayArr[s.nthWeekday],
+          time,
+        });
       }
       return t('sched.summary.monthly_weekday', {
         nth: nthArr[s.nth - 1] ?? String(s.nth),
@@ -151,7 +221,8 @@ export function SchedulePicker({
   onChange: (next: SchedulePickerValue) => void;
 }) {
   const { t } = useTranslation('automation');
-  const weekdayArr = t('sched.weekdays', { returnObjects: true }) as string[];
+  const weekdayArr = t('sched.weekdays_short', { returnObjects: true }) as string[];
+  const weekdayLongArr = t('sched.weekdays', { returnObjects: true }) as string[];
   const nthArr = t('sched.nth', { returnObjects: true }) as string[];
   const [state, setState] = useState<State>(() => parseCron(value.expr, value.tz));
 
@@ -172,6 +243,54 @@ export function SchedulePicker({
       return { ...prev, weekdays: next };
     });
   };
+
+  // Drag-to-select for the weekday chips: pointerdown decides
+  // the paint mode from the first chip's state (add if it was off, remove if it
+  // was on); every chip the pointer then travels over is forced to that state.
+  // elementFromPoint keeps it working for touch, where the pressed chip
+  // implicitly captures the pointer.
+  const dragMode = useRef<'add' | 'remove' | null>(null);
+  useEffect(() => {
+    const end = () => { dragMode.current = null; };
+    window.addEventListener('pointerup', end);
+    window.addEventListener('pointercancel', end);
+    return () => {
+      window.removeEventListener('pointerup', end);
+      window.removeEventListener('pointercancel', end);
+    };
+  }, []);
+  const paintWeekday = (v: number, mode: 'add' | 'remove') => {
+    setState((prev) => {
+      const has = prev.weekdays.has(v);
+      if (mode === 'add' ? has : !has) return prev;
+      const next = new Set(prev.weekdays);
+      if (mode === 'add') next.add(v);
+      else next.delete(v);
+      return { ...prev, weekdays: next };
+    });
+  };
+  const readWeekdayEl = (x: number, y: number): HTMLElement | null =>
+    document.elementFromPoint(x, y)?.closest<HTMLElement>('[data-weekday]') ?? null;
+  const weekdaysDrag = {
+    onPointerDown: (e: ReactPointerEvent) => {
+      const el = readWeekdayEl(e.clientX, e.clientY);
+      if (!el) return;
+      const v = Number(el.dataset.weekday);
+      // preventDefault stops text selection / a spurious synthetic click, but
+      // also suppresses the button's implicit focus — restore it explicitly so
+      // keyboard users can keep operating the chip after a click.
+      e.preventDefault();
+      el.focus();
+      const mode: 'add' | 'remove' = state.weekdays.has(v) ? 'remove' : 'add';
+      dragMode.current = mode;
+      paintWeekday(v, mode);
+    },
+    onPointerMove: (e: ReactPointerEvent) => {
+      if (!dragMode.current) return;
+      const el = readWeekdayEl(e.clientX, e.clientY);
+      if (el) paintWeekday(Number(el.dataset.weekday), dragMode.current);
+    },
+  };
   const setTime = (v: string) => {
     const [h, m] = v.split(':').map(Number);
     if (Number.isFinite(h) && Number.isFinite(m)) update({ hour: h, minute: m });
@@ -179,66 +298,79 @@ export function SchedulePicker({
 
   const previewCron = specToCron(state);
   const summary = summarizeCron(previewCron, t);
-  const intervalDisabled = state.unit !== 'hour';
 
   return (
     <div className="cw-schedule-picker">
-      {/* Row 1: Repeat every [N] [unit] */}
+      {/* Row 1: Repeat every [unit] */}
       <div className="cw-sched-row">
         <span className="cw-sched-label">{t('sched.repeat_every')}</span>
-        <input
-          type="number"
-          className="cw-sched-num"
-          min={1}
-          max={24}
-          value={state.interval}
-          disabled={intervalDisabled}
-          aria-disabled={intervalDisabled}
-          onChange={(e) => update({ interval: Math.max(1, Math.min(24, parseInt(e.target.value, 10) || 1)) })}
-          title={intervalDisabled ? t('sched.interval_hint') : ''}
-        />
-        <Select<Unit>
+        <SegmentedControl<Unit>
           value={state.unit}
           onChange={(unit) => update({ unit })}
           options={[
+            { value: 'minute', label: t('sched.opt.minutely') },
             { value: 'hour', label: t('sched.opt.hourly') },
             { value: 'day', label: t('sched.opt.daily') },
             { value: 'week', label: t('sched.opt.weekly') },
             { value: 'month', label: t('sched.opt.monthly') },
             { value: 'custom', label: t('sched.opt.custom') },
           ]}
-          className="cw-sched-unit"
-          triggerClassName="cw-sched-select"
           ariaLabel={t('sched.repeat_every')}
         />
       </div>
+
+      {/* every-N-minutes (divisors of 60 only) */}
+      {state.unit === 'minute' && (
+        <div className="cw-sched-row">
+          <span className="cw-sched-label">{t('sched.interval_label')}</span>
+          <Select<number>
+            value={state.minuteInterval}
+            onChange={(minuteInterval) => update({ minuteInterval })}
+            // Keep a legacy non-divisor value visible until a preset is picked.
+            options={(MINUTE_INTERVALS.includes(state.minuteInterval)
+              ? MINUTE_INTERVALS
+              : [...MINUTE_INTERVALS, state.minuteInterval].sort((a, b) => a - b)
+            ).map((n) => ({ value: n, label: String(n) }))}
+            className="cw-sched-unit-tiny"
+            triggerClassName="cw-sched-select"
+            ariaLabel={t('sched.interval_label')}
+          />
+          <span className="cw-sched-suffix">{t('sched.minute_suffix')}</span>
+        </div>
+      )}
+
+      {/* every-N-hours (divisors of 24 only) */}
+      {state.unit === 'hour' && (
+        <div className="cw-sched-row">
+          <span className="cw-sched-label">{t('sched.interval_label')}</span>
+          <Select<number>
+            value={state.interval}
+            onChange={(interval) => update({ interval })}
+            // Keep a legacy non-divisor value (e.g. parsed `*/5`) visible until
+            // the user picks a divisor, instead of rendering a blank trigger.
+            options={(HOUR_INTERVALS.includes(state.interval)
+              ? HOUR_INTERVALS
+              : [...HOUR_INTERVALS, state.interval].sort((a, b) => a - b)
+            ).map((n) => ({ value: n, label: String(n) }))}
+            className="cw-sched-unit-tiny"
+            triggerClassName="cw-sched-select"
+            ariaLabel={t('sched.interval_label')}
+          />
+          <span className="cw-sched-suffix">{t('sched.interval_suffix')}</span>
+        </div>
+      )}
 
       {/* Row 2: Monthly mode dropdown */}
       {state.unit === 'month' && (
         <div className="cw-sched-row">
           <span className="cw-sched-label">{t('sched.repeat_mode')}</span>
-          <Select
-            value={state.monthlyMode === 'day' ? `day-${state.dayOfMonth}` : `wk-${state.nth}-${state.nthWeekday}`}
-            onChange={(v) => {
-              if (v.startsWith('day-')) {
-                update({ monthlyMode: 'day', dayOfMonth: parseInt(v.slice(4), 10) });
-              } else if (v.startsWith('wk-')) {
-                const [, nthStr, wdStr] = v.split('-');
-                update({ monthlyMode: 'weekday', nth: parseInt(nthStr, 10), nthWeekday: parseInt(wdStr, 10) });
-              }
-            }}
+          <SegmentedControl<MonthlyMode>
+            value={state.monthlyMode}
+            onChange={(monthlyMode) => update({ monthlyMode })}
             options={[
-              { value: `day-${state.dayOfMonth}`, label: t('sched.monthly_day_opt', { day: state.dayOfMonth }) },
-              {
-                value: `wk-${state.nth}-${state.nthWeekday}`,
-                label: t('sched.monthly_weekday_opt', {
-                  nth: nthArr[state.nth - 1] ?? String(state.nth),
-                  weekday: weekdayArr[state.nthWeekday],
-                }),
-              },
+              { value: 'day', label: t('sched.monthly_mode.day') },
+              { value: 'weekday', label: t('sched.monthly_mode.weekday') },
             ]}
-            className="cw-sched-unit"
-            triggerClassName="cw-sched-select"
             ariaLabel={t('sched.repeat_mode')}
           />
         </div>
@@ -248,34 +380,46 @@ export function SchedulePicker({
       {state.unit === 'month' && state.monthlyMode === 'day' && (
         <div className="cw-sched-row">
           <span className="cw-sched-label">{t('sched.day_of_month')}</span>
-          <input
-            type="number"
-            className="cw-sched-num"
-            min={1}
-            max={31}
-            value={state.dayOfMonth}
-            onChange={(e) => update({ dayOfMonth: Math.max(1, Math.min(31, parseInt(e.target.value, 10) || 1)) })}
+          <Select<string>
+            value={state.lastDay ? 'L' : String(state.dayOfMonth)}
+            onChange={(v) => {
+              if (v === 'L') update({ lastDay: true });
+              else update({ lastDay: false, dayOfMonth: parseInt(v, 10) });
+            }}
+            options={[
+              ...Array.from({ length: 31 }, (_, i) => ({
+                value: String(i + 1),
+                label: t('sched.day_label', { day: i + 1 }),
+              })),
+              { value: 'L', label: t('sched.last_day') },
+            ]}
+            className="cw-sched-unit-tiny"
+            triggerClassName="cw-sched-select"
+            ariaLabel={t('sched.day_of_month')}
           />
-          {t('sched.day_suffix') !== 'sched.day_suffix' && (
-            <span className="cw-sched-suffix">{t('sched.day_suffix')}</span>
-          )}
         </div>
       )}
       {state.unit === 'month' && state.monthlyMode === 'weekday' && (
         <div className="cw-sched-row">
           <span className="cw-sched-label">{t('sched.detail')}</span>
-          <Select<number>
-            value={state.nth}
-            onChange={(nth) => update({ nth })}
-            options={nthArr.map((n, i) => ({ value: i + 1, label: n }))}
-            className="cw-sched-unit cw-sched-unit-narrow"
+          <Select<string>
+            value={state.nthLast ? 'L' : String(state.nth)}
+            onChange={(v) => {
+              if (v === 'L') update({ nthLast: true });
+              else update({ nthLast: false, nth: parseInt(v, 10) });
+            }}
+            options={[
+              ...nthArr.map((n, i) => ({ value: String(i + 1), label: n })),
+              { value: 'L', label: t('sched.nth_last') },
+            ]}
+            className="cw-sched-unit-tiny"
             triggerClassName="cw-sched-select"
             ariaLabel={t('sched.detail')}
           />
           <Select<number>
             value={state.nthWeekday}
             onChange={(nthWeekday) => update({ nthWeekday })}
-            options={weekdayArr.map((d, i) => ({ value: i, label: t('sched.weekday_option', { day: d }) }))}
+            options={weekdayLongArr.map((d, i) => ({ value: i, label: d }))}
             className="cw-sched-unit cw-sched-unit-narrow"
             triggerClassName="cw-sched-select"
             ariaLabel={t('sched.weekday_label')}
@@ -287,18 +431,39 @@ export function SchedulePicker({
       {state.unit === 'week' && (
         <div className="cw-sched-row cw-sched-row-stack">
           <span className="cw-sched-label">{t('sched.weekday_label')}</span>
-          <div className="cw-weekday-row" role="group" aria-label={t('sched.weekday_label')}>
-            {weekdayArr.map((label, i) => (
-              <button
-                key={i}
-                type="button"
-                className={`cw-weekday-chip ${state.weekdays.has(i) ? 'is-active' : ''}`}
-                aria-pressed={state.weekdays.has(i)}
-                onClick={() => toggleDay(i)}
-              >
-                {label}
-              </button>
-            ))}
+          <div
+            className="cw-weekday-row"
+            role="group"
+            aria-label={t('sched.weekday_label')}
+            onPointerDown={weekdaysDrag.onPointerDown}
+            onPointerMove={weekdaysDrag.onPointerMove}
+          >
+            {weekdayArr.map((label, i) => {
+              const implied = state.weekdays.size === 0 && i === WEEKDAY_FALLBACK;
+              // The implied fallback day actually runs, so report it as pressed
+              // (with a hint that it's the implicit default) rather than leaving
+              // assistive tech to announce "no day selected".
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  data-weekday={i}
+                  className={`cw-weekday-chip ${
+                    state.weekdays.has(i) ? 'is-active' : implied ? 'is-implied' : ''
+                  }`}
+                  aria-pressed={state.weekdays.has(i) || implied}
+                  aria-label={implied ? t('sched.weekday_implied', { day: label }) : undefined}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      toggleDay(i);
+                    }
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
           </div>
         </div>
       )}

--- a/app/src/components/SchedulePicker.tsx
+++ b/app/src/components/SchedulePicker.tsx
@@ -2,7 +2,8 @@
 // dialog. Output is a cron expression, so options that cron can't
 // faithfully express (e.g. "every N weeks", "end after N occurrences") are
 // intentionally not surfaced. croner is used backend-side, so we lean on
-// its `W#N` syntax for "the nth weekday of the month".
+// its `<weekday>#<n>` syntax (e.g. `4#2` = 2nd Thursday) for "the nth weekday
+// of the month", and `<weekday>L` / `L` for the last weekday / last day.
 
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/app/src/components/SegmentedControl.tsx
+++ b/app/src/components/SegmentedControl.tsx
@@ -1,0 +1,44 @@
+// Segmented control (tablist) for a small set of mutually-exclusive choices —
+// an inline alternative to a dropdown, in the cw-side-seg / ComposerAgentPicker
+// tab style. Each option may carry an optional leading icon.
+
+import { Icon, type IconName } from './Icon';
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+  icon?: IconName;
+}
+
+export function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+  className,
+}: {
+  value: T;
+  onChange: (value: T) => void;
+  options: SegmentedOption<T>[];
+  ariaLabel?: string;
+  // Extra class on the track (e.g. to size it as a flex item).
+  className?: string;
+}) {
+  return (
+    <div className={`cw-segmented${className ? ` ${className}` : ''}`} role="tablist" aria-label={ariaLabel}>
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          role="tab"
+          aria-selected={o.value === value}
+          className="cw-segmented-tab"
+          onClick={() => onChange(o.value)}
+        >
+          {o.icon && <Icon name={o.icon} size={14} />}
+          <span>{o.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/src/i18n/locales/en/automation.json
+++ b/app/src/i18n/locales/en/automation.json
@@ -217,6 +217,7 @@
     "cancel_aria": "Cancel",
     "bearer_token": "bearer token",
     "edit_trigger_aria": "Edit trigger",
+    "duplicate_trigger_aria": "Duplicate trigger",
     "webhook_not_editable": "Webhooks can't be edited",
     "edit": "Edit",
     "delete_again": "Press again to delete",
@@ -238,20 +239,30 @@
     "trigger_save_failed": "Failed to update trigger: {{message}}"
   },
   "sched": {
-    "weekdays": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    "weekdays_short": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    "weekdays": ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
     "nth": ["1st", "2nd", "3rd", "4th", "5th"],
-    "repeat_every": "Repeat every",
-    "repeat_mode": "Repeats",
+    "repeat_every": "Frequency",
+    "repeat_mode": "Mode",
+    "monthly_mode": {
+      "day": "Date",
+      "weekday": "Day of the week"
+    },
     "day_of_month": "Day",
-    "day_suffix": "",
+    "day_label": "{{day}}",
+    "last_day": "Last day",
+    "nth_last": "Last",
     "detail": "Detail",
-    "weekday_label": "Days",
+    "weekday_label": "Day of the week",
     "run_time": "Time",
     "timezone": "Timezone",
-    "interval_hint": "cron only supports N>1 for the hourly unit.",
+    "interval_label": "Interval",
+    "interval_suffix": "hours",
+    "minute_suffix": "minutes",
     "cron_preview_title": "Generated cron expression",
     "opt": {
-      "hourly": "Hourly",
+      "minutely": "By minute",
+      "hourly": "By hour",
       "daily": "Daily",
       "weekly": "Weekly",
       "monthly": "Monthly",
@@ -260,14 +271,20 @@
     "monthly_day_opt": "Day {{day}} of month",
     "monthly_weekday_opt": "The {{nth}} {{weekday}}",
     "weekday_option": "{{day}}",
+    "weekday_implied": "{{day}} (default)",
     "summary": {
+      "every_minute": "Every minute",
+      "every_n_minutes": "Every {{n}} minutes",
       "every_hour": "Every hour",
       "every_n_hours": "Every {{n}} hours",
+      "oclock": "{{h}} o'clock",
       "daily": "Daily at {{time}}",
       "weekly_all": "Weekly at {{time}}",
       "weekly": "Weekly on {{days}} at {{time}}",
       "monthly_day": "Monthly on day {{day}} at {{time}}",
-      "monthly_weekday": "Monthly on the {{nth}} {{weekday}} at {{time}}"
+      "monthly_last": "Last day of month at {{time}}",
+      "monthly_weekday": "Monthly on the {{nth}} {{weekday}} at {{time}}",
+      "monthly_weekday_last": "Last {{weekday}} of month at {{time}}"
     }
   },
   "webhook_dialog": {

--- a/app/src/i18n/locales/ko/automation.json
+++ b/app/src/i18n/locales/ko/automation.json
@@ -217,6 +217,7 @@
     "cancel_aria": "취소",
     "bearer_token": "bearer 토큰",
     "edit_trigger_aria": "트리거 편집",
+    "duplicate_trigger_aria": "트리거 복제",
     "webhook_not_editable": "웹훅은 편집 불가",
     "edit": "편집",
     "delete_again": "한 번 더 눌러 삭제",
@@ -238,20 +239,30 @@
     "trigger_save_failed": "트리거 수정 실패: {{message}}"
   },
   "sched": {
-    "weekdays": ["일", "월", "화", "수", "목", "금", "토"],
+    "weekdays_short": ["일", "월", "화", "수", "목", "금", "토"],
+    "weekdays": ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"],
     "nth": ["첫째", "둘째", "셋째", "넷째", "다섯째"],
     "repeat_every": "반복 주기",
-    "repeat_mode": "반복 방식",
+    "repeat_mode": "방식",
+    "monthly_mode": {
+      "day": "날짜",
+      "weekday": "요일"
+    },
     "day_of_month": "며칠",
-    "day_suffix": "일",
+    "day_label": "{{day}}일",
+    "last_day": "말일",
+    "nth_last": "마지막",
     "detail": "상세",
     "weekday_label": "요일",
     "run_time": "실행 시각",
     "timezone": "시간대",
-    "interval_hint": "cron으로는 매시간 단위에서만 N>1을 지원합니다.",
+    "interval_label": "간격",
+    "interval_suffix": "시간마다",
+    "minute_suffix": "분마다",
     "cron_preview_title": "생성될 cron 표현식",
     "opt": {
-      "hourly": "시간마다",
+      "minutely": "분 단위",
+      "hourly": "시간 단위",
       "daily": "매일",
       "weekly": "매주",
       "monthly": "매월",
@@ -260,14 +271,20 @@
     "monthly_day_opt": "매월 {{day}}일",
     "monthly_weekday_opt": "매월 {{nth}} {{weekday}}요일",
     "weekday_option": "{{day}}요일",
+    "weekday_implied": "{{day}} (기본값)",
     "summary": {
+      "every_minute": "매분",
+      "every_n_minutes": "{{n}}분마다",
       "every_hour": "매시간",
       "every_n_hours": "{{n}}시간마다",
+      "oclock": "{{h}}시",
       "daily": "매일 {{time}}",
       "weekly_all": "매주 {{time}}",
       "weekly": "매주 {{days}}요일 {{time}}",
       "monthly_day": "매월 {{day}}일 {{time}}",
-      "monthly_weekday": "매월 {{nth}} {{weekday}}요일 {{time}}"
+      "monthly_last": "매월 말일 {{time}}",
+      "monthly_weekday": "매월 {{nth}} {{weekday}}요일 {{time}}",
+      "monthly_weekday_last": "매월 마지막 {{weekday}}요일 {{time}}"
     }
   },
   "webhook_dialog": {

--- a/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
@@ -206,10 +206,7 @@ function AutomationSettingsPage() {
   // time). The clone is created disabled so an exact duplicate doesn't double-
   // fire alongside the original until the user edits and enables it.
   const duplicateTrigger = (trig: Trigger) =>
-    createTriggerMutation.mutate(trig.spec, {
-      onSuccess: (created) =>
-        updateTriggerMutation.mutate({ triggerId: created.trigger.id, patch: { enabled: false } }),
-    });
+    createTriggerMutation.mutate({ ...trig.spec, enabled: false});
 
   // ── Add-trigger draft ───────────────────────────────────────────────────
   const [showAddForm, setShowAddForm] = useState(false);

--- a/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '@/components/Icon';
+import { IconButton } from '@/components/uiPrimitives';
 import { SchedulePicker, summarizeCron, type SchedulePickerValue } from '@/components/SchedulePicker';
 import { WebhookTokenDialog } from '@/components/WebhookTokenDialog';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -199,17 +200,16 @@ function AutomationSettingsPage() {
   const removePrompt = (i: number) => setPrompts((p) => p.filter((_, idx) => idx !== i));
 
   // ── Trigger row actions ─────────────────────────────────────────────────
-  const [pendingTriggerDeleteId, setPendingTriggerDeleteId] = useState<string | null>(null);
-  const removeTrigger = (id: string) => {
-    if (pendingTriggerDeleteId !== id) {
-      setPendingTriggerDeleteId(id);
-      return;
-    }
-    setPendingTriggerDeleteId(null);
-    deleteTriggerMutation.mutate(id);
-  };
   const toggleTriggerEnabled = (t: Trigger) =>
     updateTriggerMutation.mutate({ triggerId: t.id, patch: { enabled: !t.enabled } });
+  // Clone a trigger's spec into a new trigger (e.g. same schedule at a different
+  // time). The clone is created disabled so an exact duplicate doesn't double-
+  // fire alongside the original until the user edits and enables it.
+  const duplicateTrigger = (trig: Trigger) =>
+    createTriggerMutation.mutate(trig.spec, {
+      onSuccess: (created) =>
+        updateTriggerMutation.mutate({ triggerId: created.trigger.id, patch: { enabled: false } }),
+    });
 
   // ── Add-trigger draft ───────────────────────────────────────────────────
   const [showAddForm, setShowAddForm] = useState(false);
@@ -737,25 +737,19 @@ function AutomationSettingsPage() {
                               <span className="cw-switch-track" aria-hidden />
                             </span>
                           </label>
-                          <button
-                            className="cw-trigger-action"
-                            type="button"
-                            aria-label={t('detail.save_aria')}
+                          <IconButton
+                            icon="check"
+                            label={t('detail.save_aria')}
                             onClick={saveEdit}
-                            title={t('detail.save_aria')}
                             disabled={updateTriggerMutation.isPending}
-                          >
-                            <Icon name="check" size={14} />
-                          </button>
-                          <button
-                            className="cw-trigger-action"
-                            type="button"
-                            aria-label={t('detail.cancel_aria')}
+                            iconSize={14}
+                          />
+                          <IconButton
+                            icon="x"
+                            label={t('detail.cancel_aria')}
                             onClick={cancelEdit}
-                            title={t('detail.cancel_aria')}
-                          >
-                            <Icon name="x" size={14} />
-                          </button>
+                            iconSize={14}
+                          />
                         </header>
                         <div className="cw-trigger-edit-body">
                           <SchedulePicker value={editSchedule} onChange={setEditSchedule} />
@@ -788,26 +782,28 @@ function AutomationSettingsPage() {
                             <span className="cw-switch-track" aria-hidden />
                           </span>
                         </label>
-                        <button
-                          className="cw-trigger-action"
-                          type="button"
-                          aria-label={t('detail.edit_trigger_aria')}
+                        <IconButton
+                          icon="copy"
+                          label={t('detail.duplicate_trigger_aria')}
+                          onClick={() => duplicateTrigger(trigger)}
+                          disabled={!isCron || createTriggerMutation.isPending}
+                          iconSize={14}
+                        />
+                        <IconButton
+                          icon="settings"
+                          label={t('detail.edit_trigger_aria')}
+                          title={!isCron ? t('detail.webhook_not_editable') : t('detail.edit')}
                           onClick={() => startEdit(trigger)}
                           disabled={!isCron}
-                          title={!isCron ? t('detail.webhook_not_editable') : t('detail.edit')}
-                        >
-                          <Icon name="settings" size={14} />
-                        </button>
-                        <button
-                          className={`cw-trigger-action${pendingTriggerDeleteId === trigger.id ? ' is-armed' : ''}`}
-                          type="button"
-                          aria-label={pendingTriggerDeleteId === trigger.id ? t('detail.delete_again') : t('detail.delete_trigger_aria')}
-                          onClick={() => removeTrigger(trigger.id)}
-                        >
-                          {pendingTriggerDeleteId === trigger.id
-                            ? t('detail.delete_again')
-                            : <Icon name="trash" size={14} />}
-                        </button>
+                          iconSize={14}
+                        />
+                        <IconButton
+                          icon="trash"
+                          label={t('detail.delete_trigger_aria')}
+                          confirmText={t('detail.delete_again')}
+                          onClick={() => deleteTriggerMutation.mutate(trigger.id)}
+                          iconSize={14}
+                        />
                       </>
                     )}
                   </li>

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -9,10 +9,14 @@ import { IconButton } from '@/components/uiPrimitives';
 import { Select } from '@/components/Select';
 import { MarkdownRenderer } from '@/components/chat/MarkdownRenderer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { ArtifactsPanel } from '@/components/ArtifactsPanel';
+import { CopyToSharedDialog } from '@/components/CopyToSharedDialog';
 import { summarizeCron } from '@/components/SchedulePicker';
 import { cancelRun as cancelRunApi, createRun, listAutomations, listRunEvents, listRuns, listTriggers } from '@/api/automations';
 import { listMessages } from '@/api/messages';
 import { getModelCatalog, modelLabel } from '@/api/models';
+import { getProject } from '@/api/projects';
+import type { DirentScope } from '@/api/dirents';
 import { getAgentSurface } from '@/domain/agentSurfaces';
 import { formatMessageTime } from '@/lib/formatMessageTime';
 import { useDuplicateSession } from '@/lib/useDuplicateSession';
@@ -21,7 +25,8 @@ import { loadNs } from '@/i18n/loader';
 import type { Automation, Message, Run, Trigger } from '@/domain/types';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/automation/')({
-  loader: () => loadNs('automation'),
+  // 'session'/'dialogs' cover the artifacts panel + copy-to-shared dialog.
+  loader: () => loadNs('automation', 'session', 'dialogs', 'common'),
   component: AutomationsPage,
 });
 
@@ -152,6 +157,10 @@ function AutomationsPage() {
     [automations],
   );
   const queryClient = useQueryClient();
+  const project = useQuery({ queryKey: ['project', projectSlug], queryFn: () => getProject(projectSlug) });
+  const projectId = project.data?.id ?? '';
+  // Source scope + paths for the "copy artifact to shared" dialog (null = closed).
+  const [copyToShared, setCopyToShared] = useState<{ scope: DirentScope; paths: string[] } | null>(null);
   const runQueries = useQueries({
     queries: automations.map((a) => ({
       queryKey: ['runs', a.id],
@@ -294,21 +303,41 @@ function AutomationsPage() {
   const selectedRun: Run | null = selectedRunId
     ? displayRuns.find((r) => r.id === selectedRunId) ?? null
     : null;
+  const selectedRunLive = selectedRun
+    ? selectedRun.status === 'queued' || selectedRun.status === 'running'
+    : false;
   const messagesQuery = useQuery({
     queryKey: ['messages', selectedRun?.sessionId],
     queryFn: () => listMessages(selectedRun!.sessionId),
     enabled: Boolean(selectedRun),
   });
-  const selectedRunLive = selectedRun
-    ? selectedRun.status === 'queued' || selectedRun.status === 'running'
-    : false;
   const eventsQuery = useQuery({
     queryKey: ['runEvents', selectedRun?.automationId, selectedRun?.id],
     queryFn: () => listRunEvents(selectedRun!.automationId, selectedRun!.id),
     enabled: Boolean(selectedRun),
-    // Poll the audit log while the selected run is still in-flight.
-    refetchInterval: selectedRunLive ? 4000 : false,
   });
+  // Single poller for the selected in-flight run: one 4s timer refreshes the
+  // session preview, the event log, and the artifacts panel together (rather
+  // than three independent intervals). On the live→done transition it fires
+  // once more for that run so the final snapshot lands.
+  const liveRun = selectedRunLive && selectedRun && projectId
+    ? { sessionId: selectedRun.sessionId, runId: selectedRun.id, automationId: selectedRun.automationId }
+    : null;
+  const prevLiveRef = useRef<typeof liveRun>(null);
+  useEffect(() => {
+    const refresh = (r: NonNullable<typeof liveRun>) => {
+      void queryClient.invalidateQueries({ queryKey: ['messages', r.sessionId] });
+      void queryClient.invalidateQueries({ queryKey: ['runEvents', r.automationId, r.runId] });
+      void queryClient.invalidateQueries({ queryKey: ['dirents', 'artifacts', projectId, r.sessionId] });
+    };
+    const prev = prevLiveRef.current;
+    if (prev && prev.runId !== liveRun?.runId) refresh(prev); // final snapshot
+    prevLiveRef.current = liveRun;
+    if (!liveRun) return;
+    const id = setInterval(() => refresh(liveRun), 4000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [liveRun?.runId, projectId, queryClient]);
   const previewMessages: Message[] = messagesQuery.data ?? [];
   const runEvents: RunEventLike[] = useMemo(
     () => (eventsQuery.data ?? []).map((e) => ({
@@ -469,6 +498,14 @@ function AutomationsPage() {
           })
         )}
       </div>
+
+      {projectId && (
+        <ArtifactsPanel
+          projectId={projectId}
+          sessionId={run.sessionId}
+          onCopyToShared={(scope, paths) => setCopyToShared({ scope, paths })}
+        />
+      )}
 
       <details className="cw-event-logs">
         <summary>
@@ -733,6 +770,20 @@ function AutomationsPage() {
           onConfirm={confirmManualRun}
           onClose={() => setPendingManualRun(null)}
           confirmOnEnter
+        />
+      )}
+
+      {copyToShared !== null && (
+        <CopyToSharedDialog
+          open
+          projectId={projectId}
+          sourceScope={copyToShared.scope}
+          sourcePaths={copyToShared.paths}
+          onClose={() => setCopyToShared(null)}
+          onDone={() => {
+            setCopyToShared(null);
+            void queryClient.invalidateQueries({ queryKey: ['dirents', 'shared', projectId] });
+          }}
         />
       )}
     </section>

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -3539,6 +3539,8 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 .cw-trigger-badge {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
+  white-space: nowrap;
   font-size: 11px;
   font-weight: 500;
   padding: 2px 8px;
@@ -4114,28 +4116,6 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   outline: 2px solid var(--cw-accent-line);
   outline-offset: 2px;
 }
-.cw-trigger-action {
-  border: 0;
-  background: transparent;
-  color: var(--cw-ink-3);
-  width: 28px;
-  height: 28px;
-  border-radius: var(--cw-radius-sm);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.cw-trigger-action:hover { background: var(--cw-paper-3); color: var(--cw-ink); }
-.cw-trigger-action.is-armed,
-.cw-trigger-action.is-armed:hover {
-  width: auto;
-  padding: 0 10px;
-  background: var(--cw-destructive);
-  color: var(--cw-paper);
-  font-size: 11px;
-  font-weight: 600;
-}
 
 .cw-trigger-picker {
   display: grid;
@@ -4227,13 +4207,58 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   font-weight: 500;
   flex: 0 0 80px;
 }
-.cw-sched-num { width: 70px; text-align: center; font-variant-numeric: tabular-nums; }
 .cw-sched-unit { min-width: 200px; flex: 1 1 200px; }
 .cw-sched-unit-narrow { min-width: 110px; flex: 0 0 auto; }
+.cw-sched-unit-tiny { min-width: 64px; flex: 0 0 auto; }
 .cw-sched-time { width: 120px; }
 .cw-sched-text { flex: 1 1 200px; min-width: 0; }
 .cw-sched-suffix { font-size: 13px; color: var(--cw-ink-2); }
-.cw-weekday-row { display: flex; gap: 6px; flex-wrap: wrap; }
+/* Segmented control for repeat-frequency / mode (mirrors cw-side-seg). */
+.cw-segmented {
+  display: flex;
+  gap: 2px;
+  flex: 1 1 200px;
+  min-width: 0;
+  padding: 3px;
+  background: var(--cw-bg-muted);
+  border-radius: var(--cw-radius-md);
+}
+.cw-segmented-tab {
+  flex: 1 1 0;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: calc(var(--cw-radius-md) - 3px);
+  background: transparent;
+  color: var(--cw-ink-3);
+  font-size: 12.5px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  transition: background 120ms, color 120ms, box-shadow 120ms;
+}
+.cw-segmented-tab:hover { color: var(--cw-ink); }
+.cw-segmented-tab[aria-selected="true"] {
+  background: var(--cw-accent-soft);
+  color: var(--cw-accent-2);
+  box-shadow: inset 0 0 0 1px var(--cw-accent-line);
+  font-weight: 600;
+}
+.cw-weekday-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
 .cw-weekday-chip {
   display: inline-flex;
   align-items: center;
@@ -4256,6 +4281,14 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   background: var(--cw-ink);
   border-color: var(--cw-ink);
   color: var(--cw-paper);
+}
+/* Implied default: no chip is explicitly selected, so the fallback value shows
+   as "selected, but not a deliberate choice" — a muted, dashed half-state. */
+.cw-weekday-chip.is-implied {
+  background: color-mix(in srgb, var(--cw-ink) 18%, var(--cw-paper));
+  border-color: color-mix(in srgb, var(--cw-ink) 40%, var(--cw-paper));
+  border-style: dashed;
+  color: var(--cw-ink-1);
 }
 .cw-schedule-summary {
   display: flex;
@@ -4309,8 +4342,6 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   box-shadow: 0 0 0 3px var(--cw-selected-ring);
 }
 .cw-trigger-row.is-editing {
-  background: var(--cw-selected-bg);
-  border-color: var(--cw-accent);
   flex-direction: column;
   align-items: stretch;
   gap: 12px;
@@ -4330,7 +4361,6 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   color: var(--cw-ink);
   font-weight: 500;
 }
-.cw-trigger-action:disabled { opacity: 0.35; cursor: not-allowed; }
 
 /* Webhook token reveal dialog (one-shot bearer token) */
 .cw-webhook-dialog {

--- a/backend/src/cron.rs
+++ b/backend/src/cron.rs
@@ -110,6 +110,21 @@ mod tests {
     }
 
     #[test]
+    fn last_day_of_month_resolves_next_fire() {
+        // "0 9 L * *" → 09:00 on the last day of the month (croner `L`).
+        let now = at("2026-06-10T00:00:00Z");
+        let next = next_fire_after("0 9 L * *", "UTC", now).unwrap();
+        assert_eq!(next, at("2026-06-30T09:00:00Z"));
+    }
+
+    #[test]
+    fn last_weekday_of_month_is_supported() {
+        let now = at("2026-08-01T00:00:00Z");
+        // "5L" in the day-of-week field = last Friday of the month.
+        assert!(next_fire_after("0 9 * * 5L", "UTC", now).is_ok(), "5L should parse");
+    }
+
+    #[test]
     fn invalid_cron_returns_error() {
         let now = at("2026-06-01T08:30:00Z");
         assert!(next_fire_after("not a cron", "UTC", now).is_err());

--- a/backend/src/cron.rs
+++ b/backend/src/cron.rs
@@ -118,10 +118,11 @@ mod tests {
     }
 
     #[test]
-    fn last_weekday_of_month_is_supported() {
+    fn last_weekday_of_month_resolves_next_fire() {
         let now = at("2026-08-01T00:00:00Z");
         // "5L" in the day-of-week field = last Friday of the month.
-        assert!(next_fire_after("0 9 * * 5L", "UTC", now).is_ok(), "5L should parse");
+        let next = next_fire_after("0 9 * * 5L", "UTC", now).unwrap();
+        assert_eq!(next, at("2026-08-28T09:00:00Z"));
     }
 
     #[test]


### PR DESCRIPTION
## Description
- **Schedule picker rework**
  - add 'By minute' segment(#170)
  - minute/hour interval presets (divisors of 60/24 only)
    : elsewise, it may cause confusion. ('every 5 hours' ≠ (`0 */5 * * *`))
    - minute: 5 / 10 / 15 / 20 / 30 (4 minutes or less have been excluded.)
    - hour: 1 / 2 / 3 / 4 / 6 / 8 / 12
  - monthly *day* includes "last day" (cron `L`; e.g. `0 10 L * *`: Last day of month at 10 o'clock)
  - monthly *day of week* includes "last week" (cron `<dow>L`; e.g. `0 10 * * 1L`: Last Monday of month at 10 o'clock )
  - drag-to-select weekday chips (for 'Weekly')
  - dropdown -> segmented-control UI to pick units(Monthly, Weekly, ...)
  - tidier human summaries (`N o'clock` etc.)
- **Trigger row actions**
  - **duplicate** a trigger (created **disabled** so it can't double-fire)
  - IconButton-based edit/delete with two-step delete confirm.
- **Run detail**
  - surface session **artifacts** (view + copy-to-shared)
  - a single 4s poller keeps the session preview, event log, and artifacts live while a run is in-flight.

## Notes
- cron `L` / `<dow>L` verified against `croner` (unit tests added).
- 'Timezone picker' & 'Prompts with variables' are tried to be included, but not accepted for this PR.

## Screenshots
### By minute
<details>
  <summary>Show</summary>

<img width="1171" height="563" alt="스크린샷 2026-06-16 오후 1 22 11" src="https://github.com/user-attachments/assets/022734d9-892d-4ea4-87fb-2ff42defaec3" />

</details>

### The last day of Month
<details>
  <summary>Show</summary>

<img width="1169" height="697" alt="스크린샷 2026-06-16 오후 1 23 06" src="https://github.com/user-attachments/assets/2d41237f-d40c-4aef-8bce-8a03f544ee22" />

</details>

### Day of the last week of Mongth
<details>
  <summary>Show</summary>

<img width="1168" height="715" alt="스크린샷 2026-06-16 오후 1 22 54" src="https://github.com/user-attachments/assets/35fa02fc-9735-401d-99b6-918520d9bedc" />

</details>

### Duplicate trigger (disabled at first)
<details>
  <summary>Show</summary>

<img width="832" height="207" alt="스크린샷 2026-06-16 오후 1 24 25" src="https://github.com/user-attachments/assets/d1988eff-dba1-4340-8183-0b63274e051a" />

</details>
