### PR TITLE
Runs in calendar view

### DIFF
--- a/app/src/api/automations.ts
+++ b/app/src/api/automations.ts
@@ -137,10 +137,15 @@ export async function listOccurrences(
 export async function createTrigger(
   automationId: AutomationId,
   spec: TriggerSpec,
+  opts?: { enabled?: boolean },
 ): Promise<CreatedTrigger> {
+  const body = {
+    ...specToBody(spec),
+    ...(opts?.enabled !== undefined ? { enabled: opts.enabled } : {}),
+  };
   const raw = await request<CreatedTriggerResponse>(
     `/automations/${automationId}/triggers`,
-    { method: 'POST', body: specToBody(spec) },
+    { method: 'POST', body },
   );
   return toCreatedTrigger(raw);
 }

--- a/app/src/api/automations.ts
+++ b/app/src/api/automations.ts
@@ -6,6 +6,7 @@ import { request } from './client';
 import type {
   BackendAutomation,
   BackendAutomationList,
+  BackendOccurrenceList,
   BackendRun,
   BackendRunEventList,
   BackendRunList,
@@ -17,6 +18,7 @@ import type {
 import {
   toAutomation,
   toCreatedTrigger,
+  toOccurrence,
   toRun,
   toRunEvent,
   toTrigger,
@@ -25,6 +27,7 @@ import type {
   Automation,
   AutomationId,
   CreatedTrigger,
+  Occurrence,
   Run,
   RunEvent,
   RunId,
@@ -115,6 +118,21 @@ export async function listTriggers(automationId: AutomationId): Promise<Trigger[
   return res.items.map(toTrigger);
 }
 
+/**
+ * Expand upcoming scheduled fires for all enabled cron triggers in a project,
+ * within `[from, to)`. Computed server-side from cron expressions (nothing is
+ * persisted). `from`/`to` are ISO instants.
+ */
+export async function listOccurrences(
+  projectRef: string,
+  from: string,
+  to: string,
+): Promise<{ items: Occurrence[]; truncated: boolean }> {
+  const qs = new URLSearchParams({ project_ref: projectRef, from, to }).toString();
+  const res = await request<BackendOccurrenceList>(`/automations/occurrences?${qs}`);
+  return { items: res.items.map(toOccurrence), truncated: res.truncated };
+}
+
 /** Returns the created trigger plus the one-time `webhookToken` (webhook only). */
 export async function createTrigger(
   automationId: AutomationId,
@@ -177,6 +195,20 @@ export async function listRuns(
   const res = await request<BackendRunList>(
     `/automations/${automationId}/runs${qs ? `?${qs}` : ''}`,
   );
+  return res.items.map(toRun);
+}
+
+/**
+ * Cron-triggered runs across a project whose scheduled time falls in
+ * `[from, to)` — the calendar's realized (past) slots. `from`/`to` are ISO.
+ */
+export async function listRunsInWindow(
+  projectRef: string,
+  from: string,
+  to: string,
+): Promise<Run[]> {
+  const qs = new URLSearchParams({ project_ref: projectRef, from, to }).toString();
+  const res = await request<BackendRunList>(`/automations/runs?${qs}`);
   return res.items.map(toRun);
 }
 

--- a/app/src/api/automations.ts
+++ b/app/src/api/automations.ts
@@ -199,8 +199,8 @@ export async function listRuns(
 }
 
 /**
- * Cron-triggered runs across a project whose scheduled time falls in
- * `[from, to)` — the calendar's realized (past) slots. `from`/`to` are ISO.
+ * Automation runs across a project whose scheduled time falls in `[from, to)`
+ * — the calendar's realized (past) slots. `from`/`to` are ISO.
  */
 export async function listRunsInWindow(
   projectRef: string,

--- a/app/src/api/backend-types.ts
+++ b/app/src/api/backend-types.ts
@@ -202,6 +202,19 @@ export interface BackendTriggerList {
   items: BackendTrigger[];
 }
 
+export interface BackendOccurrence {
+  trigger_id: string;
+  automation_id: string;
+  automation_name: string;
+  fire_at: string;
+  tz: string | null;
+}
+
+export interface BackendOccurrenceList {
+  items: BackendOccurrence[];
+  truncated: boolean;
+}
+
 /** POST body is the spec directly (no wrapper). */
 export type CreateTriggerRequest = BackendTriggerSpec;
 

--- a/app/src/api/transformers.ts
+++ b/app/src/api/transformers.ts
@@ -7,6 +7,7 @@ import type {
   FileAsset,
   Message,
   MessageSender,
+  Occurrence,
   PreferredLanguage,
   Project,
   Run,
@@ -23,6 +24,7 @@ import type {
   BackendAutomation,
   BackendDirent,
   BackendMember,
+  BackendOccurrence,
   BackendProject,
   BackendRun,
   BackendRunEvent,
@@ -329,6 +331,16 @@ export function toTrigger(backend: BackendTrigger): Trigger {
     nextFireAt: backend.next_fire_at,
     createdAt: backend.created_at,
     updatedAt: backend.updated_at,
+  };
+}
+
+export function toOccurrence(backend: BackendOccurrence): Occurrence {
+  return {
+    triggerId: backend.trigger_id,
+    automationId: backend.automation_id,
+    automationName: backend.automation_name,
+    fireAt: backend.fire_at,
+    tz: backend.tz,
   };
 }
 

--- a/app/src/components/AutomationCalendar.tsx
+++ b/app/src/components/AutomationCalendar.tsx
@@ -1,0 +1,465 @@
+// Month calendar that unifies a project's schedule timeline: past slots show
+// the actual runs that happened (real, with status), future slots show
+// computed cron occurrences (predicted — nothing persisted, see
+// listOccurrences). The split point is "now". Every instant (UTC) is bucketed
+// and displayed in the browser's local timezone, matching standard calendars.
+
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '@/components/Icon';
+import { listOccurrences, listRunsInWindow } from '@/api/automations';
+import type { Occurrence, Run, Trigger } from '@/domain/types';
+
+type TriggerKind = 'cron' | 'webhook' | 'manual';
+
+const MAX_PER_CELL = 4;
+const DAY_POPOVER_CAP = 15;
+
+// Per-automation accent. Avoids the run-status hues (red 25 / amber 75 /
+// green 145) so an accent is never mistaken for a status, but spreads across
+// the whole teal→pink arc with strong lightness variation between neighbours
+// so the colours stay mutually distinct (not a cramped blue-purple band).
+const PALETTE = [
+  'oklch(0.66 0.12 180)', // teal
+  'oklch(0.78 0.11 208)', // sky (light)
+  'oklch(0.55 0.17 240)', // blue
+  'oklch(0.46 0.15 268)', // indigo (dark)
+  'oklch(0.64 0.20 300)', // violet (bright)
+  'oklch(0.50 0.18 325)', // plum (dark)
+  'oklch(0.74 0.14 350)', // pink (light)
+];
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+function addDays(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + n);
+}
+function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1);
+}
+function localDayKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+function hhmm(d: Date): string {
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+// Slot identity for de-duping a future occurrence against an already-created
+// run for the same automation+minute (avoids showing both at the boundary).
+function slotKey(automationId: string, iso: string): string {
+  return `${automationId}@${iso.slice(0, 16)}`;
+}
+
+type CalEntry =
+  | { kind: 'run'; time: Date; run: Run }
+  | { kind: 'occ'; time: Date; occ: Occurrence };
+
+export function AutomationCalendar({
+  projectSlug,
+  automationNameById,
+  triggerById,
+  filterAutomationId,
+  statusFilter,
+  triggerFilter,
+  selectedKey,
+  selectedRunId,
+  onSelectOccurrence,
+  onSelectRun,
+}: {
+  projectSlug: string;
+  automationNameById: Record<string, string>;
+  /** Resolves a run's trigger kind for the trigger filter. */
+  triggerById: Record<string, Trigger>;
+  /** When set, only this automation's fires/runs are shown. */
+  filterAutomationId?: string | null;
+  /** Status filter, shared with the list view ('all' = no filter). */
+  statusFilter: string;
+  /** Trigger-kind filter, shared with the list view ('all' = no filter). */
+  triggerFilter: string;
+  /** `${triggerId}@${fireAt}` of the selected future fire, for highlight. */
+  selectedKey?: string | null;
+  /** id of the selected past run, for highlight. */
+  selectedRunId?: string | null;
+  /** Clicking a future fire opens its (predicted) detail. `anchor` is the
+   *  clicked element, for positioning a popover in the narrow layout. */
+  onSelectOccurrence?: (occ: Occurrence, anchor: HTMLElement) => void;
+  /** Clicking a past run opens the same run detail as the list view. */
+  onSelectRun?: (run: Run, anchor: HTMLElement) => void;
+}) {
+  const { t, i18n } = useTranslation('automation');
+  const [cursor, setCursor] = useState(() => startOfMonth(new Date()));
+
+  const monthStart = startOfMonth(cursor);
+  // Grid spans 6 weeks starting on the Sunday on/before the 1st.
+  const gridStart = addDays(monthStart, -monthStart.getDay());
+  const gridDays = useMemo(
+    () => Array.from({ length: 42 }, (_, i) => addDays(gridStart, i)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [localDayKey(gridStart)],
+  );
+  const gridEnd = addDays(gridStart, 42); // exclusive
+
+  // Past slots render as real runs, and occurrences are dropped client-side
+  // when fireAt <= now — so there's no point expanding the past portion. Clamp
+  // the query start to today when today is inside the window; a fully-past
+  // window has no future fires at all, so skip the request entirely.
+  const todayStart = startOfDay(new Date());
+  const occFrom = gridStart > todayStart ? gridStart : todayStart;
+  const hasFuture = occFrom < gridEnd;
+  const occQuery = useQuery({
+    queryKey: ['occurrences', projectSlug, localDayKey(gridStart), localDayKey(occFrom)],
+    queryFn: () => listOccurrences(projectSlug, occFrom.toISOString(), gridEnd.toISOString()),
+    enabled: hasFuture,
+    staleTime: 60_000,
+  });
+
+  // Realized (past) runs for the visible window — windowed query so old months
+  // aren't limited to the recently-fetched run set. Polls while any run in the
+  // window is still in-flight so the calendar reflects status changes live.
+  const runsQuery = useQuery({
+    queryKey: ['calRuns', projectSlug, localDayKey(gridStart)],
+    queryFn: () => listRunsInWindow(projectSlug, gridStart.toISOString(), gridEnd.toISOString()),
+    staleTime: 30_000,
+    refetchInterval: (q) =>
+      (q.state.data ?? []).some((r) => r.status === 'queued' || r.status === 'running')
+        ? 4000 : false,
+  });
+
+  // Pin the past/future split for the component's lifetime: a per-render
+  // Date.now() would bust the entriesByDay memo every render and drift the
+  // boundary mid-session.
+  const now = useMemo(() => Date.now(), []);
+  const matchAutomation = (id: string) => !filterAutomationId || id === filterAutomationId;
+
+  // Assign accent by the automation's rank in the project list (insertion
+  // order of automationNameById) rather than hashing its id: collision-free
+  // for the first PALETTE.length automations and stable per automation across
+  // months/filters. Beyond that, colors repeat (disambiguated by the label).
+  const colorByAutomation = useMemo(() => {
+    const map = new Map<string, string>();
+    Object.keys(automationNameById).forEach((id, i) => map.set(id, PALETTE[i % PALETTE.length]!));
+    return map;
+  }, [automationNameById]);
+  const automationColor = (id: string) => colorByAutomation.get(id) ?? PALETTE[0]!;
+  const runTriggerKind = (run: Run): TriggerKind =>
+    run.triggerId ? (triggerById[run.triggerId]?.kind as TriggerKind) ?? 'manual' : 'manual';
+  // Occurrences are future schedule predictions — only meaningful when the
+  // trigger filter admits 'cron' and no specific status is selected.
+  const showOccurrences =
+    (triggerFilter === 'all' || triggerFilter === 'cron') && statusFilter === 'all';
+
+  // Merge real runs (past) + predicted occurrences (future) into per-day
+  // buckets, honoring the shared status / trigger-kind filters.
+  const entriesByDay = useMemo(() => {
+    const map = new Map<string, CalEntry[]>();
+    const push = (e: CalEntry) => {
+      const k = localDayKey(e.time);
+      const arr = map.get(k);
+      if (arr) arr.push(e);
+      else map.set(k, [e]);
+    };
+
+    const runSlots = new Set<string>();
+    for (const r of runsQuery.data ?? []) {
+      if (!matchAutomation(r.automationId)) continue;
+      if (statusFilter !== 'all' && r.status !== statusFilter) continue;
+      if (triggerFilter !== 'all' && runTriggerKind(r) !== triggerFilter) continue;
+      runSlots.add(slotKey(r.automationId, r.scheduledFor));
+      push({ kind: 'run', time: new Date(r.scheduledFor), run: r });
+    }
+    if (showOccurrences) {
+      for (const o of occQuery.data?.items ?? []) {
+        if (!matchAutomation(o.automationId)) continue;
+        if (Date.parse(o.fireAt) <= now) continue; // past → represented by a run
+        if (runSlots.has(slotKey(o.automationId, o.fireAt))) continue; // already a run
+        push({ kind: 'occ', time: new Date(o.fireAt), occ: o });
+      }
+    }
+
+    for (const arr of map.values()) arr.sort((a, b) => a.time.getTime() - b.time.getTime());
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runsQuery.data, occQuery.data, triggerById, filterAutomationId, statusFilter, triggerFilter, showOccurrences, now]);
+
+  // Legend reflects what's actually shown (post-filter).
+  const legend = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const arr of entriesByDay.values()) for (const e of arr) {
+      if (e.kind === 'run') seen.set(e.run.automationId, automationNameById[e.run.automationId] ?? e.run.automationId);
+      else seen.set(e.occ.automationId, e.occ.automationName);
+    }
+    return [...seen.entries()];
+  }, [entriesByDay, automationNameById]);
+
+  const weekdays = t('sched.weekdays_short', { returnObjects: true }) as string[];
+
+  const monthLabel = useMemo(
+    () => new Intl.DateTimeFormat(i18n.language, { year: 'numeric', month: 'long' }).format(monthStart),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [i18n.language, monthStart.getFullYear(), monthStart.getMonth()],
+  );
+
+  const todayKey = localDayKey(new Date());
+  const total = gridDays.reduce((n, d) => n + (entriesByDay.get(localDayKey(d))?.length ?? 0), 0);
+
+  // "+N more" expands the day into a popover listing every entry.
+  const [dayPopover, setDayPopover] = useState<{ day: Date; anchor: HTMLElement } | null>(null);
+
+  const pickEntry = (e: CalEntry, anchor: HTMLElement) => {
+    if (e.kind === 'run') onSelectRun?.(e.run, anchor);
+    else onSelectOccurrence?.(e.occ, anchor);
+  };
+
+  // One entry button, shared by the day cells and the "+N more" popover.
+  // `onActivate` lets the popover override the detail anchor (to the day cell)
+  // and close itself, while cells just select with their own element.
+  const renderEntry = (
+    e: CalEntry,
+    i: number,
+    onActivate: (e: CalEntry, el: HTMLElement) => void,
+  ) => {
+    if (e.kind === 'run') {
+      const { run } = e;
+      const name = automationNameById[run.automationId] ?? run.automationId;
+      const active = selectedRunId != null && run.id === selectedRunId;
+      return (
+        <button
+          key={`r-${run.id}`}
+          type="button"
+          className={`cw-cal-event cw-cal-run ${active ? 'is-active' : ''}`}
+          style={{ ['--cal-accent' as string]: automationColor(run.automationId) }}
+          title={`${name} — ${hhmm(e.time)} · ${t(`status.${run.status}`)}`}
+          onClick={(ev) => onActivate(e, ev.currentTarget)}
+        >
+          <span className={`cw-status-dot cw-status-${run.status} is-compact`} />
+          <span className="cw-cal-event-time">{hhmm(e.time)}</span>
+          <span className="cw-cal-event-name">{name}</span>
+        </button>
+      );
+    }
+    const { occ } = e;
+    const active = selectedKey != null && `${occ.triggerId}@${occ.fireAt}` === selectedKey;
+    return (
+      <button
+        key={`o-${occ.triggerId}-${i}`}
+        type="button"
+        className={`cw-cal-event cw-cal-occ ${active ? 'is-active' : ''}`}
+        style={{ ['--cal-accent' as string]: automationColor(occ.automationId) }}
+        title={`${occ.automationName} — ${hhmm(e.time)}${occ.tz ? ` · ${occ.tz}` : ''}`}
+        onClick={(ev) => onActivate(e, ev.currentTarget)}
+      >
+        <span className="cw-cal-event-time">{hhmm(e.time)}</span>
+        <span className="cw-cal-event-name">{occ.automationName}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="cw-cal">
+      <header className="cw-cal-head">
+        <div className="cw-cal-nav">
+          <button
+            type="button"
+            className="cw-cal-navbtn"
+            aria-label={t('calendar.prev_month')}
+            onClick={() => setCursor((c) => addMonths(c, -1))}
+          >
+            <Icon name="chevron-left" size={16} />
+          </button>
+          <strong className="cw-cal-month">{monthLabel}</strong>
+          <button
+            type="button"
+            className="cw-cal-navbtn"
+            aria-label={t('calendar.next_month')}
+            onClick={() => setCursor((c) => addMonths(c, 1))}
+          >
+            <Icon name="chevron-right" size={16} />
+          </button>
+          <button
+            type="button"
+            className="cw-cal-today"
+            onClick={() => setCursor(startOfMonth(new Date()))}
+          >
+            {t('calendar.today')}
+          </button>
+        </div>
+        <span className="cw-cal-count">{t('calendar.fires_count', { count: total })}</span>
+      </header>
+
+      {legend.length > 0 && (
+        <ul className="cw-cal-legend">
+          {legend.map(([id, name]) => (
+            <li key={id}>
+              <span className="cw-cal-legend-dot" style={{ background: automationColor(id) }} />
+              <span>{name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {occQuery.data?.truncated && (
+        <p className="cw-cal-truncated">
+          <Icon name="zap" size={12} /> {t('calendar.truncated')}
+        </p>
+      )}
+
+      <div className="cw-cal-grid" role="grid" aria-label={monthLabel}>
+        {weekdays.map((w) => (
+          <div key={w} className="cw-cal-weekday" role="columnheader">{w}</div>
+        ))}
+        {gridDays.map((day) => {
+          const key = localDayKey(day);
+          const entries = entriesByDay.get(key) ?? [];
+          const outside = day.getMonth() !== monthStart.getMonth();
+          const isToday = key === todayKey;
+          const shown = entries.slice(0, MAX_PER_CELL);
+          const overflow = entries.length - shown.length;
+          return (
+            <div
+              key={key}
+              role="gridcell"
+              className={`cw-cal-cell ${outside ? 'is-outside' : ''} ${isToday ? 'is-today' : ''}`}
+            >
+              <span className="cw-cal-daynum">{day.getDate()}</span>
+              <div className="cw-cal-events">
+                {shown.map((e, i) => renderEntry(e, i, pickEntry))}
+                {overflow > 0 && (
+                  <button
+                    type="button"
+                    className="cw-cal-more"
+                    onClick={(ev) =>
+                      setDayPopover({
+                        day,
+                        anchor: (ev.currentTarget.closest('.cw-cal-cell') as HTMLElement | null) ?? ev.currentTarget,
+                      })
+                    }
+                  >
+                    {t('calendar.more', { count: overflow })}
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {!occQuery.isLoading && !runsQuery.isLoading && total === 0 && (
+        <div className="cw-cal-empty">
+          <Icon name="calendar" size={20} />
+          <b>{t('calendar.empty_title')}</b>
+          <p>{t('calendar.empty_hint')}</p>
+        </div>
+      )}
+
+      <p className="cw-cal-tznote">{t('calendar.tz_note')}</p>
+
+      {dayPopover && (
+        <CalendarDayPopover
+          anchor={dayPopover.anchor}
+          title={new Intl.DateTimeFormat(i18n.language, { month: 'long', day: 'numeric', weekday: 'long' }).format(dayPopover.day)}
+          onClose={() => setDayPopover(null)}
+        >
+          {(() => {
+            const dayEntries = entriesByDay.get(localDayKey(dayPopover.day)) ?? [];
+            const shown = dayEntries.slice(0, DAY_POPOVER_CAP);
+            const extra = dayEntries.length - shown.length;
+            // Anchor the detail to the day cell (survives the popover closing).
+            const activate = (entry: CalEntry) => { pickEntry(entry, dayPopover.anchor); setDayPopover(null); };
+            return (
+              <>
+                {shown.map((e, i) => renderEntry(e, i, activate))}
+                {extra > 0 && <p className="cw-cal-daypop-more">{t('calendar.more', { count: extra })}</p>}
+              </>
+            );
+          })()}
+        </CalendarDayPopover>
+      )}
+    </div>
+  );
+}
+
+/** Lists every entry for a day, anchored to its cell. Flips above when there's
+ *  not enough room below; scrolls when taller than the available space. */
+function CalendarDayPopover({
+  anchor,
+  title,
+  onClose,
+  children,
+}: {
+  anchor: HTMLElement;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{
+    placement: 'below' | 'above';
+    top?: number;
+    bottom?: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
+
+  const recompute = useCallback(() => {
+    const r = anchor.getBoundingClientRect();
+    const margin = 12;
+    const gap = 10;
+    const width = Math.max(180, Math.min(280, r.width));
+    let left = r.left + r.width / 2 - width / 2;
+    left = Math.max(margin, Math.min(left, window.innerWidth - width - margin));
+    const spaceBelow = window.innerHeight - r.bottom - gap - margin;
+    const spaceAbove = r.top - gap - margin;
+    if (spaceBelow >= 200 || spaceBelow >= spaceAbove) {
+      setPos({ placement: 'below', top: r.top - gap, left, width, maxHeight: Math.max(160, spaceBelow) });
+    } else {
+      setPos({ placement: 'above', bottom: window.innerHeight - r.bottom + gap, left, width, maxHeight: Math.max(160, spaceAbove) });
+    }
+  }, [anchor]);
+
+  useLayoutEffect(() => { recompute(); }, [recompute]);
+
+  useEffect(() => {
+    const onScroll = () => recompute();
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, [recompute]);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (ref.current?.contains(target) || anchor.contains(target)) return;
+      onClose();
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [anchor, onClose]);
+
+  if (!pos) return null;
+  return createPortal(
+    <div
+      ref={ref}
+      className={`cw-cal-daypop is-${pos.placement}`}
+      role="dialog"
+      style={{ top: pos.top, bottom: pos.bottom, left: pos.left, width: pos.width, maxHeight: pos.maxHeight }}
+    >
+      <header className="cw-cal-daypop-head">{title}</header>
+      <div className="cw-cal-daypop-list">{children}</div>
+    </div>,
+    document.body,
+  );
+}

--- a/app/src/components/AutomationCalendar.tsx
+++ b/app/src/components/AutomationCalendar.tsx
@@ -59,6 +59,9 @@ type CalEntry =
   | { kind: 'run'; time: Date; run: Run }
   | { kind: 'occ'; time: Date; occ: Occurrence };
 
+// One automation's entries on a given day (a cell/popover chip).
+type DayGroup = { automationId: string; name: string; entries: CalEntry[] };
+
 export function AutomationCalendar({
   projectSlug,
   automationNameById,
@@ -151,6 +154,13 @@ export function AutomationCalendar({
     return map;
   }, [automationNameById]);
   const automationColor = (id: string) => colorByAutomation.get(id) ?? PALETTE[0]!;
+  // Rank in the project list — used only as a stable tiebreaker when two
+  // automations share the same first-fire time within a day.
+  const automationIndex = useMemo(() => {
+    const map = new Map<string, number>();
+    Object.keys(automationNameById).forEach((id, i) => map.set(id, i));
+    return map;
+  }, [automationNameById]);
   const runTriggerKind = (run: Run): TriggerKind =>
     run.triggerId ? (triggerById[run.triggerId]?.kind as TriggerKind) ?? 'manual' : 'manual';
   // Occurrences are future schedule predictions — shown when the trigger filter
@@ -215,8 +225,12 @@ export function AutomationCalendar({
   const todayKey = localDayKey(new Date());
   const total = gridDays.reduce((n, d) => n + (entriesByDay.get(localDayKey(d))?.length ?? 0), 0);
 
-  // "+N more" expands the day into a popover listing every entry.
-  const [dayPopover, setDayPopover] = useState<{ day: Date; anchor: HTMLElement } | null>(null);
+  // Day popover: lists individual entries — either every entry for the day
+  // ("+N more"), or one automation's entries (a multi-run chip). `automationId`
+  // null = unscoped.
+  const [dayPopover, setDayPopover] = useState<
+    { day: Date; anchor: HTMLElement; automationId: string | null } | null
+  >(null);
 
   const pickEntry = (e: CalEntry, anchor: HTMLElement) => {
     if (e.kind === 'run') onSelectRun?.(e.run, anchor);
@@ -263,6 +277,68 @@ export function AutomationCalendar({
       >
         <span className="cw-cal-event-time">{hhmm(e.time)}</span>
         <span className="cw-cal-event-name">{occ.automationName}</span>
+      </button>
+    );
+  };
+
+  const isEntrySelected = (e: CalEntry): boolean =>
+    e.kind === 'run'
+      ? selectedRunId != null && e.run.id === selectedRunId
+      : selectedKey != null && `${e.occ.triggerId}@${e.occ.fireAt}` === selectedKey;
+
+  // Group a day's entries by automation, ordered by project rank. One chip per
+  // automation — single entry shows its time, multiple show a count — so a day
+  // with many runs (retries, minutely/hourly) stays readable.
+  const groupsForDay = (dayKey: string) => {
+    const byAuto = new Map<string, CalEntry[]>();
+    for (const e of entriesByDay.get(dayKey) ?? []) {
+      const id = e.kind === 'run' ? e.run.automationId : e.occ.automationId;
+      const arr = byAuto.get(id);
+      if (arr) arr.push(e);
+      else byAuto.set(id, [e]);
+    }
+    return [...byAuto.entries()]
+      .map(([automationId, entries]) => ({
+        automationId,
+        name:
+          automationNameById[automationId] ??
+          entries.find((e): e is Extract<CalEntry, { kind: 'occ' }> => e.kind === 'occ')?.occ
+            .automationName ??
+          automationId,
+        entries,
+      }))
+      // Order by each automation's first (earliest) entry that day; ties broken
+      // by project rank for stability. Entries are already time-sorted, so
+      // entries[0] is the earliest.
+      .sort((a, b) => {
+        const dt = a.entries[0]!.time.getTime() - b.entries[0]!.time.getTime();
+        if (dt !== 0) return dt;
+        return (
+          (automationIndex.get(a.automationId) ?? Infinity) -
+          (automationIndex.get(b.automationId) ?? Infinity)
+        );
+      });
+  };
+
+  // One automation chip (cell or popover). Click handling is delegated so the
+  // cell and the "+N more" popover can route single vs multiple differently.
+  const renderGroup = (g: DayGroup, onPick: (g: DayGroup, el: HTMLElement) => void) => {
+    const single = g.entries.length === 1;
+    const first = g.entries[0]!;
+    const active = g.entries.some(isEntrySelected);
+    const runStatus = single && first.kind === 'run' ? first.run.status : null;
+    return (
+      <button
+        key={g.automationId}
+        type="button"
+        className={`cw-cal-group ${active ? 'is-active' : ''}`}
+        style={{ ['--cal-accent' as string]: automationColor(g.automationId) }}
+        title={single ? `${g.name} — ${hhmm(first.time)}` : `${g.name} (${g.entries.length})`}
+        onClick={(ev) => onPick(g, ev.currentTarget)}
+      >
+        {runStatus && <span className={`cw-status-dot cw-status-${runStatus} is-compact`} />}
+        <span className="cw-cal-group-name">{g.name}</span>
+        <span className="cw-cal-group-meta">{single ? hhmm(first.time) : `×${g.entries.length}`}</span>
       </button>
     );
   };
@@ -322,11 +398,11 @@ export function AutomationCalendar({
         ))}
         {gridDays.map((day) => {
           const key = localDayKey(day);
-          const entries = entriesByDay.get(key) ?? [];
+          const groups = groupsForDay(key);
           const outside = day.getMonth() !== monthStart.getMonth();
           const isToday = key === todayKey;
-          const shown = entries.slice(0, MAX_PER_CELL);
-          const overflow = entries.length - shown.length;
+          const shown = groups.slice(0, MAX_PER_CELL);
+          const overflow = groups.length - shown.length;
           return (
             <div
               key={key}
@@ -335,7 +411,12 @@ export function AutomationCalendar({
             >
               <span className="cw-cal-daynum">{day.getDate()}</span>
               <div className="cw-cal-events">
-                {shown.map((e, i) => renderEntry(e, i, pickEntry))}
+                {shown.map((g) => renderGroup(g, (grp, el) => {
+                  if (grp.entries.length === 1) { pickEntry(grp.entries[0]!, el); return; }
+                  // Multiple → drill into this automation's entries for the day.
+                  const cell = (el.closest('.cw-cal-cell') as HTMLElement | null) ?? el;
+                  setDayPopover({ day, anchor: cell, automationId: grp.automationId });
+                }))}
                 {overflow > 0 && (
                   <button
                     type="button"
@@ -344,6 +425,7 @@ export function AutomationCalendar({
                       setDayPopover({
                         day,
                         anchor: (ev.currentTarget.closest('.cw-cal-cell') as HTMLElement | null) ?? ev.currentTarget,
+                        automationId: null,
                       })
                     }
                   >
@@ -369,13 +451,37 @@ export function AutomationCalendar({
       {dayPopover && (
         <CalendarDayPopover
           anchor={dayPopover.anchor}
-          title={new Intl.DateTimeFormat(i18n.language, { month: 'long', day: 'numeric', weekday: 'long' }).format(dayPopover.day)}
+          title={
+            <>
+              {new Intl.DateTimeFormat(i18n.language, { month: 'long', day: 'numeric', weekday: 'long' }).format(dayPopover.day)}
+              {dayPopover.automationId && (
+                <span className="cw-cal-daypop-sub">{automationNameById[dayPopover.automationId] ?? ''}</span>
+              )}
+            </>
+          }
           onClose={() => setDayPopover(null)}
         >
-          {(() => {
-            const dayEntries = entriesByDay.get(localDayKey(dayPopover.day)) ?? [];
-            const shown = dayEntries.slice(0, DAY_POPOVER_CAP);
-            const extra = dayEntries.length - shown.length;
+          {dayPopover.automationId == null ? (() => {
+            // Unscoped: list automations (grouped), like the cells. Single →
+            // open its detail; multiple → re-scope this popover to it.
+            const groups = groupsForDay(localDayKey(dayPopover.day));
+            const shown = groups.slice(0, DAY_POPOVER_CAP);
+            const extra = groups.length - shown.length;
+            return (
+              <>
+                {shown.map((g) => renderGroup(g, (grp) => {
+                  if (grp.entries.length === 1) { pickEntry(grp.entries[0]!, dayPopover.anchor); setDayPopover(null); return; }
+                  setDayPopover({ ...dayPopover, automationId: grp.automationId });
+                }))}
+                {extra > 0 && <p className="cw-cal-daypop-more">{t('calendar.more', { count: extra })}</p>}
+              </>
+            );
+          })() : (() => {
+            // Scoped to one automation: list its individual entries.
+            const entries = (entriesByDay.get(localDayKey(dayPopover.day)) ?? [])
+              .filter((e) => (e.kind === 'run' ? e.run.automationId : e.occ.automationId) === dayPopover.automationId);
+            const shown = entries.slice(0, DAY_POPOVER_CAP);
+            const extra = entries.length - shown.length;
             // Anchor the detail to the day cell (survives the popover closing).
             const activate = (entry: CalEntry) => { pickEntry(entry, dayPopover.anchor); setDayPopover(null); };
             return (
@@ -400,7 +506,7 @@ function CalendarDayPopover({
   children,
 }: {
   anchor: HTMLElement;
-  title: string;
+  title: React.ReactNode;
   onClose: () => void;
   children: React.ReactNode;
 }) {

--- a/app/src/components/AutomationCalendar.tsx
+++ b/app/src/components/AutomationCalendar.tsx
@@ -130,10 +130,15 @@ export function AutomationCalendar({
         ? 4000 : false,
   });
 
-  // Pin the past/future split for the component's lifetime: a per-render
-  // Date.now() would bust the entriesByDay memo every render and drift the
-  // boundary mid-session.
-  const now = useMemo(() => Date.now(), []);
+  // Past/future split point. Advanced once a minute (not per render, which
+  // would thrash the entriesByDay memo) so a calendar left open across a fire
+  // stops showing the now-past occurrence as a prediction — the real run takes
+  // over once the run-window query picks it up.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
   const matchAutomation = (id: string) => !filterAutomationId || id === filterAutomationId;
 
   // Assign accent by the automation's rank in the project list (insertion

--- a/app/src/components/AutomationCalendar.tsx
+++ b/app/src/components/AutomationCalendar.tsx
@@ -153,10 +153,13 @@ export function AutomationCalendar({
   const automationColor = (id: string) => colorByAutomation.get(id) ?? PALETTE[0]!;
   const runTriggerKind = (run: Run): TriggerKind =>
     run.triggerId ? (triggerById[run.triggerId]?.kind as TriggerKind) ?? 'manual' : 'manual';
-  // Occurrences are future schedule predictions — only meaningful when the
-  // trigger filter admits 'cron' and no specific status is selected.
+  // Occurrences are future schedule predictions — shown when the trigger filter
+  // admits 'cron' and the status filter is either unset ('all') or the
+  // dedicated 'scheduled' pseudo-status (which also hides all real runs, since
+  // no run has that status).
   const showOccurrences =
-    (triggerFilter === 'all' || triggerFilter === 'cron') && statusFilter === 'all';
+    (triggerFilter === 'all' || triggerFilter === 'cron') &&
+    (statusFilter === 'all' || statusFilter === 'scheduled');
 
   // Merge real runs (past) + predicted occurrences (future) into per-day
   // buckets, honoring the shared status / trigger-kind filters.

--- a/app/src/components/AutomationCalendar.tsx
+++ b/app/src/components/AutomationCalendar.tsx
@@ -532,7 +532,7 @@ function CalendarDayPopover({
     if (spaceBelow >= 200 || spaceBelow >= spaceAbove) {
       setPos({ placement: 'below', top: r.top - gap, left, width, maxHeight: Math.max(160, spaceBelow) });
     } else {
-      setPos({ placement: 'above', bottom: window.innerHeight - r.bottom + gap, left, width, maxHeight: Math.max(160, spaceAbove) });
+      setPos({ placement: 'above', bottom: window.innerHeight - r.bottom - gap, left, width, maxHeight: Math.max(160, spaceAbove) });
     }
   }, [anchor]);
 

--- a/app/src/components/SegmentedControl.tsx
+++ b/app/src/components/SegmentedControl.tsx
@@ -16,6 +16,7 @@ export function SegmentedControl<T extends string>({
   options,
   ariaLabel,
   className,
+  iconOnly = false,
 }: {
   value: T;
   onChange: (value: T) => void;
@@ -23,9 +24,17 @@ export function SegmentedControl<T extends string>({
   ariaLabel?: string;
   // Extra class on the track (e.g. to size it as a flex item).
   className?: string;
+  // Icon-only variant: shrink to content and hide labels visually (kept for
+  // screen readers). Requires every option to carry an `icon`.
+  iconOnly?: boolean;
 }) {
+  const trackClass = [
+    'cw-segmented',
+    iconOnly ? 'cw-segmented--icononly' : '',
+    className ?? '',
+  ].filter(Boolean).join(' ');
   return (
-    <div className={`cw-segmented${className ? ` ${className}` : ''}`} role="tablist" aria-label={ariaLabel}>
+    <div className={trackClass} role="tablist" aria-label={ariaLabel}>
       {options.map((o) => (
         <button
           key={o.value}

--- a/app/src/domain/types.ts
+++ b/app/src/domain/types.ts
@@ -137,6 +137,17 @@ export interface Trigger {
   updatedAt: string;
 }
 
+/** A single upcoming scheduled fire, computed from a cron trigger's expression.
+ *  Not persisted; expanded on demand for the calendar view. `fireAt` is a UTC
+ *  ISO instant — views localize it for display. */
+export interface Occurrence {
+  triggerId: TriggerId;
+  automationId: AutomationId;
+  automationName: string;
+  fireAt: string;
+  tz: string | null;
+}
+
 /** Returned only at trigger-creation time. `webhookToken` is the one-shot
  *  plaintext bearer token; subsequent reads from the API never expose it. */
 export interface CreatedTrigger {

--- a/app/src/i18n/locales/en/automation.json
+++ b/app/src/i18n/locales/en/automation.json
@@ -41,6 +41,32 @@
     "manual_confirm_body": "Run the '{{name}}' automation once now?",
     "manual_confirm_label": "Run"
   },
+  "view": {
+    "aria": "View mode",
+    "list": "List",
+    "calendar": "Calendar"
+  },
+  "calendar": {
+    "prev_month": "Previous month",
+    "next_month": "Next month",
+    "today": "Today",
+    "fires_count": "{{count}} in view",
+    "more": "+{{count}} more",
+    "truncated": "Some schedules have more fires than shown in this window.",
+    "empty_title": "No scheduled fires",
+    "empty_hint": "No enabled schedule triggers fire in this month.",
+    "tz_note": "Times shown in your local timezone."
+  },
+  "occ_detail": {
+    "close_aria": "Close",
+    "fires_at": "Fires at",
+    "schedule": "Schedule",
+    "tz": "Timezone",
+    "view_runs": "View runs",
+    "settings": "Settings",
+    "empty_title": "Select a run",
+    "empty_hint": "Click an item in the calendar to see its details here."
+  },
   "status": {
     "queued": "Queued",
     "running": "Running",

--- a/app/src/i18n/locales/en/automation.json
+++ b/app/src/i18n/locales/en/automation.json
@@ -72,7 +72,8 @@
     "running": "Running",
     "succeeded": "Succeeded",
     "failed": "Failed",
-    "cancelled": "Cancelled"
+    "cancelled": "Cancelled",
+    "scheduled": "Scheduled"
   },
   "tier": {
     "light": "Light",

--- a/app/src/i18n/locales/ko/automation.json
+++ b/app/src/i18n/locales/ko/automation.json
@@ -41,6 +41,32 @@
     "manual_confirm_body": "'{{name}}' 자동화를 지금 한 번 실행할까요?",
     "manual_confirm_label": "실행"
   },
+  "view": {
+    "aria": "보기 방식",
+    "list": "목록",
+    "calendar": "캘린더"
+  },
+  "calendar": {
+    "prev_month": "이전 달",
+    "next_month": "다음 달",
+    "today": "오늘",
+    "fires_count": "총 {{count}}건",
+    "more": "+{{count}}건 더",
+    "truncated": "이 구간에 표시된 것보다 더 많이 실행되는 일정이 있습니다.",
+    "empty_title": "예정된 실행이 없습니다",
+    "empty_hint": "이번 달에 실행되는 활성 schedule 트리거가 없습니다.",
+    "tz_note": "시간은 사용자의 로컬 시간대로 표시됩니다."
+  },
+  "occ_detail": {
+    "close_aria": "닫기",
+    "fires_at": "실행 시각",
+    "schedule": "일정",
+    "tz": "시간대",
+    "view_runs": "실행 보기",
+    "settings": "설정",
+    "empty_title": "Run을 선택하세요",
+    "empty_hint": "캘린더에서 항목을 클릭하면 상세 정보가 여기에 표시됩니다."
+  },
   "status": {
     "queued": "대기 중",
     "running": "실행 중",

--- a/app/src/i18n/locales/ko/automation.json
+++ b/app/src/i18n/locales/ko/automation.json
@@ -72,7 +72,8 @@
     "running": "실행 중",
     "succeeded": "성공",
     "failed": "실패",
-    "cancelled": "취소"
+    "cancelled": "취소",
+    "scheduled": "예약됨"
   },
   "tier": {
     "light": "경량",

--- a/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.$automationId.tsx
@@ -153,7 +153,8 @@ function AutomationSettingsPage() {
   };
 
   const createTriggerMutation = useMutation({
-    mutationFn: (spec: TriggerSpec) => createTriggerApi(automationId, spec),
+    mutationFn: (vars: { spec: TriggerSpec; enabled?: boolean }) =>
+      createTriggerApi(automationId, vars.spec, { enabled: vars.enabled }),
     onSuccess: (created) => {
       invalidateTriggers();
       if (created.webhookToken) {
@@ -206,7 +207,7 @@ function AutomationSettingsPage() {
   // time). The clone is created disabled so an exact duplicate doesn't double-
   // fire alongside the original until the user edits and enables it.
   const duplicateTrigger = (trig: Trigger) =>
-    createTriggerMutation.mutate({ ...trig.spec, enabled: false});
+    createTriggerMutation.mutate({ spec: trig.spec, enabled: false });
 
   // ── Add-trigger draft ───────────────────────────────────────────────────
   const [showAddForm, setShowAddForm] = useState(false);
@@ -221,12 +222,14 @@ function AutomationSettingsPage() {
   const submitDraft = () => {
     if (draftKind === 'cron') {
       createTriggerMutation.mutate({
-        kind: 'cron',
-        expr: draftSchedule.expr || '0 * * * *',
-        tz: draftSchedule.tz || null,
+        spec: {
+          kind: 'cron',
+          expr: draftSchedule.expr || '0 * * * *',
+          tz: draftSchedule.tz || null,
+        },
       });
     } else {
-      createTriggerMutation.mutate({ kind: 'webhook' });
+      createTriggerMutation.mutate({ spec: { kind: 'webhook' } });
     }
   };
 

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -145,9 +145,7 @@ function AutomationsPage() {
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<RunStatus | 'all'>('all');
-  // Default to schedule so the calendar reads as a schedule timeline; the user
-  // can widen to all / manual / webhook. Shared with the list view.
-  const [triggerFilter, setTriggerFilter] = useState<TriggerKind | 'all'>('cron');
+  const [triggerFilter, setTriggerFilter] = useState<TriggerKind | 'all'>('all');
   const [page, setPage] = useState(0);
   const [view, setView] = useState<'list' | 'calendar'>('list');
   const [selectedOccurrence, setSelectedOccurrence] = useState<Occurrence | null>(null);
@@ -757,11 +755,11 @@ function AutomationsPage() {
                 { value: 'manual',  label: t('trigger_kind.manual') },
               ]}
             />
-            {(statusFilter !== 'all' || triggerFilter !== 'cron') && (
+            {(statusFilter !== 'all' || triggerFilter !== 'all') && (
               <button
                 type="button"
                 className="cw-filter-reset"
-                onClick={() => { setStatusFilter('all'); setTriggerFilter('cron'); }}
+                onClick={() => { setStatusFilter('all'); setTriggerFilter('all'); }}
               >
                 <Icon name="rotate-ccw" size={12} /> {t('list.reset_filter')}
               </button>

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -34,6 +34,9 @@ export const Route = createFileRoute('/_app/projects/$projectSlug/automation/')(
 
 type RunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 type TriggerKind = 'cron' | 'webhook' | 'manual';
+// 'scheduled' is calendar-only: future predicted fires (occurrences), which
+// aren't runs and so have no run status.
+type StatusFilter = RunStatus | 'all' | 'scheduled';
 
 interface RunEventLike { id: number; ts: string; kind: string; detail?: string }
 
@@ -144,7 +147,7 @@ function AutomationsPage() {
   const { t } = useTranslation('automation');
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
-  const [statusFilter, setStatusFilter] = useState<RunStatus | 'all'>('all');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [triggerFilter, setTriggerFilter] = useState<TriggerKind | 'all'>('all');
   const [page, setPage] = useState(0);
   const [view, setView] = useState<'list' | 'calendar'>('list');
@@ -717,7 +720,11 @@ function AutomationsPage() {
           <div className="cw-runs-filterbar">
             <SegmentedControl<'list' | 'calendar'>
               value={view}
-              onChange={setView}
+              onChange={(v) => {
+                setView(v);
+                // 'scheduled' has no meaning for the runs list — clear it.
+                if (v === 'list' && statusFilter === 'scheduled') setStatusFilter('all');
+              }}
               ariaLabel={t('view.aria')}
               iconOnly
               options={[
@@ -731,12 +738,16 @@ function AutomationsPage() {
                 <span>{selectedAutomation.description ?? ''}</span>
               </div>
             )}
-            <FilterSelect<RunStatus | 'all'>
+            <FilterSelect<StatusFilter>
               label={t('list.context_status')}
               value={statusFilter}
               onChange={setStatusFilter}
               options={[
                 { value: 'all',       label: t('list.status_all') },
+                // Calendar-only: filter to upcoming predicted fires.
+                ...(view === 'calendar'
+                  ? [{ value: 'scheduled' as const, label: t('status.scheduled') }]
+                  : []),
                 { value: 'queued',    label: t('status.queued') },
                 { value: 'running',   label: t('status.running') },
                 { value: 'succeeded', label: t('status.succeeded') },

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -11,6 +11,8 @@ import { MarkdownRenderer } from '@/components/chat/MarkdownRenderer';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { ArtifactsPanel } from '@/components/ArtifactsPanel';
 import { CopyToSharedDialog } from '@/components/CopyToSharedDialog';
+import { AutomationCalendar } from '@/components/AutomationCalendar';
+import { SegmentedControl } from '@/components/SegmentedControl';
 import { summarizeCron } from '@/components/SchedulePicker';
 import { cancelRun as cancelRunApi, createRun, listAutomations, listRunEvents, listRuns, listTriggers } from '@/api/automations';
 import { listMessages } from '@/api/messages';
@@ -22,7 +24,7 @@ import { formatMessageTime } from '@/lib/formatMessageTime';
 import { useDuplicateSession } from '@/lib/useDuplicateSession';
 import { shortSessionId } from '@/lib/sessionId';
 import { loadNs } from '@/i18n/loader';
-import type { Automation, Message, Run, Trigger } from '@/domain/types';
+import type { Automation, Message, Occurrence, Run, Trigger } from '@/domain/types';
 
 export const Route = createFileRoute('/_app/projects/$projectSlug/automation/')({
   // 'session'/'dialogs' cover the artifacts panel + copy-to-shared dialog.
@@ -104,6 +106,11 @@ function shortRunId(run: Run): string {
   return run.id.slice(0, 6);
 }
 
+/** Identity for a single scheduled fire (a trigger fires at distinct instants). */
+function occurrenceKey(occ: Occurrence | null): string | null {
+  return occ ? `${occ.triggerId}@${occ.fireAt}` : null;
+}
+
 function formatEventTime(iso: string): string {
   // ISO → HH:MM:SS; fall back to first 19 chars if Date.parse fails.
   const t = Date.parse(iso);
@@ -138,8 +145,18 @@ function AutomationsPage() {
   const [selectedAutomationId, setSelectedAutomationId] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<RunStatus | 'all'>('all');
-  const [triggerFilter, setTriggerFilter] = useState<TriggerKind | 'all'>('all');
+  // Default to schedule so the calendar reads as a schedule timeline; the user
+  // can widen to all / manual / webhook. Shared with the list view.
+  const [triggerFilter, setTriggerFilter] = useState<TriggerKind | 'all'>('cron');
   const [page, setPage] = useState(0);
+  const [view, setView] = useState<'list' | 'calendar'>('list');
+  const [selectedOccurrence, setSelectedOccurrence] = useState<Occurrence | null>(null);
+  // Run picked from the calendar — its window query is separate from the list
+  // view's run set, so keep the object to resolve detail even when it isn't in
+  // `displayRuns` (e.g. an old month not covered by the recent-run fetch).
+  const [pickedRun, setPickedRun] = useState<Run | null>(null);
+  // Anchor element for the narrow-layout calendar detail popover (speech bubble).
+  const [calAnchorEl, setCalAnchorEl] = useState<HTMLElement | null>(null);
 
   const catalogQuery = useQuery({
     queryKey: ['models', projectSlug],
@@ -154,6 +171,10 @@ function AutomationsPage() {
   const automations: Automation[] = automationsQuery.data ?? [];
   const automationById = useMemo(
     () => Object.fromEntries(automations.map((a) => [a.id, a])),
+    [automations],
+  );
+  const automationNameById = useMemo(
+    () => Object.fromEntries(automations.map((a) => [a.id, a.name])),
     [automations],
   );
   const queryClient = useQueryClient();
@@ -301,7 +322,8 @@ function AutomationsPage() {
 
   const selectedAutomation = selectedAutomationId ? automationById[selectedAutomationId] : null;
   const selectedRun: Run | null = selectedRunId
-    ? displayRuns.find((r) => r.id === selectedRunId) ?? null
+    ? displayRuns.find((r) => r.id === selectedRunId)
+      ?? (pickedRun?.id === selectedRunId ? pickedRun : null)
     : null;
   const selectedRunLive = selectedRun
     ? selectedRun.status === 'queued' || selectedRun.status === 'running'
@@ -383,6 +405,71 @@ function AutomationsPage() {
   // Below this viewport, drop the right-side drawer column and expand the
   // selected row inline within the runs list instead.
   const isWide = useWideLayout('(min-width: 1440px)');
+
+  const renderOccurrenceDetail = (occ: Occurrence) => {
+    const trigger = triggerById[occ.triggerId] ?? null;
+    const fire = new Date(occ.fireAt);
+    return (
+      <>
+        <header className="cw-run-drawer-head">
+          <div className="cw-run-drawer-title">
+            <Icon name="calendar" size={16} />
+            <strong>{occ.automationName}</strong>
+          </div>
+          <div className="cw-run-drawer-actions">
+            <button
+              type="button"
+              className="cw-run-drawer-close"
+              onClick={() => setSelectedOccurrence(null)}
+              aria-label={t('occ_detail.close_aria')}
+            >
+              <Icon name="x" size={16} />
+            </button>
+          </div>
+          <div className="cw-run-drawer-meta">
+            <TriggerBadge trigger={trigger} placement="below-start" />
+            <span>{formatScheduledAt(occ.fireAt, t)}</span>
+          </div>
+        </header>
+
+        <dl className="cw-occ-detail">
+          <div>
+            <dt>{t('occ_detail.fires_at')}</dt>
+            <dd>{fire.toLocaleString()}</dd>
+          </div>
+          {trigger?.spec.kind === 'cron' && (
+            <div>
+              <dt>{t('occ_detail.schedule')}</dt>
+              <dd>{summarizeCron(trigger.spec.expr, t)}</dd>
+            </div>
+          )}
+          {occ.tz && (
+            <div>
+              <dt>{t('occ_detail.tz')}</dt>
+              <dd>{occ.tz}</dd>
+            </div>
+          )}
+        </dl>
+
+        <div className="cw-occ-actions">
+          <button
+            type="button"
+            className="cw-btn-secondary"
+            onClick={() => { setView('list'); setSelectedAutomationId(occ.automationId); setSelectedOccurrence(null); }}
+          >
+            <Icon name="list" size={14} /> {t('occ_detail.view_runs')}
+          </button>
+          <button
+            type="button"
+            className="cw-btn-secondary"
+            onClick={() => openSettings(occ.automationId)}
+          >
+            <Icon name="settings" size={14} /> {t('occ_detail.settings')}
+          </button>
+        </div>
+      </>
+    );
+  };
 
   const renderRunDetail = (run: Run) => {
     const status = effectiveStatus(run);
@@ -559,7 +646,7 @@ function AutomationsPage() {
           <button
             type="button"
             className={`cw-rail-row ${selectedAutomationId === null ? 'is-active' : ''}`}
-            onClick={() => setSelectedAutomationId(null)}
+            onClick={() => { setSelectedAutomationId(null); setSelectedOccurrence(null); }}
           >
             <span className="cw-rail-name">{t('list.all_automations')}</span>
             <span className="cw-rail-count">{allRuns.length}</span>
@@ -572,7 +659,7 @@ function AutomationsPage() {
               <div
                 key={automation.id}
                 className={`cw-rail-row cw-rail-row-automation ${active ? 'is-active' : ''} ${isDisabled(automation.id) ? 'is-disabled' : ''}`}
-                onClick={() => { setSelectedAutomationId(automation.id); setSelectedRunId(null); }}
+                onClick={() => { setSelectedAutomationId(automation.id); setSelectedRunId(null); setSelectedOccurrence(null); }}
                 role="button"
                 tabIndex={0}
                 onKeyDown={(e) => {
@@ -580,6 +667,7 @@ function AutomationsPage() {
                     e.preventDefault();
                     setSelectedAutomationId(automation.id);
                     setSelectedRunId(null);
+                    setSelectedOccurrence(null);
                   }
                 }}
               >
@@ -629,6 +717,16 @@ function AutomationsPage() {
 
         <main className="cw-runs-pane">
           <div className="cw-runs-filterbar">
+            <SegmentedControl<'list' | 'calendar'>
+              value={view}
+              onChange={setView}
+              ariaLabel={t('view.aria')}
+              iconOnly
+              options={[
+                { value: 'list', label: t('view.list'), icon: 'list' },
+                { value: 'calendar', label: t('view.calendar'), icon: 'calendar' },
+              ]}
+            />
             {selectedAutomation && (
               <div className="cw-runs-context">
                 <strong>{selectedAutomation.name}</strong>
@@ -659,19 +757,48 @@ function AutomationsPage() {
                 { value: 'manual',  label: t('trigger_kind.manual') },
               ]}
             />
-            {(statusFilter !== 'all' || triggerFilter !== 'all') && (
+            {(statusFilter !== 'all' || triggerFilter !== 'cron') && (
               <button
                 type="button"
                 className="cw-filter-reset"
-                onClick={() => { setStatusFilter('all'); setTriggerFilter('all'); }}
+                onClick={() => { setStatusFilter('all'); setTriggerFilter('cron'); }}
               >
                 <Icon name="rotate-ccw" size={12} /> {t('list.reset_filter')}
               </button>
             )}
-            <span className="cw-runs-count">{t('list.runs_count', { count: visibleRuns.length })}</span>
+            {view === 'list' && (
+              <span className="cw-runs-count">{t('list.runs_count', { count: visibleRuns.length })}</span>
+            )}
           </div>
 
-          {visibleRuns.length === 0 ? (
+          {view === 'calendar' ? (
+            <div className="cw-cal-pane">
+              <AutomationCalendar
+                projectSlug={projectSlug}
+                automationNameById={automationNameById}
+                triggerById={triggerById}
+                filterAutomationId={selectedAutomationId}
+                statusFilter={statusFilter}
+                triggerFilter={triggerFilter}
+                selectedKey={occurrenceKey(selectedOccurrence)}
+                selectedRunId={selectedRunId}
+                onSelectOccurrence={(occ, el) => {
+                  const willSelect = occurrenceKey(selectedOccurrence) !== occurrenceKey(occ);
+                  setSelectedRunId(null);
+                  setPickedRun(null);
+                  setSelectedOccurrence(willSelect ? occ : null);
+                  setCalAnchorEl(willSelect ? el : null);
+                }}
+                onSelectRun={(run, el) => {
+                  const willSelect = selectedRunId !== run.id;
+                  setSelectedOccurrence(null);
+                  setSelectedRunId(willSelect ? run.id : null);
+                  setPickedRun(willSelect ? run : null);
+                  setCalAnchorEl(willSelect ? el : null);
+                }}
+              />
+            </div>
+          ) : visibleRuns.length === 0 ? (
             <div className="cw-runs-empty">
               <Icon name="calendar" size={20} />
               <b>{t('list.empty_title')}</b>
@@ -723,7 +850,7 @@ function AutomationsPage() {
             </ul>
           )}
 
-          {visibleRuns.length > 0 && totalPages > 1 && (
+          {view === 'list' && visibleRuns.length > 0 && totalPages > 1 && (
             <footer className="cw-runs-pagination">
               <button
                 type="button"
@@ -750,7 +877,16 @@ function AutomationsPage() {
 
         {isWide && (
           <aside className="cw-run-drawer">
-            {selectedRun ? renderRunDetail(selectedRun) : (
+            {view === 'calendar' ? (
+              selectedOccurrence ? renderOccurrenceDetail(selectedOccurrence)
+              : selectedRun ? renderRunDetail(selectedRun) : (
+                <div className="cw-run-drawer-empty">
+                  <Icon name="calendar" size={22} />
+                  <b>{t('occ_detail.empty_title')}</b>
+                  <p>{t('occ_detail.empty_hint')}</p>
+                </div>
+              )
+            ) : selectedRun ? renderRunDetail(selectedRun) : (
               <div className="cw-run-drawer-empty">
                 <Icon name="message-square" size={22} />
                 <b>{t('list.select_run_title')}</b>
@@ -760,6 +896,15 @@ function AutomationsPage() {
           </aside>
         )}
       </div>
+
+      {!isWide && view === 'calendar' && calAnchorEl && (selectedOccurrence || selectedRun) && (
+        <CalendarDetailBubble
+          anchorEl={calAnchorEl}
+          onClose={() => { setSelectedOccurrence(null); setSelectedRunId(null); setCalAnchorEl(null); }}
+        >
+          {selectedOccurrence ? renderOccurrenceDetail(selectedOccurrence) : renderRunDetail(selectedRun!)}
+        </CalendarDetailBubble>
+      )}
 
       {pendingManualRun && (
         <ConfirmDialog
@@ -787,6 +932,100 @@ function AutomationsPage() {
         />
       )}
     </section>
+  );
+}
+
+/** Narrow-layout calendar detail rendered as a speech bubble anchored under
+ *  the clicked entry, floating over the calendar. Flips above when there's not
+ *  enough room below; scrolls internally when taller than the viewport. */
+function CalendarDetailBubble({
+  anchorEl,
+  onClose,
+  children,
+}: {
+  anchorEl: HTMLElement;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  const bubbleRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{
+    placement: 'below' | 'above';
+    top?: number;
+    bottom?: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+    arrowLeft: number;
+  } | null>(null);
+
+  const recompute = useCallback(() => {
+    const r = anchorEl.getBoundingClientRect();
+    const margin = 12;
+    const gap = 10;
+    // Match the bubble's left/right to the calendar grid's edges; the tail
+    // still points at the clicked entry's center.
+    const grid = (anchorEl.closest('.cw-cal-grid') as HTMLElement | null) ?? anchorEl;
+    const cr = grid.getBoundingClientRect();
+    // Inset ~10px from each calendar edge.
+    const inset = 10;
+    const left = cr.left + inset;
+    const width = cr.width - inset * 2;
+    const arrowLeft = Math.max(18, Math.min(r.left + r.width / 2 - left, width - 18));
+    const spaceBelow = window.innerHeight - r.bottom - gap - margin;
+    const spaceAbove = r.top - gap - margin;
+    const placement = spaceBelow < 200 && spaceAbove > spaceBelow ? 'above' : 'below';
+    if (placement === 'below') {
+      setPos({ placement, top: r.bottom + gap, left, width, maxHeight: Math.max(160, spaceBelow), arrowLeft });
+    } else {
+      setPos({ placement, bottom: window.innerHeight - r.top + gap, left, width, maxHeight: Math.max(160, spaceAbove), arrowLeft });
+    }
+  }, [anchorEl]);
+
+  useLayoutEffect(() => { recompute(); }, [recompute]);
+
+  useEffect(() => {
+    const onScroll = () => recompute();
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, [recompute]);
+
+  useEffect(() => {
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (bubbleRef.current?.contains(target) || anchorEl.contains(target)) return;
+      onClose();
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [anchorEl, onClose]);
+
+  if (!pos) return null;
+  return createPortal(
+    <div
+      ref={bubbleRef}
+      className={`cw-cal-bubble is-${pos.placement}`}
+      role="dialog"
+      style={{
+        top: pos.top,
+        bottom: pos.bottom,
+        left: pos.left,
+        width: pos.width,
+        maxHeight: pos.maxHeight,
+        ['--arrow-left' as string]: `${pos.arrowLeft}px`,
+      }}
+    >
+      <div className="cw-cal-bubble-scroll">{children}</div>
+    </div>,
+    document.body,
   );
 }
 

--- a/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.automation.index.tsx
@@ -403,9 +403,13 @@ function AutomationsPage() {
     setPendingManualRun(null);
   };
 
-  // Below this viewport, drop the right-side drawer column and expand the
-  // selected row inline within the runs list instead.
-  const isWide = useWideLayout('(min-width: 1440px)');
+  // Below this viewport, drop the right-side drawer column (list expands the
+  // selected row inline; calendar uses an anchored popover). The calendar's
+  // 7-column grid needs more room than the runs list, so it keeps full width
+  // until a wider breakpoint rather than sharing with a ~440px drawer.
+  const isWideList = useWideLayout('(min-width: 1440px)');
+  const isWideCalendar = useWideLayout('(min-width: 1680px)');
+  const isWide = view === 'calendar' ? isWideCalendar : isWideList;
 
   const renderOccurrenceDetail = (occ: Occurrence) => {
     const trigger = triggerById[occ.triggerId] ?? null;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -3014,15 +3014,20 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Fill the scroll shell so there's no dead space below the grid. */
+  flex: 1;
 }
 .cw-automation-page .cw-page-head { margin-bottom: 16px; padding-bottom: 16px; }
 
 .cw-automation-grid {
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr) minmax(380px, 440px);
+  /* Single row that fills the page height; panes stretch to it (no magic
+     viewport offset, so the shell is filled exactly with no trailing gap). */
+  grid-template-rows: minmax(0, 1fr);
   gap: 20px;
-  align-items: start;
-  --cw-pane-min-h: max(400px, calc(100vh - 200px));
+  flex: 1;
+  min-height: 0;
 }
 /* Narrow layout (set by JS below the 1440px breakpoint): drop the right
    drawer column; selected run expands inline within its row instead. */
@@ -3032,8 +3037,296 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 .cw-automation-grid > .cw-automation-rail,
 .cw-automation-grid > .cw-runs-pane,
 .cw-automation-grid > .cw-run-drawer {
-  min-height: var(--cw-pane-min-h);
-  max-height: var(--cw-pane-min-h);
+  /* Floor keeps the panes usable on short viewports (shell scrolls then);
+     on taller ones the 1fr row stretches them to fill. */
+  min-height: 400px;
+}
+
+/* ── Calendar view ──────────────────────────────────────────────────────── */
+.cw-cal {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.cw-cal-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.cw-cal-nav {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.cw-cal-navbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--cw-border);
+  border-radius: var(--cw-radius-sm);
+  background: var(--cw-bg);
+  color: var(--cw-ink-2);
+  cursor: pointer;
+}
+.cw-cal-navbtn:hover { border-color: var(--cw-border-hover); color: var(--cw-ink); }
+.cw-cal-month {
+  min-width: 9.5em;
+  text-align: center;
+  font-size: 15px;
+  color: var(--cw-ink);
+}
+.cw-cal-today {
+  margin-left: 6px;
+  padding: 5px 12px;
+  border: 1px solid var(--cw-border);
+  border-radius: var(--cw-radius-full);
+  background: var(--cw-bg);
+  color: var(--cw-ink-2);
+  font-size: 12px;
+  cursor: pointer;
+}
+.cw-cal-today:hover { border-color: var(--cw-border-hover); color: var(--cw-ink); }
+.cw-cal-count { color: var(--cw-ink-3); font-size: 13px; }
+
+.cw-cal-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.cw-cal-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--cw-ink-2);
+}
+.cw-cal-legend-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: var(--cw-radius-full);
+  flex: none;
+}
+.cw-cal-truncated {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0;
+  font-size: 12px;
+  color: var(--cw-ink-3);
+}
+
+.cw-cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--cw-border);
+  border: 1px solid var(--cw-border);
+  border-radius: var(--cw-radius-md);
+  overflow: hidden;
+}
+.cw-cal-weekday {
+  background: var(--cw-bg-subtle);
+  padding: 8px 6px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--cw-ink-3);
+}
+.cw-cal-cell {
+  background: var(--cw-bg);
+  min-height: 132px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.cw-cal-cell.is-outside { background: var(--cw-bg-muted); }
+.cw-cal-cell.is-outside .cw-cal-daynum { color: var(--cw-ink-4); }
+.cw-cal-cell.is-today { box-shadow: inset 0 0 0 2px var(--cw-accent); }
+.cw-cal-daynum {
+  font-size: 12px;
+  color: var(--cw-ink-2);
+  align-self: flex-start;
+}
+.cw-cal-cell.is-today .cw-cal-daynum { color: var(--cw-accent); font-weight: 700; }
+.cw-cal-events {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.cw-cal-event {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  width: 100%;
+  padding: 2px 6px;
+  border: none;
+  border-left: 3px solid var(--cal-accent, var(--cw-accent));
+  border-radius: 3px;
+  background: var(--cw-bg-subtle);
+  color: var(--cw-ink);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+  min-width: 0;
+}
+.cw-cal-event:hover { background: var(--cw-bg-muted); }
+.cw-cal-event-time { font-variant-numeric: tabular-nums; color: var(--cw-ink-2); flex: none; }
+.cw-cal-event-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.cw-cal-more {
+  align-self: flex-start;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 11px;
+  color: var(--cw-ink-3);
+  padding: 1px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: left;
+}
+.cw-cal-more:hover { color: var(--cw-ink); background: var(--cw-bg-muted); }
+
+/* "+N more" → all entries for a day, anchored to its cell. */
+.cw-cal-daypop {
+  position: fixed;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  background: var(--cw-paper-2);
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.20);
+  overflow: hidden;
+}
+.cw-cal-daypop-head {
+  padding: 9px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--cw-ink-2);
+  border-bottom: 1px solid var(--cw-line-soft);
+}
+.cw-cal-daypop-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 6px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+/* Entries in the popover get a touch more room than in the dense cells. */
+.cw-cal-daypop-list .cw-cal-event { font-size: 12px; padding: 4px 8px; }
+.cw-cal-daypop-more { margin: 2px 0 0; padding: 4px 8px; font-size: 11px; color: var(--cw-ink-3); }
+
+/* Popovers reveal from their anchored edge via a clip-path inset wipe — no
+   transform distortion. Downward when placed below, upward when flipped above.
+   (fill-mode none, so the clip reverts after the wipe and the bubble's tail,
+   which sits outside the box, reappears.) */
+@keyframes cw-pop-reveal-down {
+  from { opacity: 0.3; clip-path: inset(0 0 100% 0); }
+  to   { opacity: 1; clip-path: inset(0 0 0 0); }
+}
+@keyframes cw-pop-reveal-up {
+  from { opacity: 0.3; clip-path: inset(100% 0 0 0); }
+  to   { opacity: 1; clip-path: inset(0 0 0 0); }
+}
+.cw-cal-daypop.is-below { animation: cw-pop-reveal-down 100ms ease-out; }
+.cw-cal-daypop.is-above { animation: cw-pop-reveal-up 100ms ease-out; }
+@media (prefers-reduced-motion: reduce) {
+  .cw-cal-daypop { animation: none; }
+}
+
+.cw-cal-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 28px;
+  text-align: center;
+  color: var(--cw-ink-3);
+}
+.cw-cal-empty b { color: var(--cw-ink-2); font-weight: 600; }
+.cw-cal-tznote { margin: 0; font-size: 11px; color: var(--cw-ink-4); }
+
+/* Calendar lives inside the runs pane. The wrapper is the scroll container so
+   that, in the narrow layout, the inline detail stacks naturally BELOW the
+   calendar (rather than competing for flex space) and the whole thing scrolls
+   when it overflows. */
+.cw-runs-pane > .cw-cal-pane {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.cw-cal-pane > .cw-cal { padding: 14px; }
+.cw-cal-event.is-active {
+  background: var(--cw-accent-soft);
+  box-shadow: inset 0 0 0 1px var(--cw-accent);
+}
+/* Realized runs carry a status dot; predicted fires have none — that's the
+   distinction. (A dashed 3px border renders as ugly stubs on short rows.) */
+.cw-cal-run { align-items: center; }
+.cw-cal-run .cw-status-dot { flex: none; }
+
+/* Narrow-layout calendar detail: a speech bubble floating over the calendar,
+   anchored under the clicked entry. The outer keeps overflow visible so the
+   arrow shows; the inner body scrolls when content is taller than the window. */
+.cw-cal-bubble {
+  position: fixed;
+  z-index: 60;
+  background: var(--cw-paper-2);
+  border: 1px solid var(--cw-line);
+  border-radius: var(--cw-radius-md);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.20);
+}
+.cw-cal-bubble::before {
+  content: '';
+  position: absolute;
+  left: var(--arrow-left, 28px);
+  width: 12px;
+  height: 12px;
+  background: var(--cw-paper-2);
+  border: 1px solid var(--cw-line);
+  transform: translateX(-50%) rotate(45deg);
+  pointer-events: none;
+}
+.cw-cal-bubble.is-below::before { top: -7px; border-right: 0; border-bottom: 0; }
+.cw-cal-bubble.is-above::before { bottom: -7px; border-left: 0; border-top: 0; }
+.cw-cal-bubble-scroll {
+  max-height: inherit;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-radius: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 18px 20px;
+}
+
+/* Occurrence (scheduled fire) detail in the drawer / inline. */
+.cw-occ-detail {
+  margin: 0;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.cw-occ-detail > div { display: flex; flex-direction: column; gap: 2px; }
+.cw-occ-detail dt { font-size: 11px; color: var(--cw-ink-3); text-transform: uppercase; letter-spacing: 0.03em; }
+.cw-occ-detail dd { margin: 0; font-size: 13px; color: var(--cw-ink); }
+.cw-occ-actions {
+  display: flex;
+  gap: 8px;
+  padding: 0 16px 16px;
 }
 
 .cw-run-inline-detail {
@@ -4137,6 +4430,21 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   padding: 3px;
   background: var(--cw-bg-muted);
   border-radius: var(--cw-radius-md);
+}
+/* Icon-only variant: shrink to content, fixed-width tabs (no reflow on
+   selection), labels hidden visually but kept for screen readers. */
+.cw-segmented--icononly { flex: 0 0 auto; }
+.cw-segmented--icononly .cw-segmented-tab { flex: 0 0 auto; gap: 0; padding: 0 9px; }
+.cw-segmented--icononly .cw-segmented-tab > span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 .cw-segmented-tab {
   flex: 1 1 0;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -3180,6 +3180,29 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
 .cw-cal-event:hover { background: var(--cw-bg-muted); }
 .cw-cal-event-time { font-variant-numeric: tabular-nums; color: var(--cw-ink-2); flex: none; }
 .cw-cal-event-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+
+/* Per-automation chip in a day cell: name (truncating) + trailing time/count. */
+.cw-cal-group {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  padding: 2px 6px;
+  border: none;
+  border-left: 3px solid var(--cal-accent, var(--cw-accent));
+  border-radius: 3px;
+  background: var(--cw-bg-subtle);
+  color: var(--cw-ink);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+  min-width: 0;
+}
+.cw-cal-group:hover { background: var(--cw-bg-muted); }
+.cw-cal-group.is-active { background: var(--cw-accent-soft); box-shadow: inset 0 0 0 1px var(--cw-accent); }
+.cw-cal-group .cw-status-dot { flex: none; }
+.cw-cal-group-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.cw-cal-group-meta { flex: none; color: var(--cw-ink-2); font-variant-numeric: tabular-nums; }
 .cw-cal-more {
   align-self: flex-start;
   border: 0;
@@ -3207,12 +3230,17 @@ button.cw-select[aria-expanded="true"] .cw-select-caret {
   overflow: hidden;
 }
 .cw-cal-daypop-head {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
   padding: 9px 12px;
   font-size: 12px;
   font-weight: 600;
   color: var(--cw-ink-2);
   border-bottom: 1px solid var(--cw-line-soft);
 }
+/* Scoped automation name on its own line, lighter than the date. */
+.cw-cal-daypop-sub { font-size: 11px; font-weight: 500; color: var(--cw-ink-3); }
 .cw-cal-daypop-list {
   display: flex;
   flex-direction: column;

--- a/backend/src/cron.rs
+++ b/backend/src/cron.rs
@@ -64,6 +64,52 @@ pub fn next_fire_after(
         .map_err(|e| format!("no future occurrence for '{expr}': {e}"))
 }
 
+/// Expand all occurrences of `expr` (in `tz_name`) that fall within the
+/// half-open window `[from, to)`, in ascending order. `max` caps the result
+/// length to bound work for dense schedules (e.g. minutely crons over a wide
+/// window); the returned bool is `true` when the cap was hit (more occurrences
+/// exist past the last element). Used by the calendar view to preview upcoming
+/// scheduled fires without persisting them — the cron expression alone
+/// determines every future instant.
+pub fn occurrences_between(
+    expr: &str,
+    tz_name: &str,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+    max: usize,
+) -> Result<(Vec<DateTime<Utc>>, bool), String> {
+    let tz: Tz = tz_name
+        .parse()
+        .map_err(|e: chrono_tz::ParseError| format!("invalid timezone '{tz_name}': {e}"))?;
+    validate_five_field(expr)?;
+    let cron = Cron::new(expr)
+        .parse()
+        .map_err(|e| format!("invalid cron expression '{expr}': {e}"))?;
+
+    let mut out = Vec::new();
+    // First probe is inclusive so an occurrence exactly at `from` is captured;
+    // subsequent probes are exclusive to advance past the one just collected.
+    let mut cursor = from.with_timezone(&tz);
+    let mut inclusive = true;
+    loop {
+        let next = match cron.find_next_occurrence(&cursor, inclusive) {
+            Ok(t) => t,
+            // No further occurrence (croner exhausted its search horizon).
+            Err(_) => return Ok((out, false)),
+        };
+        let next_utc = next.with_timezone(&Utc);
+        if next_utc >= to {
+            return Ok((out, false));
+        }
+        out.push(next_utc);
+        if out.len() >= max {
+            return Ok((out, true));
+        }
+        cursor = next;
+        inclusive = false;
+    }
+}
+
 fn validate_five_field(expr: &str) -> Result<(), String> {
     let n = expr.split_whitespace().count();
     if n == 5 {
@@ -123,6 +169,42 @@ mod tests {
         // "5L" in the day-of-week field = last Friday of the month.
         let next = next_fire_after("0 9 * * 5L", "UTC", now).unwrap();
         assert_eq!(next, at("2026-08-28T09:00:00Z"));
+    }
+
+    #[test]
+    fn occurrences_between_expands_window() {
+        // Daily 09:00 UTC over a 3-day half-open window → 3 fires.
+        let from = at("2026-06-01T00:00:00Z");
+        let to = at("2026-06-04T00:00:00Z");
+        let (fires, truncated) = occurrences_between("0 9 * * *", "UTC", from, to, 100).unwrap();
+        assert_eq!(fires, vec![
+            at("2026-06-01T09:00:00Z"),
+            at("2026-06-02T09:00:00Z"),
+            at("2026-06-03T09:00:00Z"),
+        ]);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn occurrences_between_includes_boundary_start_excludes_end() {
+        // `from` lands exactly on an occurrence (inclusive); `to` does too (exclusive).
+        let from = at("2026-06-01T09:00:00Z");
+        let to = at("2026-06-03T09:00:00Z");
+        let (fires, _) = occurrences_between("0 9 * * *", "UTC", from, to, 100).unwrap();
+        assert_eq!(fires, vec![
+            at("2026-06-01T09:00:00Z"),
+            at("2026-06-02T09:00:00Z"),
+        ]);
+    }
+
+    #[test]
+    fn occurrences_between_caps_and_flags_truncation() {
+        // Minutely over an hour = 60 fires, but max caps at 10.
+        let from = at("2026-06-01T00:00:00Z");
+        let to = at("2026-06-01T01:00:00Z");
+        let (fires, truncated) = occurrences_between("* * * * *", "UTC", from, to, 10).unwrap();
+        assert_eq!(fires.len(), 10);
+        assert!(truncated);
     }
 
     #[test]

--- a/backend/src/handlers/automation.rs
+++ b/backend/src/handlers/automation.rs
@@ -194,9 +194,10 @@ pub async fn create_trigger(
     State(state): State<Arc<AppState>>,
     Extension(auth_user): Extension<AuthUser>,
     Path(automation_id): Path<Uuid>,
-    Json(spec): Json<CreateTriggerRequest>,
+    Json(payload): Json<CreateTriggerRequest>,
 ) -> ApiResult<(StatusCode, Json<CreatedTriggerResponse>)> {
     require_automation_access(&state, auth_user.id, automation_id).await?;
+    let CreateTriggerRequest { spec, enabled } = payload;
 
     let (token_hash, plaintext) = if matches!(spec, TriggerSpec::Webhook { .. }) {
         let token = generate_webhook_token();
@@ -217,7 +218,7 @@ pub async fn create_trigger(
 
     let trigger = state
         .repository
-        .create_trigger(automation_id, &spec, token_hash, next_fire_at)
+        .create_trigger_with_enabled(automation_id, &spec, enabled, token_hash, next_fire_at)
         .await
         .map_err(|e| match e {
             RepositoryError::UniqueViolation(_) => {

--- a/backend/src/handlers/automation.rs
+++ b/backend/src/handlers/automation.rs
@@ -6,7 +6,7 @@ use axum::{
     extract::{Extension, Path, Query, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
 };
-use chrono::Utc;
+use chrono::{DateTime, Duration, Utc};
 use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -17,9 +17,9 @@ use crate::{
     error::{ApiResult, AppError},
     model::{
         AutomationListResponse, AutomationResponse, CreateAutomationRequest, CreateTriggerRequest,
-        CreatedTriggerResponse, EventListResponse, EventResponse, RunListResponse, RunResponse,
-        TriggerListResponse, TriggerResponse, TriggerSpec, UpdateAutomationRequest,
-        UpdateTriggerRequest,
+        CreatedTriggerResponse, EventListResponse, EventResponse, OccurrenceListResponse,
+        OccurrenceResponse, RunListResponse, RunResponse, TriggerListResponse, TriggerResponse,
+        TriggerSpec, UpdateAutomationRequest, UpdateTriggerRequest,
     },
     repository::{DbAutomation, RepositoryError},
     state::AppState,
@@ -334,6 +334,145 @@ pub async fn delete_trigger(
         .await
         .map_err(|e| AppError::internal(e.to_string()))?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+// ── occurrences (computed schedule preview) ──────────────────────────────────
+
+/// Hard caps so a dense cron (e.g. minutely) over a wide window can't blow up
+/// the response or CPU. Per-trigger so one busy trigger doesn't starve others.
+const OCCURRENCE_PER_TRIGGER_MAX: usize = 500;
+const OCCURRENCE_WINDOW_MAX_DAYS: i64 = 366;
+
+#[derive(Debug, Deserialize, schemars::JsonSchema, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct OccurrencesQuery {
+    /// Project UUID, active slug, or retired slug — required.
+    pub project_ref: Option<String>,
+    /// Window start (RFC3339); defaults to now.
+    pub from: Option<DateTime<Utc>>,
+    /// Window end (RFC3339, exclusive); defaults to `from` + 31 days.
+    pub to: Option<DateTime<Utc>>,
+}
+
+/// GET /automations/occurrences?project_ref=&from=&to=
+/// Expands every enabled cron trigger in the project into its upcoming fire
+/// times within the window. Nothing is persisted — the cron expression alone
+/// determines all future instants, so this is pure computation over the live
+/// trigger set. A malformed stored expression is skipped (logged), not fatal.
+pub async fn list_occurrences(
+    State(state): State<Arc<AppState>>,
+    Extension(auth_user): Extension<AuthUser>,
+    Query(q): Query<OccurrencesQuery>,
+) -> ApiResult<Json<OccurrenceListResponse>> {
+    let project_ref = q
+        .project_ref
+        .ok_or_else(|| AppError::bad_request("project_ref is required"))?;
+    let project_id = super::project::resolve_project_id(&state, &project_ref).await?;
+    require_member(&state, auth_user.id, project_id).await?;
+
+    let from = q.from.unwrap_or_else(Utc::now);
+    let to = q.to.unwrap_or_else(|| from + Duration::days(31));
+    if to <= from {
+        return Err(AppError::bad_request("`to` must be after `from`"));
+    }
+    if to - from > Duration::days(OCCURRENCE_WINDOW_MAX_DAYS) {
+        return Err(AppError::bad_request(format!(
+            "window too wide (max {OCCURRENCE_WINDOW_MAX_DAYS} days)"
+        )));
+    }
+
+    let triggers = state
+        .repository
+        .list_enabled_cron_triggers_in_project(project_id)
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?;
+
+    let default_tz = crate::cron::default_tz_name();
+    let mut items: Vec<OccurrenceResponse> = Vec::new();
+    let mut truncated = false;
+    for (trigger, automation_name) in triggers {
+        let spec = TriggerSpec::from_db(trigger.kind, &trigger.spec_json)
+            .map_err(|e| AppError::internal(format!("trigger spec decode: {e}")))?;
+        let TriggerSpec::Cron { expr, tz } = spec else {
+            continue; // defensive: query already filters kind = 'cron'
+        };
+        let tz_name = tz.as_deref().unwrap_or(default_tz);
+        let (fires, trig_truncated) = match crate::cron::occurrences_between(
+            &expr,
+            tz_name,
+            from,
+            to,
+            OCCURRENCE_PER_TRIGGER_MAX,
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(trigger = %trigger.id, "occurrences expand skipped: {e}");
+                continue;
+            }
+        };
+        truncated |= trig_truncated;
+        items.extend(fires.into_iter().map(|fire_at| OccurrenceResponse {
+            trigger_id: trigger.id,
+            automation_id: trigger.automation_id,
+            automation_name: automation_name.clone(),
+            fire_at,
+            tz: tz.clone(),
+        }));
+    }
+    items.sort_by_key(|o| o.fire_at);
+
+    Ok(Json(OccurrenceListResponse { items, truncated }))
+}
+
+/// Cap on runs returned per window request (calendar buckets per day anyway).
+const RUN_WINDOW_MAX: i64 = 500;
+
+#[derive(Debug, Deserialize, schemars::JsonSchema, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct RunWindowQuery {
+    /// Project UUID, active slug, or retired slug — required.
+    pub project_ref: Option<String>,
+    /// Window start (RFC3339); defaults to now.
+    pub from: Option<DateTime<Utc>>,
+    /// Window end (RFC3339, exclusive); defaults to `from` + 31 days.
+    pub to: Option<DateTime<Utc>>,
+}
+
+/// GET /automations/runs?project_ref=&from=&to=
+/// Runs across the project whose `scheduled_for` falls in the window — the
+/// calendar's realized (past) slots, any trigger kind (the client filters).
+/// Pairs with `/automations/occurrences` (future predictions).
+pub async fn list_runs_window(
+    State(state): State<Arc<AppState>>,
+    Extension(auth_user): Extension<AuthUser>,
+    Query(q): Query<RunWindowQuery>,
+) -> ApiResult<Json<RunListResponse>> {
+    let project_ref = q
+        .project_ref
+        .ok_or_else(|| AppError::bad_request("project_ref is required"))?;
+    let project_id = super::project::resolve_project_id(&state, &project_ref).await?;
+    require_member(&state, auth_user.id, project_id).await?;
+
+    let from = q.from.unwrap_or_else(Utc::now);
+    let to = q.to.unwrap_or_else(|| from + Duration::days(31));
+    if to <= from {
+        return Err(AppError::bad_request("`to` must be after `from`"));
+    }
+    if to - from > Duration::days(OCCURRENCE_WINDOW_MAX_DAYS) {
+        return Err(AppError::bad_request(format!(
+            "window too wide (max {OCCURRENCE_WINDOW_MAX_DAYS} days)"
+        )));
+    }
+
+    let runs = state
+        .repository
+        .list_runs_in_window(project_id, from, to, RUN_WINDOW_MAX)
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?;
+
+    Ok(Json(RunListResponse {
+        items: runs.into_iter().map(RunResponse::from).collect(),
+    }))
 }
 
 // ── runs / events (read-only) ────────────────────────────────────────────────

--- a/backend/src/model/automation.rs
+++ b/backend/src/model/automation.rs
@@ -214,6 +214,29 @@ pub struct TriggerListResponse {
     pub items: Vec<TriggerResponse>,
 }
 
+// ── occurrences (computed schedule preview) ──────────────────────────────────
+
+/// A single upcoming scheduled fire, expanded from a cron trigger's expression.
+/// Not persisted — computed on demand for the calendar view.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct OccurrenceResponse {
+    pub trigger_id: Uuid,
+    pub automation_id: Uuid,
+    pub automation_name: String,
+    /// The exact fire instant (UTC). Clients localize for display.
+    pub fire_at: DateTime<Utc>,
+    /// The trigger's timezone (the cron expr is evaluated in this zone).
+    pub tz: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct OccurrenceListResponse {
+    pub items: Vec<OccurrenceResponse>,
+    /// `true` if any trigger's expansion hit the per-trigger cap within the
+    /// window (the calendar is showing a partial set for at least one trigger).
+    pub truncated: bool,
+}
+
 // ── run ─────────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/backend/src/model/automation.rs
+++ b/backend/src/model/automation.rs
@@ -189,9 +189,21 @@ impl TriggerResponse {
     }
 }
 
-/// Trigger creation body is `TriggerSpec` directly (avoids serde flatten +
-/// deny_unknown_fields conflict from a wrapper struct).
-pub type CreateTriggerRequest = TriggerSpec;
+fn default_true() -> bool {
+    true
+}
+
+/// Trigger creation body: the `TriggerSpec` fields (internally tagged by
+/// `kind`) flattened inline, plus an optional `enabled` (defaults to true) so a
+/// trigger can be created disabled in one request — e.g. duplicating a trigger.
+/// No `deny_unknown_fields` here: it's incompatible with `#[serde(flatten)]`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateTriggerRequest {
+    #[serde(flatten)]
+    pub spec: TriggerSpec,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/backend/src/repository/automation.rs
+++ b/backend/src/repository/automation.rs
@@ -475,6 +475,20 @@ impl SqliteRepository {
         webhook_token_hash: Option<String>,
         next_fire_at: Option<DateTime<Utc>>,
     ) -> RepositoryResult<DbAutomationTrigger> {
+        self.create_trigger_with_enabled(automation_id, spec, true, webhook_token_hash, next_fire_at)
+            .await
+    }
+
+    /// Like `create_trigger`, but lets the caller create the trigger disabled
+    /// (e.g. duplicating a trigger so the clone doesn't double-fire).
+    pub async fn create_trigger_with_enabled(
+        &self,
+        automation_id: Uuid,
+        spec: &TriggerSpec,
+        enabled: bool,
+        webhook_token_hash: Option<String>,
+        next_fire_at: Option<DateTime<Utc>>,
+    ) -> RepositoryResult<DbAutomationTrigger> {
         let id = Uuid::new_v4();
         let now = Self::now_string();
         let kind = spec.kind();
@@ -484,12 +498,13 @@ impl SqliteRepository {
         sqlx::query(
             "INSERT INTO automation_triggers \
                (id, automation_id, kind, spec_json, enabled, next_fire_at, webhook_token_hash, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?)",
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(id.to_string())
         .bind(automation_id.to_string())
         .bind(kind.as_str())
         .bind(&spec_json)
+        .bind(if enabled { 1i64 } else { 0i64 })
         .bind(&nfa_str)
         .bind(&webhook_token_hash)
         .bind(&now)
@@ -503,7 +518,7 @@ impl SqliteRepository {
             automation_id,
             kind,
             spec_json,
-            enabled: true,
+            enabled,
             next_fire_at,
             webhook_token_hash,
             created_at: Self::parse_timestamp(now.clone(), "automation_triggers.created_at")?,

--- a/backend/src/repository/automation.rs
+++ b/backend/src/repository/automation.rs
@@ -662,6 +662,32 @@ impl SqliteRepository {
         rows.iter().map(Self::row_to_db_trigger).collect()
     }
 
+    /// Enabled cron triggers whose automation is also enabled, for one project,
+    /// each paired with its automation's name. Powers the calendar view, which
+    /// expands these into upcoming fire times in-memory (no persisted schedule).
+    pub async fn list_enabled_cron_triggers_in_project(
+        &self,
+        project_id: Uuid,
+    ) -> RepositoryResult<Vec<(DbAutomationTrigger, String)>> {
+        let rows = sqlx::query(
+            "SELECT t.id, t.automation_id, t.kind, t.spec_json, t.enabled, t.next_fire_at, t.webhook_token_hash, t.created_at, t.updated_at, a.name AS automation_name \
+             FROM automation_triggers t \
+             JOIN automations a ON a.id = t.automation_id \
+             WHERE a.project_id = ? AND t.kind = 'cron' AND t.enabled = 1 AND a.enabled = 1 \
+             ORDER BY a.name ASC, t.created_at ASC",
+        )
+        .bind(project_id.to_string())
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter()
+            .map(|row| {
+                let trigger = Self::row_to_db_trigger(row)?;
+                let name: String = row.get("automation_name");
+                Ok((trigger, name))
+            })
+            .collect()
+    }
+
     // ── automation_runs ─────────────────────────────────────────────────────
 
     pub async fn create_run(
@@ -1017,6 +1043,36 @@ impl SqliteRepository {
         .bind(automation_id.to_string())
         .bind(limit)
         .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter().map(Self::row_to_db_run).collect()
+    }
+
+    /// All runs in a project whose `scheduled_for` falls in `[from, to)` — the
+    /// calendar's realized (past) slots, any trigger kind (the client filters
+    /// by kind/status). Capped at `limit`, keeping the most recent (DESC) so a
+    /// dense window drops the oldest rather than the newest.
+    pub async fn list_runs_in_window(
+        &self,
+        project_id: Uuid,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        limit: i64,
+    ) -> RepositoryResult<Vec<DbAutomationRun>> {
+        let from_s = Self::ts_string(from);
+        let to_s = Self::ts_string(to);
+        let rows = sqlx::query(
+            "SELECT r.id, r.automation_id, r.trigger_id, r.session_id, r.status, r.scheduled_for, r.lease_until, r.previous_run_id, r.idempotency_key, r.created_at, r.updated_at, s.agent_type, s.model \
+             FROM automation_runs r \
+             JOIN sessions s ON s.id = r.session_id \
+             JOIN automations a ON a.id = r.automation_id \
+             WHERE a.project_id = ? AND r.scheduled_for >= ? AND r.scheduled_for < ? \
+             ORDER BY r.scheduled_for DESC LIMIT ?",
+        )
+        .bind(project_id.to_string())
+        .bind(&from_s)
+        .bind(&to_s)
+        .bind(limit)
         .fetch_all(&self.pool)
         .await?;
         rows.iter().map(Self::row_to_db_run).collect()

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -134,6 +134,17 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
             get(handlers::list_automations).post(handlers::create_automation),
         )
         .api_route(
+            // Static segment — must precede `/automations/{automation_id}` so
+            // matchit routes it here rather than treating "occurrences" as an id.
+            "/automations/occurrences",
+            get(handlers::list_occurrences),
+        )
+        .api_route(
+            // Static segment — precedes `/automations/{automation_id}`.
+            "/automations/runs",
+            get(handlers::list_runs_window),
+        )
+        .api_route(
             "/automations/{automation_id}",
             get(handlers::get_automation)
                 .patch(handlers::update_automation)

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -190,7 +190,11 @@ async fn fire_cron_trigger_once(
             automation.project_id,
             automation.created_by,
             trigger.id,
-            now,
+            // Stamp the exact cron instant (not the wake time) so scheduled_for
+            // is precise — keeps the calendar's per-minute dedupe aligned and
+            // the list's "scheduled at" exact. It's <= now (the due query
+            // gates on next_fire_at <= now), so it's still claimable at once.
+            trigger.next_fire_at.unwrap_or(now),
             next_fire,
             &payload,
         )


### PR DESCRIPTION
## Description
A calendar view on the automation page (List/Calendar toggle in the runs pane). It unifies the schedule timeline: **past slots show real runs** (with status), **future slots show predicted cron occurrences**, split at "now" and de-duped at the boundary.

- **Backend**: two project-scoped(`?project_ref=...`), date-windowed(`?from=...&to=...`) GET endpoints
  - (new) `GET /automations/occurrences` (expands cron exprs in-memory; nothing persisted)
  - (modified) `GET /automations/runs`
- **App**: Calendar view(refer to screenshots)

## Notes
- Colors are assigned per-automation by index (collision-free up to the palette size`=7`) and kept distinct from run-status hues.

## Screenshots
### Segemented toggle at the top of the list
<details>
  <summary>Show</summary>

<img width="399" height="261" alt="스크린샷 2026-06-15 오후 10 41 22" src="https://github.com/user-attachments/assets/d4d5451b-ba9c-4b14-a029-cec9ea852bd6" />

</details>

### Overall calendar view
<details>
  <summary>Show</summary>

automation legends with color palette / showing +N more / schedule info for future run / filters('schedule' is default for trigger) / today button / the actual runs for past slots, the expected run schedules for future slots

<img width="1979" height="1050" alt="스크린샷 2026-06-15 오후 10 41 54" src="https://github.com/user-attachments/assets/8dd3a20e-9077-4a76-920f-6b806eade0a6" />

</details>

### Speech-bubble-like detail view for narrow screens
<details>
  <summary>Show</summary>

<img width="739" height="462" alt="스크린샷 2026-06-15 오후 10 42 25" src="https://github.com/user-attachments/assets/9fb409d1-204d-494e-89b0-9ec962600acc" />

</details>

### Show all runs in the day with `+N more` button
<details>
  <summary>Show</summary>

<img width="253" height="256" alt="스크린샷 2026-06-15 오후 10 42 06" src="https://github.com/user-attachments/assets/ed736f3b-4ada-40b8-ba9b-1c25ccef90f5" />

</details>
