### PR TITLE
fix(env): document KIMI and Brave keys in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
+KIMI_API_KEY=
+
+# Web search for the deep-research agent
+BRAVE_SEARCH_API_KEY=
 
 # Backend
 BIND_ADDR=127.0.0.1:8080


### PR DESCRIPTION
`.env.example` listed OpenAI / Anthropic / Gemini, but the code also reads two more keys that were undocumented:

- `KIMI_API_KEY` — moonshotai provider (`ailoy` `lang_model/provider.rs`)
- `BRAVE_SEARCH_API_KEY` — web search for the deep-research agent (`agent-k/.../deep_research/tool/api_search.rs`)

Added both so a fresh setup knows they exist. No code change.
