### PR TITLE
[Bugfix] fix(worker): resume automation runs from a step cursor

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use crate::{
     cron::next_fire_after,
-    handlers::session::{attribute_messages, build_session_agent},
+    handlers::session::{attribute_messages, build_session_agent, inject_attachment_note},
     model::{EventKind, RunStatus, TriggerSpec},
     repository::DbAutomationRun,
     state::AppState,
@@ -399,12 +399,47 @@ async fn execute_run(
         .await
         .map_err(|e| e.to_string())?;
 
-    let agent = build_session_agent(state, automation.project_id, run.session_id)
+    // Resume cursor: skip steps already completed in a prior attempt of THIS
+    // run (re-claimed after a lease loss). Derived from the event log so no
+    // schema/migration is needed — the highest `step_finished{idx}` marks the
+    // last durably-completed step, and a step's messages are persisted iff that
+    // event was written (see the persist ordering below), so the cursor and the
+    // session messages never disagree except across a crash between the two.
+    let resume_from = repo
+        .list_events_for_run(run.id)
+        .await
+        .map_err(|e| e.to_string())?
+        .iter()
+        .filter(|e| e.kind == EventKind::StepFinished)
+        .filter_map(|e| {
+            e.payload
+                .as_ref()
+                .and_then(|p| p.get("step_index"))
+                .and_then(serde_json::Value::as_i64)
+        })
+        .max()
+        .map_or(0usize, |last| (last + 1) as usize);
+
+    let mut agent = build_session_agent(state, automation.project_id, run.session_id)
         .await
         .map_err(|e| e.to_string())?;
+    // On a resumed run, restore the messages from already-completed steps so
+    // the remaining prompts see their context (e.g. step 1 sees step 0's
+    // answer). No-op on a fresh first attempt — the session has no messages.
+    if resume_from > 0 {
+        let history: Vec<Message> = repo
+            .get_messages(run.session_id)
+            .await
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .map(|r| inject_attachment_note(r.message, &r.attachments))
+            .collect();
+        agent.state.history.extend(history);
+        tracing::info!(run = %run.id, resume_from, "resuming run from step cursor");
+    }
     state.insert_agent(run.session_id, agent);
 
-    for (idx, prompt) in automation.prompts.iter().enumerate() {
+    for (idx, prompt) in automation.prompts.iter().enumerate().skip(resume_from) {
         if cancel.is_cancelled() {
             return Err("cancelled".into());
         }
@@ -454,20 +489,24 @@ async fn execute_run(
         let new_msgs = agent.get_history()[prev_len..].to_vec();
         drop(agent);
 
-        // Attribute the prompt to the automation's creator (User-kind) and any
-        // agent outputs to the agent (Agent-kind), via the same helper that
-        // session.send_message uses.
-        let to_persist = attribute_messages(new_msgs, &outputs, automation.created_by, vec![]);
-        repo.append_messages(run.session_id, &to_persist)
-            .await
-            .map_err(|e| e.to_string())?;
-
+        // A step that did not finish cleanly persists NOTHING. The resume cursor
+        // only advances on `step_finished`, so writing a half-run step's prompt
+        // here would let the re-claim replay the same step and duplicate the
+        // user message — exactly the bug this guards against. Bail first.
         if cancelled {
             return Err("cancelled".into());
         }
         if let Some(err) = step_err {
             return Err(format!("step {step_index} failed: {err}"));
         }
+
+        // Clean completion: persist the prompt (User-kind) + agent outputs
+        // (Agent-kind) via the same helper session.send_message uses, then write
+        // `step_finished` — the durable cursor a resumed run reads back.
+        let to_persist = attribute_messages(new_msgs, &outputs, automation.created_by, vec![]);
+        repo.append_messages(run.session_id, &to_persist)
+            .await
+            .map_err(|e| e.to_string())?;
 
         repo.append_event(
             run.id,


### PR DESCRIPTION
## Observation
An unexpected behavior is observed:
4 user messages were found in the run session of 2-prompt automation.

<details>
  <summary>Show screenshot</summary>

<img width="443" height="1091" alt="스크린샷 2026-06-19 오전 11 17 26" src="https://github.com/user-attachments/assets/1d5ddea2-9718-4ee0-b35d-241def14a5be" />

</details>

## Analysis
Here's what the event log showed.

| ts | kind | meaning |
|---|---|---|
| 19:20:54.289 | triggered / queued | cron fired |
| 19:20:54.576 | **started** | **1st execution begins** |
| 19:20:54.583 | step_started{0} | seq25 |
| 19:20:59.455 | step_finished{0} | → seq25 user + seq26 agent |
| 19:20:59.456 | step_started{1} | seq27 |
| **19:54:04.594** | **lease_lost** | **lease expired → reaper flipped the same run back to 'queued'** |
| 20:10:26.822 | **started** | **2nd execution (same run re-claimed)** |
| 20:10:26.825 | step_started{0} | seq28(==seq25) **replayed** |
| 20:10:28.522 | step_finished{0} | → seq28 user + seq29 agent **⚠️ duplicate** |
| 20:10:28.523 | step_started{1} | seq30 |
| 20:28:03.551 | step_finished{1} | → seq30 user + seq31 agent |
| 20:28:03.552 | succeeded | done |

### Resulting session_messages — 4 user messages

| seq | role | source |
|---|---|---|
| 25 | user | 1st run, step0 |
| 26 | agent | 1st run, step0 |
| 27 | user | **1st run, step1 orphan** — no paired agent reply ⚠️ Defect B |
| 28 | user | **2nd run, step0 replay** ⚠️ Defect A |
| 29 | agent | 2nd run, step0 |
| 30 | user | 2nd run, step1 |
| 31 | agent | 2nd run, step1 |

---

## Root cause — two defects + the trigger

### Trigger · lease expiry → same run re-executed

Lease is 3 min (`LEASE_MINUTES=3`), heartbeat renews every 30 s (`HEARTBEAT_INTERVAL`), reaper scans every 60 s (`REAP_INTERVAL`). The 1st run's step1 **ran for ~33 min without finishing**, and during that time the heartbeat failed to renew the lease for >3 min, so `lease_until` expired. `reap_expired_leases` then flipped **the same run row** (not a new chain entry) back to `status='queued'`, and a worker re-claimed it.

### Defect A — no step cursor → replay from 0

`execute_run` iterates `automation.prompts` **from idx 0 on every claim**. There is no column recording how far it got, so on re-claim the already-finished step0 runs again → **duplicate step0** (seq28).

### Defect B — interrupted step persists its message first

`append_messages` ran **before** the `if cancelled` check, so step1's user prompt, injected before the lease was lost, was left in the session with no paired reply → **orphan step1** (seq27).

---

## Fix

Both defects stem from one gap: **the run accumulates messages as it progresses but never tracks which step completed.** We close it with a single invariant:

> **Invariant** — a step's messages are persisted **only when `step_finished{idx}` is recorded** (i.e. only when the step finished cleanly). Then **the cursor and the session messages can never disagree**, so a re-claim skips finished steps and re-runs only the unfinished one, exactly once.

- **No migration** — the cursor is derived from the existing event log (max `step_finished{idx}`) instead of a new column.
- On resume, **the finished steps' messages are restored into the agent history** (the worker previously started with an empty agent), so the remaining prompts see prior-answer context. No-op on a fresh first run.
- **Cancelled / errored steps persist nothing** → orphan messages (Defect B) eliminated at the source.

**Accepted exception**: in the rare window where the process dies *after* `append_messages` succeeds but *before* `step_finished` is written, that step's user message can be duplicated once (there is no message↔step mapping to clean it up — an agreed-upon acceptable edge case).

### Flow on the same scenario, post-fix

```
1st claim → step0 persisted + step_finished{0} → step1 in progress, lease lost
   → cancelled → nothing persisted (orphan seq27 never created)
2nd re-claim → resume_from = 1 from events → step0 history restored
   → .skip(1) skips re-running step0 (no duplicate step0)
   → only step1 runs → succeeded
resulting user messages: step0 ×1, step1 ×1  ✓
```
