### PR TITLE
Refactor: PPTX improve

### DIFF
--- a/agent-k/src/agents/coworker.rs
+++ b/agent-k/src/agents/coworker.rs
@@ -182,6 +182,22 @@ pub async fn get_coworker_agent_with_opts(
                         pptx_dir.join("script/verify_pptx.py"),
                         include_bytes!("skill/pptx/script/verify_pptx.py").to_vec(),
                     ),
+                    FileEntry::new(
+                        pptx_dir.join("script/html2pptx.py"),
+                        include_bytes!("skill/pptx/script/html2pptx.py").to_vec(),
+                    ),
+                    FileEntry::new(
+                        pptx_dir.join("script/components.css"),
+                        include_bytes!("skill/pptx/script/components.css").to_vec(),
+                    ),
+                    FileEntry::new(
+                        pptx_dir.join("script/template.html"),
+                        include_bytes!("skill/pptx/script/template.html").to_vec(),
+                    ),
+                    FileEntry::new(
+                        pptx_dir.join("script/contact_sheet.py"),
+                        include_bytes!("skill/pptx/script/contact_sheet.py").to_vec(),
+                    ),
                 ],
             )
             .skill(

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -132,21 +132,18 @@ issues = verify("/workspace/artifacts/deck.pptx")
 print(summarize(issues))
 ```
 
-Six checks:
+Five checks:
 
 - `fonts` — CJK runs with no East-Asian typeface (tofu risk)
 - `sizes` — 5+ distinct sizes on one slide (one off-scale dramatic beat allowed)
 - `page_numbers` — title (1) or closing (N) slide carrying `n / N`
 - `overlap` — text boxes whose bboxes collide (layered/stacked pairs
   filtered out)
-- `dead_bottom` — content slide whose body content ends high, leaving a large
-  empty band at the bottom (the recurring dead-bottom; fix per Grid → "Fill
-  the canvas")
 - `palette` — discipline: flags palette **sprawl** (too many distinct
   non-neutral colors) and reports any color used on a single slide;
   advisory — lean on B for whether the palette fits the subject
 
-`fonts`/`sizes`/`page_numbers`/`overlap`/`dead_bottom` pass when their lists are empty.
+`fonts`/`sizes`/`page_numbers`/`overlap` pass when their lists are empty.
 (No `overflow`/`word_wrap` check — boxes are sized to browser-measured
 text and line breaks are frozen, so clipping/re-wrap can't happen; no
 chart check — charts are raster.) **Do not `read` `verify_pptx.py`** —
@@ -190,8 +187,15 @@ across all slides at once; zoom in only where needed. Check for
   present and recurring across slides
 - The last slide IS a closing pattern (mirrors the title)
 - Layouts vary — not every content slide using the same division
-- **No large dead space** — content fills the canvas, no blank lower band or
-  hollow column (Grid → "Fill the canvas")
+- **Scan each slide's lower third — on the contact sheet, not by opening every
+  PNG.** A big empty bottom band shows clearly even at thumbnail size. If a
+  content slide's lower band is empty — content marooned at the top, or a
+  card/column stretched tall but hollow below its text — that's a defect (not a
+  deliberate full-bleed / divider / closing). Fix it: a supporting visual, a
+  bottom takeaway band, vertical distribution, or larger type (Grid → "Fill the
+  canvas"). You can SEE here what geometry can't — a card whose content
+  genuinely fills it is fine; a hollow one is not. (Deep-read an individual
+  slide only when the thumbnail is ambiguous.)
 - Palette is composed from the subject and actually shows its Accent (not a
   stock-theme reflex — see "Palette")
 - **Distinctiveness check** — would this exact palette + layout fit an

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -38,11 +38,13 @@ Two non-negotiable rules:
 
 **Hard rules — if any of these slip, the deck fails:**
 
-- Install the toolchain before converting (the sandbox ships neither):
+- Install the toolchain before converting (the sandbox ships neither).
+  Run all three up front — **do not** wait for a launch failure to add
+  `install-deps`; the sandbox is always missing the browser's system
+  libraries, so skipping it just wastes a failed conversion:
   `pip install python-pptx playwright` then
-  `playwright install chromium --only-shell`
-  (add `playwright install-deps chromium` if the browser won't launch).
-- Write `outline.md` **before** any HTML (Process §1).
+  `playwright install chromium --only-shell` then
+  `playwright install-deps chromium`.
 - Each slide is a `<div class="slide">` sized **exactly 1280×720 px**
   (16:9). Author at 96 px/in. **No `transform: scale()` / `zoom`** on
   slide content — it breaks the px→inch mapping.
@@ -50,71 +52,48 @@ Two non-negotiable rules:
   `'Noto Sans CJK KR'` / `JP` / `SC` / `TC` (the `CJK` infix is
   mandatory — `'Noto Sans KR'` falls back to tofu).
 - Verify gate: `verify()` reports no issues AND the contact-sheet
-  overview `read` (+ any suspect slide deep-read) — both required (§4).
+  overview `read` (+ any suspect slide deep-read) — both required (§3).
 - Only the final `.pptx` (plus the `.source.html` sidecar the converter
-  auto-saves beside it) belong in `artifacts/` — your working `deck.html`,
-  intermediate PNGs, and `outline.md` stay in the working directory.
+  auto-saves beside it) belong in `artifacts/` — your working `deck.html`
+  and intermediate PNGs stay in the working directory.
 
 ---
 
-## Process — outline → HTML → convert → verify
+## Process — HTML → convert → verify
 
-**Separate content from layout.** Write everything as markdown first,
-then author HTML, then convert.
+### 1. Author the HTML
 
-### 1. Outline (`outline.md`) — verbatim slide content
-
-**Do not skip this step.** It is the source of truth the HTML copies
-*from*; without it, content drifts into free-improvisation.
-
-One section per slide, **including both bookends** — a "10 slides"
-request means 1 title + 8 content + 1 closing, *not* 10 content slides.
-Generate the bookends even when the prompt doesn't mention them.
-
-**Slide 1 — title slide (always)**:
-- `## Slide 1: <deck title>` — e.g. `## Slide 1: Q1 2026 Business Review`
-- `**Eyebrow**` sub-line (caption-tier label, e.g. `**Pixellife Inc.**`)
-- `**Subtitle**` sub-line (one-line framing). No bullets / tables / charts.
-
-**Slides 2 to N−1 — content slides**:
-- `## Slide N: <takeaway-headline>` — a *takeaway sentence*
-  ("Revenue grew 31.7%, margin improved in step"), not a topic
-  ("Q1 results"). Becomes the slide title.
-- A **bold sub-line** for the kicker / framing label.
-- Data as a **markdown table**; narrative as a **bulleted list**.
-- Explicit chart / visual hints inline
-  (e.g. `**Bar chart: revenue by quarter, free vs paid**`).
-
-**Slide N — closing slide (always)**:
-- `## Slide N: <closing message>` — e.g. `## Slide 10: Thank you. — Questions?`
-- No bullets / tables / charts (Action-plan variant aside).
-
-A 10-slide outline runs ~200–400 lines. Save as `outline.md` in the
-working directory (not under `artifacts/`).
-
-### 2. Author the HTML
+Work straight from the source material into `deck.html` — no separate
+outline file. Plan the deck first: **include both bookends** — a "10 slides"
+request means 1 title + 8 content + 1 closing, *not* 10 content slides;
+generate the bookends even when the prompt doesn't mention them. Give every
+content slide a **takeaway-sentence** title ("Revenue grew 31.7%, margin
+improved in step"), not a topic label ("Q1 results"). Title slide: deck title
++ eyebrow + one-line subtitle, no bullets/tables/charts. Closing slide: a
+closing message, no bullets/tables/charts (Action-plan variant aside).
 
 Create one `deck.html` linking `components.css` (copy it from the skill
-`script/` dir next to this file, or `<link>` it by path). Pick **one**
-palette theme on `<body>` (e.g. `class="theme-corporate-slate"`) and set
-`<html lang="ko">` for Korean. Emit one `<div class="slide">` per
-`outline.md` section, transcribing text **verbatim** — don't rewrite or
-shorten. Pick the layout grammar from the section's content shape
-(styled table or compact stat row for metrics, card grid for parallel
-items, asymmetric split for chart + sidebar) and vary across the deck.
+`script/` dir next to this file, or `<link>` it by path). At the top of
+the file, **define this deck's composed palette** — a `<style>` block (or
+`:root`) setting the nine role variables you derived in the Palette step. Set
+`<html lang="ko">` for Korean. Emit one `<div class="slide">` per slide,
+keeping text **verbatim** from the source — don't rewrite or shorten. Data as
+styled tables, narrative as bulleted lists. Pick the layout grammar from each
+slide's content shape (styled table or compact stat row for metrics, card grid
+for parallel items, asymmetric split for chart + sidebar) and vary across the deck.
 
-`script/template.html` is a working 4-slide reference (title + metrics
-stat-row + Chart.js chart + closing) — read it once and follow its
-structure.
+`script/template.html` is a **mechanics** reference (how to define the
+palette variables, structure a `.slide`, use the components, and signal
+Chart.js readiness) — **not a look to copy**. Read it once for the wiring,
+then compose your own palette and vary the layouts for your subject; don't
+reproduce its colors or slide order, or every deck ends up looking the same.
 
-**Charts carry no editability requirement** — each becomes its own
-raster picture object. Use Chart.js (`<canvas>`), inline SVG, or a static
-`<img>`. With Chart.js: set `animation:false`, use palette colors via
-`getComputedStyle(...).getPropertyValue('--secondary')`, set chart
-`font.family` to the CJK family, and set `window.__pptx_ready = true`
-after the chart paints (the converter waits for it). See `template.html`.
+**Charts carry no editability requirement** — each becomes its own raster
+picture object (Chart.js `<canvas>`, inline SVG, or static `<img>`). For the
+Chart.js settings (`animation:false`, palette colors, `font.family`,
+`__pptx_ready`) see *Authoring notes → Charts* and `template.html`.
 
-### 3. Convert to PPTX
+### 2. Convert to PPTX
 
 ```
 python /workspace/skills/pptx/script/html2pptx.py deck.html \
@@ -129,7 +108,7 @@ self-contained copy of the source HTML (linked CSS inlined) next to the
 `.pptx` as `<out>.source.html` for review (pass `--no-keep-html` to skip;
 `--dump-json out.json` to inspect the scraped geometry).
 
-### 4. Verify the output renders correctly
+### 3. Verify the output renders correctly
 
 **Gate: do not surface the `.pptx` until BOTH (A) every `verify()` check
 is clean AND (B) the contact sheet has been `read`-inspected (plus any
@@ -152,8 +131,9 @@ Five checks, on the emitted text boxes:
 - `page_numbers` — title (1) or closing (N) slide carrying `n / N`
 - `overlap` — text boxes whose bboxes collide (layered/stacked pairs
   filtered out)
-- `palette` — advisory: reflects text-run colors only (shape/bg fills
-  aside), so lean on visual inspection in B
+- `palette` — discipline: flags palette **sprawl** (too many distinct
+  non-neutral colors) and reports any color used on a single slide;
+  advisory — lean on B for whether the palette fits the subject
 
 `fonts`/`sizes`/`page_numbers`/`overlap` pass when their lists are empty.
 (No `overflow`/`word_wrap` check — boxes are sized to browser-measured
@@ -194,13 +174,19 @@ across all slides at once; zoom in only where needed. Check for
 
 …and for **design quality** (`verify_pptx` cannot catch these):
 
-- Slide 1 IS a title pattern (anchor + three-tier text + signature mark)
+- Slide 1 opens on something specific to THIS subject (not a generic
+  anchor + three-tier-text template), and the deck's **signature** is
+  present and recurring across slides
 - The last slide IS a closing pattern (mirrors the title)
 - Layouts vary — not every content slide using the same division
 - **No large dead space** — content fills the canvas; the bottom third
   isn't blank and content isn't all stacked to one side (Grid → "Fill
   the canvas"). Tall containers around short text are the usual cause
-- Palette fits the deck's subject/mood — not Corporate Slate by default
+- Palette is composed from the subject and actually shows its Accent — not
+  the default navy/blue/amber-on-white reflex
+- **Distinctiveness check** — would this exact palette + layout fit an
+  unrelated subject just as well? If yes, it's a default: push the accent /
+  signature toward something this subject justifies, and note what you changed
 - Slide titles are takeaway sentences, not topic labels
 
 **Fix at the source**: edit the HTML (position, size, font, content) and
@@ -220,55 +206,61 @@ Loop until both A and B pass — partial pass is failure.
 
 ---
 
-## Palette — color roles
+## Start from the subject (do this first)
 
-The *role structure* is fixed (and encoded as CSS variables in
-`components.css`). The *hex values* are chosen per deck (matched to
-subject and mood) and frozen for that deck's lifetime.
+Before any visual choices, write one line each: **what this deck is about,
+who's in the room, and the one thing it has to accomplish.** A Q1 review for
+a gaming studio's board and an H1 retrospective for a fragrance brand should
+not come out looking interchangeable. Pull the deck's look from the subject's
+own world — its product, materials, vocabulary, mood. If memory holds the
+user's context or past decks, treat it as a hint.
 
-**Colored fills** — Primary (anchor; titles, deepest text), Secondary
-(principal accent; edge strip, card top strips, 1st chart series,
-category tags), Accent (warm pop; eyebrows, corner blocks, quote strip —
-sparingly).
+Decide two things up front and hold them across every slide:
 
-**Surfaces** — Background (page), Surface (card/tile fill), Tinted Panel
-(Surface ~5–10% toward Accent; callout bands).
+- **A composed palette** (next section) — built for this subject, not lifted
+  from a stock theme.
+- **A signature** — the one element a viewer walks away remembering: a
+  recurring motif or treatment drawn from the subject (a marker shape, a
+  numeral style, a divider, how charts are framed). Put the deck's single
+  visual risk here and keep the rest restrained — one signature, not a
+  scatter of effects.
 
-**Structural** — Muted (subtitles, captions, footers, axis labels),
-Hairline (dividers, footer line, card borders, tracks).
+## Palette — compose per deck (no fixed gallery)
 
-**Status** — Positive (green, `+18%`), Negative (red, `-3d`). Deltas
-only, never a fill.
+The *role structure* is fixed; the *hex values are composed for THIS deck*
+and frozen for its lifetime. There is no gallery to pick from — derive one.
 
-**Rule of three.** Per slide, ≤ 3 colored fills from {Primary,
-Secondary, Accent}. A fourth turns it into a paint chart.
+**Roles** — set as CSS variables in the deck's `<style>`; `components.css`
+consumes them:
+- **Primary** — anchor: titles, deepest text.
+- **Secondary** — principal accent: edge strip, card strips, 1st chart
+  series, category tags.
+- **Accent** — one warm / contrasting pop: eyebrows, the signature, emphasis.
+  Use sparingly, but **do use it** — an unused accent reads as unfinished.
+- **Background** / **Surface** — page / card-tile fill.
+- **Muted** — subtitles, captions, axis labels.
+- **Hairline** — dividers, borders, tracks.
+- **Positive** / **Negative** — green / red deltas only, never a fill.
 
----
+**Compose like this:**
+1. Pick a **hue family from the subject's world** (its key art, packaging,
+   industry, mood) — not a reflex default.
+2. Set **Background + Surface** as near-neutral members of that family (a
+   warm off-white, a cool paper, a deliberate dark) — not plain `#FFFFFF`
+   unless that's a real choice.
+3. Choose **one Accent with genuine contrast** against the background.
+4. Keep hues **tonal, not pure-saturation** (`#2563EB`, not `#0000FF`).
+5. Confirm **text-on-background contrast** is comfortably readable.
+6. **Lock the nine values** for the whole deck. Rule of three: ≤ 3 colored
+   fills from {Primary, Secondary, Accent} per slide; a fourth turns it into
+   a paint chart. Never introduce a new hex mid-deck.
 
-## Palette gallery — choose by feel, never default
-
-At the start of every deck: read the title/subject, decide the mood
-(Authoritative? Cinematic? Editorial? Playful? Academic?), and pick the
-theme whose feel matches — or compose a new one in the same style. Lock
-those nine hex values. **Match the palette to *this* deck's mood, not to
-deck history** — reaching for Corporate Slate whenever the brief says
-"business" is anchoring. **Prefer tonal/pastel siblings over pure-
-saturation primaries** (`#2563EB` not `#0000FF`).
-
-Each maps to a `theme-*` class in `components.css` — the exact hex values
-live there, so apply the class (don't re-type hexes):
-
-- **Corporate Slate** `theme-corporate-slate` — restrained, authoritative, financial
-- **Midnight Keynote** `theme-midnight-keynote` — cinematic, bold, on-stage (dark)
-- **Warm Editorial** `theme-warm-editorial` — magazine-like, narrative, hospitable
-- **Forest Research** `theme-forest-research` — calm, considered, exact (academic)
-- **Mono Editorial** `theme-mono-editorial` — typographic, silent, luxury
-- **Playful Violet** `theme-playful-violet` — lively, contemporary, consumer
-- **Sand & Ink** `theme-sand-ink` — quiet, journalistic, considered
-- **Glacier** `theme-glacier` — clean, scientific, optimistic
-
-If none fits, compose a new theme in the same style (copy a block in
-`components.css`, change the hue family, keep the role distribution).
+**Avoid the templated look.** If your palette is the one you'd reach for on
+*any* business deck (navy + blue + amber on near-white is the usual reflex),
+that's anchoring — push the hue family and accent toward what the subject
+actually justifies. `components.css` ships an inert neutral fallback and a
+placeholder compose recipe (`<...>` slots) — fill the slots with hexes you
+derived; don't ship the placeholders or copy a previous deck's palette.
 
 ---
 
@@ -291,8 +283,8 @@ Pick faces that render identically in the sandbox and on opener machines:
 |---|---|---|---|---|
 | `.t-display` | 54 | 40 | Bold | Title/closing slides, large quotes |
 | `.t-title` | 32 | 24 | Bold | Slide titles, divider titles |
-| `.t-body` | 18 | 13.5 | Regular | Bullets, paragraphs, stat labels |
-| `.t-caption` | 11 | 8 | Bold UPPERCASE | Eyebrows, tags, footers, axis labels |
+| `.t-body` | 18 | 13.5 | Regular | Bullets, paragraphs, body text |
+| `.t-caption` | 11 | 8 | Bold UPPERCASE | Eyebrows, tags, footers, axis + stat labels |
 
 (Px values are what you author; the converter scales px×0.75 → pt.)
 
@@ -386,21 +378,14 @@ The converter decomposes each slide (see the four bullets at the top):
   frozen, so soffice won't re-wrap them; `verify_pptx` + visual `read`
   remain the safety net.)
 
-### CJK fonts — set the exact family
-Author CSS must use `'Noto Sans CJK KR'` (or JP/SC/TC) — the `CJK`
-infix is mandatory; `'Noto Sans KR'` will not resolve and renders tofu
-in both Chromium and soffice. The converter copies the computed
-font-family onto each run's Latin **and** EA typeface, so a correct CSS
-family is all you need. `verify_pptx`'s `fonts` check gates this.
-
 ### Charts — Chart.js / SVG (own raster picture)
 Native chart editability is **not** required. Render charts however
 looks best:
 - **Chart.js** (`<canvas>`): set `animation:false`, `responsive:true`,
   `maintainAspectRatio:false` inside a sized container; pull series
-  colors from the palette CSS variables; set `font.family` to the CJK
-  family on ticks/legend; signal `window.__pptx_ready = true` after
-  paint. (See `template.html`.)
+  colors from the palette CSS variables; set `font.family` on ticks/legend
+  to the deck's font (a Noto CJK family for CJK, else labels go tofu);
+  signal `window.__pptx_ready = true` after paint. (See `template.html`.)
 - **Inline SVG** or a **static `<img>`** also work and need no readiness
   flag (but still wait on `document.fonts.ready`, which the converter
   does).
@@ -421,11 +406,12 @@ box and keep narrative/insight text outside it.
 Pick by the slide's *job*, not by what looks pretty. Compose freshly
 within each — don't trace the same layout every deck.
 
-- **Title slide (slide 1)** — deck's visual signature: anchor shape +
-  three-tier text (eyebrow `.t-caption .c-accent` → `.t-display
-  .c-primary` title → `.t-body .c-muted` subtitle) + a small Accent
-  signature mark. Compose freshly; "filled rectangle in one corner" is
-  the AI tell. No page number.
+- **Title slide (slide 1)** — the deck's opening statement, led by something
+  concrete from THIS subject (a number, phrase, motif, or visual from its
+  world) plus the deck's signature, eyebrow, and title. The
+  eyebrow→`.t-display`→subtitle three-tier stack is a fallback, not the goal;
+  "filled rectangle in one corner + three lines of text" is the AI tell —
+  build something the subject earns. No page number.
 - **Section divider** — full-bleed Primary background, huge numeral
   ("01") at 3–4× title in lightened Secondary left, section title right
   (Display, Surface), Accent strip beneath. No page number.
@@ -472,14 +458,9 @@ within each — don't trace the same layout every deck.
   series colors from the palette)
 - Page number on title / divider / closing slides
 - Two patterns merged into one slide
-- New hex color introduced mid-deck (one locked theme)
+- New hex color introduced mid-deck (one locked palette)
 - Content extending past the 1280×720 canvas (right/bottom edge) — it
   gets clipped and reads as "cut off"; keep every element inside
 - Relying on chart `<canvas>` / SVG text being editable — it's baked
 
 (The geometry/font/artifact hard rules at the top also still apply.)
-
----
-
-A quiet, consistent deck reads as designed. A loud, varied deck reads as
-assembled.

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -135,7 +135,7 @@ print(summarize(issues))
 Five checks, on the emitted text boxes:
 
 - `fonts` — CJK runs with no East-Asian typeface (tofu risk)
-- `sizes` — 5+ distinct tier / out-of-tier sizes on one slide
+- `sizes` — 5+ distinct sizes on one slide (one off-scale dramatic beat allowed)
 - `page_numbers` — title (1) or closing (N) slide carrying `n / N`
 - `overlap` — text boxes whose bboxes collide (layered/stacked pairs
   filtered out)
@@ -205,9 +205,10 @@ visual passes total** — re-rendering after each tiny edit is the main
 reason a deck takes forever. In particular, **do not hand-chase CJK
 line-wrapping**: the converter **freezes the browser's exact line breaks**
 (text boxes are `word_wrap`-off with hard `<a:br/>` breaks), so
-soffice/PowerPoint render the same lines you saw in the browser — re-wrap
-and overflow can't happen. Intervene only on real layout issues
-(off-canvas overflow, element collisions, empty space).
+soffice/PowerPoint render the same lines you saw in the browser — the text
+can't re-wrap or reflow. (Off-canvas overflow is separate — that's the
+author placing content past the edge, and it still needs fixing.) Intervene
+only on real layout issues (off-canvas overflow, element collisions, empty space).
 
 Loop until both A and B pass — partial pass is failure.
 
@@ -312,7 +313,7 @@ display), Number-Cover hero (180–250 px). One per slide, sparingly.
 Korean reads "floaty." `components.css` applies `letter-spacing −1%`
 body / `−2%` titles and tighter line-height to `:lang(ko)`. **Assume
 content-slide titles wrap to 2 lines in Korean** — leave room in the
-title band, or step the title down to ~26–28 px.
+title band, or set `--fs-title` toward the lower end of its range.
 
 **One emphasis per slide** — bold *or* color, not both, one phrase max.
 
@@ -466,8 +467,8 @@ within each — don't trace the same layout every deck.
 
 - Text-only slide (no shapes doing work)
 - Default bullet characters (`●` `-` `>` `■`) — use `.bullets` markers
-- Third font, or 5+ sizes *from the four-step scale* on one slide
-  (dramatic-beat sizes don't count)
+- Third font, or 5+ distinct sizes on one slide (the four-step scale plus
+  more than one dramatic-beat size)
 - Centered body text (only big stat values and divider numerals center)
 - Big "KPI card" metric tiles — use a styled table or compact `.stat-row`
 - 7+ bullets on a content slide

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -132,18 +132,21 @@ issues = verify("/workspace/artifacts/deck.pptx")
 print(summarize(issues))
 ```
 
-Five checks, on the emitted text boxes:
+Six checks:
 
 - `fonts` — CJK runs with no East-Asian typeface (tofu risk)
 - `sizes` — 5+ distinct sizes on one slide (one off-scale dramatic beat allowed)
 - `page_numbers` — title (1) or closing (N) slide carrying `n / N`
 - `overlap` — text boxes whose bboxes collide (layered/stacked pairs
   filtered out)
+- `dead_bottom` — content slide whose body content ends high, leaving a large
+  empty band at the bottom (the recurring dead-bottom; fix per Grid → "Fill
+  the canvas")
 - `palette` — discipline: flags palette **sprawl** (too many distinct
   non-neutral colors) and reports any color used on a single slide;
   advisory — lean on B for whether the palette fits the subject
 
-`fonts`/`sizes`/`page_numbers`/`overlap` pass when their lists are empty.
+`fonts`/`sizes`/`page_numbers`/`overlap`/`dead_bottom` pass when their lists are empty.
 (No `overflow`/`word_wrap` check — boxes are sized to browser-measured
 text and line breaks are frozen, so clipping/re-wrap can't happen; no
 chart check — charts are raster.) **Do not `read` `verify_pptx.py`** —

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -38,6 +38,11 @@ Two non-negotiable rules:
 
 **Hard rules — if any of these slip, the deck fails:**
 
+- **The deliverable is the `.pptx`, not the HTML.** You are NOT done when
+  `deck.html` is written — that is step 1 of 3. The task is complete only
+  when `/workspace/artifacts/deck.pptx` exists AND verify (§3) passes. Never
+  end your turn after authoring; always run HTML → convert → verify through
+  to the end in one go.
 - Install the toolchain before converting (the sandbox ships neither).
   Run all three up front — **do not** wait for a launch failure to add
   `install-deps`; the sandbox is always missing the browser's system
@@ -92,6 +97,9 @@ reproduce its colors or slide order, or every deck ends up looking the same.
 picture object (Chart.js `<canvas>`, inline SVG, or static `<img>`). For the
 Chart.js settings (`animation:false`, palette colors, `font.family`,
 `__pptx_ready`) see *Authoring notes → Charts* and `template.html`.
+
+Once `deck.html` is written, **continue straight to §2 — do not stop here.**
+A finished `deck.html` is not a finished deck.
 
 ### 2. Convert to PPTX
 

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -187,11 +187,10 @@ across all slides at once; zoom in only where needed. Check for
   present and recurring across slides
 - The last slide IS a closing pattern (mirrors the title)
 - Layouts vary — not every content slide using the same division
-- **No large dead space** — content fills the canvas; the bottom third
-  isn't blank and content isn't all stacked to one side (Grid → "Fill
-  the canvas"). Tall containers around short text are the usual cause
-- Palette is composed from the subject and actually shows its Accent — not
-  the default navy/blue/amber-on-white reflex
+- **No large dead space** — content fills the canvas, no blank lower band or
+  hollow column (Grid → "Fill the canvas")
+- Palette is composed from the subject and actually shows its Accent (not a
+  stock-theme reflex — see "Palette")
 - **Distinctiveness check** — would this exact palette + layout fit an
   unrelated subject just as well? If yes, it's a default: push the accent /
   signature toward something this subject justifies, and note what you changed
@@ -284,17 +283,26 @@ Pick faces that render identically in the sandbox and on opener machines:
   name isn't present. The EA typeface is set on every emitted run by the
   converter, so CJK survives the round-trip.
 
-`components.css` encodes the four-step scale as `.t-display` / `.t-title`
-/ `.t-body` / `.t-caption`:
+**Type scale — compose per deck, then lock it.** Like the palette, the four
+*roles* are fixed but the *sizes* are yours to set for THIS deck: define the
+four `--fs-*` variables once at the top (in the same `<style>` as the palette),
+then never deviate. `components.css` reads them via `.t-display` / `.t-title`
+/ `.t-body` / `.t-caption`.
 
-| Class | Px | Pt | Weight | Use |
+Size by the deck's density, and **size up to fill the canvas** — a slide is a
+big surface, so lean toward the larger end; a sparse deck reads empty with
+document-sized type:
+
+| Role | Var | Range (px) | Lean larger when… | Use |
 |---|---|---|---|---|
-| `.t-display` | 54 | 40 | Bold | Title/closing slides, large quotes |
-| `.t-title` | 32 | 24 | Bold | Slide titles, divider titles |
-| `.t-body` | 18 | 13.5 | Regular | Bullets, paragraphs, body text |
-| `.t-caption` | 11 | 8 | Bold UPPERCASE | Eyebrows, tags, footers, axis + stat labels |
+| Display | `--fs-display` | 48–72 | few words per slide | title/closing, large quotes |
+| Title | `--fs-title` | 30–44 | sparse decks | slide & divider titles |
+| Body | `--fs-body` | 18–24 | little body text | bullets, paragraphs |
+| Caption | `--fs-caption` | 10–13 | — | eyebrows, tags, footers, axis/stat labels |
 
-(Px values are what you author; the converter scales px×0.75 → pt.)
+Dense data deck → smaller end; message-light exec/cover deck → larger end.
+Whatever you pick, keep the four locked across every slide (the converter
+scales px×0.75 → pt; verify flags 5+ sizes on one slide).
 
 **Dramatic-beat sizes** sit *outside* the scale and are allowed on top
 of it — section-divider numerals (3–4× title), quote glyph (~4×
@@ -330,24 +338,23 @@ intentionally break the grid — those are the dramatic beats.
 *one* axis of asymmetry per deck and apply it consistently; don't
 randomize per slide.
 
-**Fill the canvas — the most common failure.** The body area is ~500 px
-tall (y 154 → 658); short content top-aligned in it leaves a dead bottom
-third. **That blank lower band is the #1 complaint — treat it as a
-defect to fix in verify-B, not a style choice.** Use the whole 1280×720:
+**Fill the canvas — the most common failure.** Short content marooned at the
+top with a dead band beneath is the #1 complaint. Treat empty space as a design
+material you place on purpose, not a gap left over:
 
-- **Never stretch a tall container around short content.** A `.card` or
-  column that spans the full `.body-area` height but holds 3 short lines
-  leaves a dead bottom. Either **size the container to its content**
-  (let it be short) or **distribute/vertically-center** the content
-  (`justify-content: space-between` / `center`) so it uses the height.
-- Spread content across **both axes**. If the left column is full and
-  the right is empty (or top full / bottom empty), rebalance: widen
-  columns, add a supporting visual, enlarge type, or increase spacing.
-- A two-column split should have **both columns roughly balanced** in
-  height — don't put 6 bullets left and 2 right with the rest blank.
-- Prefer fewer, larger, well-spaced elements over a tight cluster
-  floating in a sea of white. Generous *balanced* whitespace is design;
-  a blank lower half is a hole.
+- **Don't pool emptiness in one place.** A little air everywhere reads as
+  composed; one whole empty lower third reads as unfinished. If a region is
+  bare, the layout is unbalanced — redistribute until no single area is hollow.
+- **Use the space at scale.** When there's little to say, say it bigger —
+  larger type, a hero number, a bolder visual, more generous spacing. Don't
+  tuck a few lines into a corner and leave the rest blank; let the content
+  command the whole slide.
+- **Carry a sparse slide with a visual, not more white space.** If a slide is
+  becoming a short bullet list, reach for a **chart, table, timeline, or
+  diagram** instead — it fills the space *and* adds information. A text-only
+  slide that is also half-empty is the weakest slide in the deck.
+- **Balance the columns.** In a two-column or card layout both sides should
+  reach about the same depth and weight — never one full and one hollow.
 
 ---
 
@@ -427,7 +434,9 @@ within each — don't trace the same layout every deck.
   4–6 bullets max (3–4 for CJK). Title = takeaway sentence.
 - **Two-column comparison** — vertical hairline split, category tag atop
   each column (Secondary left, Accent right), 3–5 bullets each. Keep
-  left/right meaning consistent across all comparison slides.
+  left/right meaning consistent across all comparison slides. Give each column
+  a closing takeaway or key stat so it reads as substantial — not a tall box
+  with a few bullets floating at the top (the classic dead-bottom card).
 - **Metrics** — present numbers as a **styled table** or a **compact
   inline stat row** (`.stat-row` → `.stat-value` + uppercase
   `.stat-label` + optional `.stat-delta`). Do **not** use big "KPI
@@ -457,8 +466,7 @@ within each — don't trace the same layout every deck.
 - Third font, or 5+ sizes *from the four-step scale* on one slide
   (dramatic-beat sizes don't count)
 - Centered body text (only big stat values and divider numerals center)
-- Big "KPI card" metric tiles — use a styled table or a compact
-  `.stat-row` instead (tall metric cards read as empty / monotonous)
+- Big "KPI card" metric tiles — use a styled table or compact `.stat-row`
 - 7+ bullets on a content slide
 - Drop shadows, glow, gradients, 3D, clipart, SmartArt, default
   PowerPoint placeholders

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -42,7 +42,7 @@ Two non-negotiable rules:
   Run all three up front — **do not** wait for a launch failure to add
   `install-deps`; the sandbox is always missing the browser's system
   libraries, so skipping it just wastes a failed conversion:
-  `pip install python-pptx playwright` then
+  `pip install python-pptx playwright pypdfium2` then
   `playwright install chromium --only-shell` then
   `playwright install-deps chromium`.
 - Each slide is a `<div class="slide">` sized **exactly 1280×720 px**
@@ -142,14 +142,14 @@ chart check — charts are raster.) **Do not `read` `verify_pptx.py`** —
 these checks are the full contract; only read the source on an
 unexpected exception.
 
-**B. Visual confirmation** — render to PDF + PNG, montage into ONE contact
-sheet, and look. Install `poppler-utils` first (provides `pdftoppm`):
+**B. Visual confirmation** — render the `.pptx` to a PDF, then to one
+montaged contact sheet, and look. `contact_sheet.py` renders the PDF's
+pages itself (via `pypdfium2`, installed up front) and writes a
+`slide-N.png` per page for deep-reads:
 
 ```
-apt-get install -y poppler-utils
 soffice --headless --convert-to pdf /workspace/artifacts/deck.pptx
-pdftoppm -r 75 -png deck.pdf slide
-python /workspace/skills/pptx/script/contact_sheet.py slide*.png -o contact.png
+python /workspace/skills/pptx/script/contact_sheet.py deck.pdf -o contact.png
 ```
 
 **`read` `contact.png` ONCE** for a whole-deck overview, then deep-`read`

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -440,8 +440,11 @@ within each — don't trace the same layout every deck.
 - **Metrics** — present numbers as a **styled table** or a **compact
   inline stat row** (`.stat-row` → `.stat-value` + uppercase
   `.stat-label` + optional `.stat-delta`). Do **not** use big "KPI
-  card" tiles — tall metric cards read as empty and monotonous. Vary
-  the metric treatment across the deck.
+  card" tiles — tall metric cards read as empty and monotonous. A stat row
+  alone (the usual exec-summary) leaves the lower half bare — pair it with a
+  supporting trend visual (a small chart/sparkline of the same numbers), a
+  bottom takeaway band, or vertical distribution so the body fills. Vary the
+  metric treatment across the deck.
 - **Quote slide** — oversized `"` glyph (~4× Display, Accent toward
   Background), quote at Title size ≤ 4 lines, attribution (Body, Muted)
   right-aligned below a short Accent strip.

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -1,16 +1,36 @@
 ---
 name: pptx
-description: Guidelines for producing a slide deck (.pptx) that looks designed, not assembled. One palette, one type scale, one shape vocabulary, one grid — across the whole deck. A text-only slide is a failed slide. Read fully before producing any slide.
+description: Produce a slide deck (.pptx) that looks designed, not assembled, by authoring each slide in HTML/CSS and converting to an editable PPTX. One palette, one type scale, one shape vocabulary, one grid — across the whole deck. A text-only slide is a failed slide. Read fully before producing any slide.
 ---
 
-# PPTX Design Guidelines
+# PPTX Design Guidelines (HTML-authored)
+
+You author slides as **HTML + CSS** (charts via Chart.js / SVG / images,
+freely), then run `html2pptx.py` to convert them to an **editable
+`.pptx`**. The converter **decomposes** each slide into native objects
+rather than one flat image:
+
+- **Text** → native, editable text boxes.
+- **Simple shapes** (solid-fill boxes, borders, hairline dividers, edge
+  strips, card top-strips, bullet markers) → native autoshapes you can
+  move and recolor.
+- **Charts / images / SVG** (Chart.js `<canvas>`, `<img>`, inline
+  `<svg>`) → each its **own picture object** (separate, movable) — their
+  internal text/data is raster, not editable.
+- **Page backdrop** → the slide's solid background color becomes a
+  native slide fill (no full-slide image). Only un-modelable content
+  (gradient / shadow / background-image) falls back to a base picture.
+
+So text and simple shapes round-trip as real, editable PowerPoint
+objects; only chart/image internals stay raster. Stacking follows
+document order. Design fidelity is exactly what Chromium renders.
 
 Two non-negotiable rules:
 
 1. **Every slide carries shapes that do work** — not decoration.
    Text-only slides fail. Always add at least one of: edge strip,
    custom bullet markers, hairline divider, corner block, sidebar
-   tag, card grouping.
+   tag, card grouping. `components.css` ships these.
 2. **Every slide obeys the same system** — same palette, two fonts,
    four type sizes, margins, shape vocabulary. If two slides pinned
    side by side show a different stroke weight or type size, the
@@ -18,707 +38,448 @@ Two non-negotiable rules:
 
 **Hard rules — if any of these slip, the deck fails:**
 
-- Install `python-pptx` before any deck-building code — the sandbox
-  doesn't ship it (`pip install python-pptx`).
-- Write `outline.md` **before** any python-pptx code (Process §1)
-- Verify gate: `verify()` reports no issues AND every PNG `read`
-  with the `read` tool — both required (Process §3)
-- Charts: native `add_chart()` (editable in PowerPoint). Set EA
-  typeface on every axis / legend / data label AND explicit fill
-  color on every series AND call `patch_chart_xml(chart)` after
-  every `add_chart()` — patches the bits strict-mode PowerPoint
-  rejects (doughnut/pie `endParaRPr lang`, per-slice-color `c:dPt`
-  `bubble3D`) and that other parsers silently ignore (Rendering
-  notes — Charts)
-- No `MSO_AUTO_SIZE` on titles / KPI / tags / captions (Anti-patterns)
-- `text_frame.word_wrap = True` on every text box — `False` lets the
-  shape grow horizontally past the design in strict-mode PowerPoint (Rendering
-  notes — Text-box sizing)
-- Only `.pptx` surfaces to `artifacts/` (Anti-patterns)
+- Install the toolchain before converting (the sandbox ships neither):
+  `pip install python-pptx playwright` then
+  `playwright install chromium --only-shell`
+  (add `playwright install-deps chromium` if the browser won't launch).
+- Write `outline.md` **before** any HTML (Process §1).
+- Each slide is a `<div class="slide">` sized **exactly 1280×720 px**
+  (16:9). Author at 96 px/in. **No `transform: scale()` / `zoom`** on
+  slide content — it breaks the px→inch mapping.
+- CJK decks: set `lang` on `<html>` and use the **exact** family names
+  `'Noto Sans CJK KR'` / `JP` / `SC` / `TC` (the `CJK` infix is
+  mandatory — `'Noto Sans KR'` falls back to tofu).
+- Verify gate: `verify()` reports no issues AND the contact-sheet
+  overview `read` (+ any suspect slide deep-read) — both required (§4).
+- Only the final `.pptx` (plus the `.source.html` sidecar the converter
+  auto-saves beside it) belong in `artifacts/` — your working `deck.html`,
+  intermediate PNGs, and `outline.md` stay in the working directory.
 
 ---
 
-## Process — outline first, then transcribe to pptx
+## Process — outline → HTML → convert → verify
 
-Two phases. **Separate content from layout** — write everything as
-markdown first, then transcribe into python-pptx.
+**Separate content from layout.** Write everything as markdown first,
+then author HTML, then convert.
 
 ### 1. Outline (`outline.md`) — verbatim slide content
 
-**Do not skip this step** — Step 2's verbatim transcribe rule needs
-an outline file to copy *from*; without it, content drifts back to
-free-improvisation.
+**Do not skip this step.** It is the source of truth the HTML copies
+*from*; without it, content drifts into free-improvisation.
 
-The outline contains the *actual content* that will appear on each
-slide. It's not a plan or summary — it's the source of truth. One
-section per slide, **including both bookends** — a "10 slides"
-request means 1 title + 8 content + 1 closing, *not* 10 content
-slides. Even when the prompt doesn't mention them, generate them.
-Slide format:
+One section per slide, **including both bookends** — a "10 slides"
+request means 1 title + 8 content + 1 closing, *not* 10 content slides.
+Generate the bookends even when the prompt doesn't mention them.
 
 **Slide 1 — title slide (always)**:
 - `## Slide 1: <deck title>` — e.g. `## Slide 1: Q1 2026 Business Review`
 - `**Eyebrow**` sub-line (caption-tier label, e.g. `**Pixellife Inc.**`)
-- `**Subtitle**` sub-line (one-line framing, e.g. `**For the exec meeting**`)
-- No bullets / tables / charts.
+- `**Subtitle**` sub-line (one-line framing). No bullets / tables / charts.
 
 **Slides 2 to N−1 — content slides**:
-- `## Slide N: <takeaway-headline>` — headline is a *takeaway
-  sentence* (e.g. "Revenue grew 31.7%, margin improved in step"),
-  not the topic (e.g. "Q1 results"). Becomes the slide title.
-- A **bold sub-line** for the kicker / framing label
-  (e.g. `**Executive Summary**`, `**Revenue by platform**`).
-- Data as a **markdown table** — rendered on the slide as a styled
-  table, KPI cards, or chart depending on the chosen layout.
-- Narrative points as a **bulleted list** — rendered with the deck's
-  bullet markers.
+- `## Slide N: <takeaway-headline>` — a *takeaway sentence*
+  ("Revenue grew 31.7%, margin improved in step"), not a topic
+  ("Q1 results"). Becomes the slide title.
+- A **bold sub-line** for the kicker / framing label.
+- Data as a **markdown table**; narrative as a **bulleted list**.
 - Explicit chart / visual hints inline
-  (e.g. `**Donut chart: revenue share by title**`) — rendered as
-  a native python-pptx chart (editable in PowerPoint).
+  (e.g. `**Bar chart: revenue by quarter, free vs paid**`).
 
 **Slide N — closing slide (always)**:
-- `## Slide N: <closing message>` — e.g.
-  `## Slide 10: Thank you. — Questions?`
-- No bullets / tables / charts (Action-plan variant exception aside).
+- `## Slide N: <closing message>` — e.g. `## Slide 10: Thank you. — Questions?`
+- No bullets / tables / charts (Action-plan variant aside).
 
 A 10-slide outline runs ~200–400 lines. Save as `outline.md` in the
-working directory (not under `artifacts/` — see Anti-patterns).
-Delete when done if turns share state.
+working directory (not under `artifacts/`).
 
-### 2. Transcribe outline → pptx
+### 2. Author the HTML
 
-Read each `outline.md` section and emit one slide. **Transcribe text
-verbatim — don't rewrite, paraphrase, or shorten.** Pick the layout
-grammar from the section's content shape (KPI showcase for KPI
-tables, card grid for parallel items, asymmetric split for chart +
-sidebar) and vary across the deck. Insert charts as native
-python-pptx chart objects (`add_chart`) with explicit CJK fonts and
-series colors (Rendering notes — Charts). Apply the locked palette,
-type scale, margins, and footer to every slide — consistency lives
-here, not in the content.
+Create one `deck.html` linking `components.css` (copy it from the skill
+`script/` dir next to this file, or `<link>` it by path). Pick **one**
+palette theme on `<body>` (e.g. `class="theme-corporate-slate"`) and set
+`<html lang="ko">` for Korean. Emit one `<div class="slide">` per
+`outline.md` section, transcribing text **verbatim** — don't rewrite or
+shorten. Pick the layout grammar from the section's content shape
+(styled table or compact stat row for metrics, card grid for parallel
+items, asymmetric split for chart + sidebar) and vary across the deck.
 
-### 3. Verify the output renders correctly
+`script/template.html` is a working 4-slide reference (title + metrics
+stat-row + Chart.js chart + closing) — read it once and follow its
+structure.
 
-**Gate: do not surface the `.pptx` until BOTH (A) every `verify()`
-check key is clean (lists empty, palette coverage ≥ 0.85) AND (B)
-every slide PNG has been `read`-inspected AND every flagged issue is
-fixed.** Step B is mandatory even if A is clean — the two catch
-different failures.
+**Charts carry no editability requirement** — each becomes its own
+raster picture object. Use Chart.js (`<canvas>`), inline SVG, or a static
+`<img>`. With Chart.js: set `animation:false`, use palette colors via
+`getComputedStyle(...).getPropertyValue('--secondary')`, set chart
+`font.family` to the CJK family, and set `window.__pptx_ready = true`
+after the chart paints (the converter waits for it). See `template.html`.
 
-**A. Run `verify_pptx.py`** — the skill ships a compliance checker:
+### 3. Convert to PPTX
+
+```
+python /workspace/skills/pptx/script/html2pptx.py deck.html \
+    -o /workspace/artifacts/deck.pptx
+```
+
+The converter renders each `.slide` in headless Chromium and emits a
+native object per element — text boxes (Latin **and** EA typeface on
+every run), autoshapes for simple boxes/borders/markers, a picture per
+chart/image, and a solid slide-background fill. It also auto-saves a
+self-contained copy of the source HTML (linked CSS inlined) next to the
+`.pptx` as `<out>.source.html` for review (pass `--no-keep-html` to skip;
+`--dump-json out.json` to inspect the scraped geometry).
+
+### 4. Verify the output renders correctly
+
+**Gate: do not surface the `.pptx` until BOTH (A) every `verify()` check
+is clean AND (B) the contact sheet has been `read`-inspected (plus any
+suspect slide deep-read) and every flagged issue fixed.** B is mandatory
+even if A is clean — they catch different failures.
+
+**A. Run `verify_pptx.py`:**
 
 ```python
 import sys; sys.path.insert(0, "/workspace/skills/pptx/script")
 from verify_pptx import verify, summarize
-
 issues = verify("/workspace/artifacts/deck.pptx")
 print(summarize(issues))
 ```
 
-It returns a dict with eight checks:
+Five checks, on the emitted text boxes:
 
-- `palette` — gallery match + frequency-weighted drift
-- `fonts` — runs containing CJK with no East-Asian typeface set
+- `fonts` — CJK runs with no East-Asian typeface (tofu risk)
 - `sizes` — 5+ distinct tier / out-of-tier sizes on one slide
-- `overflow` — *fixed-size* text boxes whose CJK-aware text estimate
-  exceeds the box's drawable height (autosize boxes are not checked
-  here — visual PNG inspection in Step 3.B catches their overlaps)
-- `page_numbers` — title slide (1) or closing slide (N) carrying an
-  `n / N`, `Page n`, or `n of N` string
-- `overlap` — shape pairs whose bboxes collide visually. Considers
-  every distinct-kind pair drawn from {text-box, table, chart,
-  picture, large autoshape}; same-kind container pairs (chart×chart,
-  table×table, picture×picture) are skipped as intentional side-by-
-  side layout, and layered-design pairs (text-on-card, vertically
-  stacked) are filtered out
-- `chart_strict` — chart XML that strict-mode PowerPoint rejects
-  (`<a:endParaRPr>` missing `lang` on doughnut/pie, or `<c:dPt>`
-  missing `<c:bubble3D>` for per-slice colors). Other parsers ignore
-  both, so the failure is invisible until PowerPoint opens the deck
-  and strips the chart → apparently-blank slide.
-- `word_wrap` — text frames with `word_wrap = False` whose single-line
-  text estimate exceeds the box width. In strict-mode PowerPoint the shape
-  grows horizontally past the design; soffice / Google Slides
-  force-wrap so the failure is invisible until PowerPoint opens it.
+- `page_numbers` — title (1) or closing (N) slide carrying `n / N`
+- `overlap` — text boxes whose bboxes collide (layered/stacked pairs
+  filtered out)
+- `palette` — advisory: reflects text-run colors only (shape/bg fills
+  aside), so lean on visual inspection in B
 
-`palette` returns a dict (passed when `coverage >= 0.85` against a
-gallery match); the other seven return lists (passed when empty). Use
-the *slide indices* in non-empty lists to target fixes.
+`fonts`/`sizes`/`page_numbers`/`overlap` pass when their lists are empty.
+(No `overflow`/`word_wrap` check — boxes are sized to browser-measured
+text and line breaks are frozen, so clipping/re-wrap can't happen; no
+chart check — charts are raster.) **Do not `read` `verify_pptx.py`** —
+these checks are the full contract; only read the source on an
+unexpected exception.
 
-**Do not `read` or `cat` `verify_pptx.py`** — the eight checks above
-are the full contract. Only read the source if you hit an unexpected
-exception.
-
-**B. Visual confirmation** — `verify_pptx` is heuristic. After fixing
-its flagged issues, render to PDF + PNG and look. **The image is
-pre-baked with `soffice` + LibreOffice but NOT with `pdftoppm`** —
-install `poppler-utils` first, every time, before the PNG step:
+**B. Visual confirmation** — render to PDF + PNG, montage into ONE contact
+sheet, and look. Install `poppler-utils` first (provides `pdftoppm`):
 
 ```
-apt-get install -y poppler-utils       # provides pdftoppm — not in image
-soffice --headless --convert-to pdf out.pptx
-pdftoppm -r 75 -png out.pdf slide
+apt-get install -y poppler-utils
+soffice --headless --convert-to pdf /workspace/artifacts/deck.pptx
+pdftoppm -r 75 -png deck.pdf slide
+python /workspace/skills/pptx/script/contact_sheet.py slide*.png -o contact.png
 ```
 
-**Open each PNG with the `read` tool — this loads the image into
-your multimodal vision so you actually *see* the rendered slide.**
-`ls`, `file`, `cat`, or any text-mode operation on a PNG is NOT
-inspection — confirming the file exists is not the check. Make one
-`read` call per slide PNG (`slide-1.png`, `slide-2.png`, …) and
-check every slide for **correctness**:
+**`read` `contact.png` ONCE** for a whole-deck overview, then deep-`read`
+only the individual `slide-N.png` that look off (or that verify-A / a
+converter `WARNING` flagged). Reading every slide individually is the
+biggest token cost and is unnecessary — the contact sheet shows tofu,
+empty space, misalignment, off-canvas cut-offs, and chart-color problems
+across all slides at once; zoom in only where needed. Check for
+**correctness**:
 
-- CJK tofu (`□□□`) in body, chart axes, legend, and data labels
-  (most common cause: missing EA typeface on chart elements)
-- Default PowerPoint chart colors (blue / orange / gray) leaking
-  through because a series was created without explicit fill
-- **Chart bbox overruns into narrative / insight / bullet text below
-  or beside it** (compute `insight_y` from `chart_y + chart_h + GUTTER`)
-- Overlap cases that the verify heuristic only *suspects*
-- Shape position drift / misalignment against the grid
-- Text boxes pushed out of place (clipping, shifted off-canvas)
-- Alignment imbalance across the deck (same role element sitting
-  at different x/y across consecutive slides)
+- CJK tofu (`□□□`) anywhere (most common: a text run or chart label
+  whose font family didn't resolve)
+- **Text box misplaced** — a box sitting at the wrong x/y vs its HTML
+  position (a slide looks shifted/misaligned)
+- Text clipped or pushed off-canvas
+- **Anything cut off at a slide edge.** If the converter prints
+  `WARNING: slide N … overflowing the 1280x720 canvas`, a card/shape/text
+  runs past the edge — fix the HTML so it fits (narrower columns, smaller
+  gap, less padding). Right-column grids are the usual offender.
+- Chart rendered blank or with wrong colors in the background
+- Alignment imbalance (same-role element at different x/y across slides)
 
 …and for **design quality** (`verify_pptx` cannot catch these):
 
-- Slide 1 IS a title slide pattern (anchor + three-tier text +
-  signature mark), not a content slide labeled "Title"
-- The last slide IS a closing slide pattern (mirrors the title)
-- Layouts vary across the deck — not every content slide using the
-  same division (e.g. 8 card-grids in a row = failure)
-- Palette fits the deck's subject / mood — not Corporate Slate by
-  default whenever the brief sounds "business"
+- Slide 1 IS a title pattern (anchor + three-tier text + signature mark)
+- The last slide IS a closing pattern (mirrors the title)
+- Layouts vary — not every content slide using the same division
+- **No large dead space** — content fills the canvas; the bottom third
+  isn't blank and content isn't all stacked to one side (Grid → "Fill
+  the canvas"). Tall containers around short text are the usual cause
+- Palette fits the deck's subject/mood — not Corporate Slate by default
 - Slide titles are takeaway sentences, not topic labels
-  ("Revenue grew 31.7%" ✓ / "Q1 Results" ✗)
 
-**Fix strategy depends on issue type**:
+**Fix at the source**: edit the HTML (position, size, font, content) and
+re-run the converter — there is no slide-level pptx surgery step.
 
-- **Correctness** (tofu, overlap, drift, clipping, page numbers on
-  bookends) — apply slide-level surgery directly to the `.pptx`:
+**Work in batches, not one pixel at a time.** Read all slides, list every
+issue, fix them across the HTML, then re-render **once**. Aim for **≤ 2–3
+visual passes total** — re-rendering after each tiny edit is the main
+reason a deck takes forever. In particular, **do not hand-chase CJK
+line-wrapping**: the converter **freezes the browser's exact line breaks**
+(text boxes are `word_wrap`-off with hard `<a:br/>` breaks), so
+soffice/PowerPoint render the same lines you saw in the browser — re-wrap
+and overflow can't happen. Intervene only on real layout issues
+(off-canvas overflow, element collisions, empty space).
 
-  ```python
-  from pptx import Presentation
-  from pptx.util import Inches, Pt
-  prs = Presentation("out.pptx")
-  slide = prs.slides[4]                          # slide index = N − 1
-  shape = slide.shapes[7]
-
-  # move (left, top) + resize (width, height)
-  shape.left,  shape.top    = Inches(0.8), Inches(1.8)
-  shape.width, shape.height = Inches(5.2), Inches(0.8)
-
-  # patch a text run (shorten / retype / fix font)
-  run = shape.text_frame.paragraphs[0].runs[0]
-  run.text      = "..."
-  run.font.size = Pt(14)
-
-  # remove a shape (e.g. stray page number on a bookend slide)
-  bad = slide.shapes[9]._element
-  bad.getparent().remove(bad)
-
-  prs.save("out.pptx")
-  ```
-
-  Then re-render PNG and re-verify — no full re-transcribe.
-
-- **Design quality** (bookend missing, layout monotony, palette
-  mismatch, topic-not-takeaway titles) — return to Step 1 (outline)
-  or Step 2 (transcribe), fix at the source, re-emit the deck.
-
-Loop until both `verify()` and PNG inspection pass — partial pass is
-failure.
+Loop until both A and B pass — partial pass is failure.
 
 ---
 
 ## Palette — color roles
 
-The *role structure* is fixed. The *hex values* are chosen per deck
-(matched to subject and mood) and frozen for that deck's lifetime.
+The *role structure* is fixed (and encoded as CSS variables in
+`components.css`). The *hex values* are chosen per deck (matched to
+subject and mood) and frozen for that deck's lifetime.
 
-**Colored fills** — Primary (anchor; slide titles, deepest text),
-Secondary (principal accent; left edge strip, KPI top strips, 1st
-chart series, category tags), Accent (warm pop; eyebrows, corner
-blocks, quote strip, "current" timeline marker — use sparingly).
+**Colored fills** — Primary (anchor; titles, deepest text), Secondary
+(principal accent; edge strip, card top strips, 1st chart series,
+category tags), Accent (warm pop; eyebrows, corner blocks, quote strip —
+sparingly).
 
-**Surfaces** — Background (page; near-white or near-black/navy),
-Surface (card / tile fill; subtly lifts off Background), Tinted
-Panel (Surface ~5–10% toward Accent; for callout / insight bands).
+**Surfaces** — Background (page), Surface (card/tile fill), Tinted Panel
+(Surface ~5–10% toward Accent; callout bands).
 
-**Structural** — Muted (supporting text: subtitles, captions,
-footers, axis labels), Hairline (structural lines only: dividers,
-footer line, card borders, timeline tracks).
+**Structural** — Muted (subtitles, captions, footers, axis labels),
+Hairline (dividers, footer line, card borders, tracks).
 
-**Status colors** — Positive (green, `+18%`), Negative (red, `-3d`).
-Deltas only, never a fill.
+**Status** — Positive (green, `+18%`), Negative (red, `-3d`). Deltas
+only, never a fill.
 
-**Rule of three.** Per slide, ≤ 3 colored fills from
-{Primary, Secondary, Accent}. A fourth turns it into a paint chart.
+**Rule of three.** Per slide, ≤ 3 colored fills from {Primary,
+Secondary, Accent}. A fourth turns it into a paint chart.
 
 ---
 
 ## Palette gallery — choose by feel, never default
 
-At the start of every deck:
+At the start of every deck: read the title/subject, decide the mood
+(Authoritative? Cinematic? Editorial? Playful? Academic?), and pick the
+theme whose feel matches — or compose a new one in the same style. Lock
+those nine hex values. **Match the palette to *this* deck's mood, not to
+deck history** — reaching for Corporate Slate whenever the brief says
+"business" is anchoring. **Prefer tonal/pastel siblings over pure-
+saturation primaries** (`#2563EB` not `#0000FF`).
 
-1. Read the title and subject. What mood? (Authoritative? Cinematic?
-   Editorial? Playful? Academic?)
-2. Pick the palette from below whose feel matches — or compose a new
-   one in the same style.
-3. Lock those nine hex values. Never change them mid-deck.
+Each maps to a `theme-*` class in `components.css` — the exact hex values
+live there, so apply the class (don't re-type hexes):
 
-**Match the palette to *this* deck's mood, not to deck history.** If
-you reach for Corporate Slate by default whenever the brief mentions
-"business" or "strategy," you are anchoring — re-read the deck's
-subject and pick the palette whose feel actually fits.
+- **Corporate Slate** `theme-corporate-slate` — restrained, authoritative, financial
+- **Midnight Keynote** `theme-midnight-keynote` — cinematic, bold, on-stage (dark)
+- **Warm Editorial** `theme-warm-editorial` — magazine-like, narrative, hospitable
+- **Forest Research** `theme-forest-research` — calm, considered, exact (academic)
+- **Mono Editorial** `theme-mono-editorial` — typographic, silent, luxury
+- **Playful Violet** `theme-playful-violet` — lively, contemporary, consumer
+- **Sand & Ink** `theme-sand-ink` — quiet, journalistic, considered
+- **Glacier** `theme-glacier` — clean, scientific, optimistic
 
-**Prefer tonal / pastel siblings over pure-saturation primaries.**
-Pure `#0000FF` / `#FF0000` / `#FFFF00` read as PowerPoint defaults.
-The gallery palettes already use tonal-down hues (`#2563EB` not
-`#0000FF`; `#F59E0B` not `#FFC107`); keep this when composing new.
-
----
-
-**Corporate Slate** — *restrained, authoritative, financial.* Strategy, board updates, consulting, finance.
-```
-Primary    #0F172A   Secondary #2563EB   Accent   #F59E0B
-Background #F8FAFC   Surface   #FFFFFF   Muted    #64748B
-Hairline   #E2E8F0   Positive  #10B981   Negative #EF4444
-```
-
-**Midnight Keynote** — *cinematic, bold, on-stage.* Product launch, high-energy pitch; Primary and Background collapse to deep dark.
-```
-Primary    #0B1220   Secondary #818CF8   Accent   #22D3EE
-Background #0B1220   Surface   #1F2937   Muted    #94A3B8
-Hairline   #1F2937   Positive  #34D399   Negative #F87171
-```
-
-**Warm Editorial** — *magazine-like, narrative, hospitable.* Brand, storytelling, retail / hospitality / lifestyle.
-```
-Primary    #7C2D12   Secondary #EA580C   Accent   #FACC15
-Background #FFF7ED   Surface   #FFFFFF   Muted    #9A3412
-Hairline   #FED7AA   Positive  #15803D   Negative #B91C1C
-```
-
-**Forest Research** — *calm, considered, exact.* Academic, R&D, white papers; green Secondary signals "verified" without corporate blue.
-```
-Primary    #1F2937   Secondary #047857   Accent   #D97706
-Background #FFFFFF   Surface   #F9FAFB   Muted    #6B7280
-Hairline   #E5E7EB   Positive  #059669   Negative #DC2626
-```
-
-**Mono Editorial** — *typographic, silent, luxury.* Manifesto, book chapter, design portfolio; emphasis moves to weight & italic.
-```
-Primary    #111827   Secondary #111827   Accent   #111827
-Background #FFFFFF   Surface   #FFFFFF   Muted    #6B7280
-Hairline   #E5E7EB   Positive  #059669   Negative #DC2626
-```
-
-**Playful Violet** — *lively, contemporary, consumer.* App launch, community / event, casual brand.
-```
-Primary    #4C1D95   Secondary #14B8A6   Accent   #F472B6
-Background #FAF5FF   Surface   #FFFFFF   Muted    #6D28D9
-Hairline   #E9D5FF   Positive  #16A34A   Negative #E11D48
-```
-
-**Sand & Ink** — *quiet, journalistic, considered.* Op-eds, foundation reports, slow-brand; warm neutrals + single deep ink.
-```
-Primary    #1C1917   Secondary #57534E   Accent   #B45309
-Background #FAFAF9   Surface   #FFFFFF   Muted    #78716C
-Hairline   #E7E5E4   Positive  #15803D   Negative #B91C1C
-```
-
-**Glacier** — *clean, scientific, optimistic.* Healthcare, climate-tech, data products that want modern without corporate.
-```
-Primary    #0E7490   Secondary #0891B2   Accent   #F97316
-Background #F0F9FF   Surface   #FFFFFF   Muted    #475569
-Hairline   #BAE6FD   Positive  #16A34A   Negative #DC2626
-```
-
-If none fits, compose a new palette in the same style — keep the
-role distribution, change the hue family.
+If none fits, compose a new theme in the same style (copy a block in
+`components.css`, change the hue family, keep the role distribution).
 
 ---
 
 ## Typography
 
-One title font, one body font, picked once per deck and never mixed
-with a third. Pick faces that render identically on every machine the
-deck might open on:
+One title font, one body font, picked once and never mixed with a third.
+Pick faces that render identically in the sandbox and on opener machines:
 
-- **Latin-only decks** — Calibri, Arial, or Helvetica
-- **CJK / mixed-script decks** — use `Noto Sans CJK KR` (Korean) /
-  `JP` (Japanese) / `SC` (Simplified Chinese) / `TC` (Traditional
-  Chinese). These are the family names registered by the sandbox's
-  `fonts-noto-cjk` package, so soffice-rendered PNGs match the deck
-  exactly. PowerPoint / Keynote / Google Slides fall back to the
-  host's system Korean / Japanese font when the exact name isn't
-  present. See Rendering notes for setup.
+- **Latin-only decks** — Calibri, Arial, or Helvetica.
+- **CJK / mixed-script decks** — `Noto Sans CJK KR/JP/SC/TC` (the family
+  names `fonts-noto-cjk` registers). soffice-rendered PNGs match exactly;
+  PowerPoint/Keynote fall back to the host's Korean font when the exact
+  name isn't present. The EA typeface is set on every emitted run by the
+  converter, so CJK survives the round-trip.
 
-| Size | Pt | Weight | Use |
-|---|---|---|---|
-| **Display** | 54 | Bold | Title slide, closing slide, large quotes |
-| **Title** | 32 | Bold | Slide titles, section divider titles |
-| **Body** | 18 | Regular | Bullets, paragraphs, KPI labels, narrative |
-| **Caption** | 11 | Bold UPPERCASE | Eyebrows, tags, footers, page numbers, axis labels, attribution |
+`components.css` encodes the four-step scale as `.t-display` / `.t-title`
+/ `.t-body` / `.t-caption`:
 
-Line height: titles 1.05, body 1.15. Letter-spacing on caption-tier
-only.
+| Class | Px | Pt | Weight | Use |
+|---|---|---|---|---|
+| `.t-display` | 54 | 40 | Bold | Title/closing slides, large quotes |
+| `.t-title` | 32 | 24 | Bold | Slide titles, divider titles |
+| `.t-body` | 18 | 13.5 | Regular | Bullets, paragraphs, stat labels |
+| `.t-caption` | 11 | 8 | Bold UPPERCASE | Eyebrows, tags, footers, axis labels |
 
-**Dramatic-beat sizes** sit *outside* the four-step scale and are
-allowed on top of it — they're scenography, not text hierarchy. Use
-sparingly, one per slide where the pattern calls for it: section
-divider numerals (3–4× Title), quote-slide glyph (~4× Display),
-Number Cover hero (180–250 pt). These don't count against the
-"keep the scale tight" discipline.
+(Px values are what you author; the converter scales px×0.75 → pt.)
 
-**Korean / CJK refinement.** Hangul fonts default to looser tracking
-and line-height than Latin — untuned Korean reads "floaty." For
-Korean runs: letter-spacing −1% on body, −2 to −3% on titles;
-line-height on multi-line titles 1.0–1.1 (tighter than Latin 1.05) so
-two-line Korean titles read as one visual unit.
+**Dramatic-beat sizes** sit *outside* the scale and are allowed on top
+of it — section-divider numerals (3–4× title), quote glyph (~4×
+display), Number-Cover hero (180–250 px). One per slide, sparingly.
 
-**One emphasis per slide** — bold *or* color, not both, one phrase
-max. Three emphasized things means it's actually three slides.
+**Korean/CJK refinement.** Hangul defaults to loose tracking — untuned
+Korean reads "floaty." `components.css` applies `letter-spacing −1%`
+body / `−2%` titles and tighter line-height to `:lang(ko)`. **Assume
+content-slide titles wrap to 2 lines in Korean** — leave room in the
+title band, or step the title down to ~26–28 px.
+
+**One emphasis per slide** — bold *or* color, not both, one phrase max.
 
 ---
 
-## Grid (16:9, 13.333" × 7.5")
+## Grid (1280×720 px = 13.333"×7.5", 16:9)
 
-All absolute dimensions below assume this canvas. For other slide
-sizes (4:3, 9:16, custom widths), scale *proportionally* — keep the
-same ratios of margin to content, title band to body, footer offset
-to bottom edge. The relationships are the system; the literal inches
-are just calibrated for the most common case.
+`components.css` encodes these; use the helper classes rather than
+re-deriving offsets.
 
-- Side margins 0.6" L/R, top 0.5", bottom 0.45"
-- **Title band** — top 1.1" of every content slide. Eyebrows above,
-  title inside. Body content starts at y ≈ 1.6"
-- **Footer** at y ≈ 7.1" — hairline divider + page number `n / N`
-  right (caption muted). Optional short deck title left. **Content
-  slides only** — title, section dividers, and closing slide carry
-  no footer / page number.
-- **Content area** — 12.13" × 5.0"
+- Side margins ~58 px L/R, 48 px top, 43 px bottom (`.pad`).
+- **Title band** — `.band-title`: top ~106 px of every content slide
+  (eyebrow above, title inside). Body starts y ≈ 154 px (`.body-area`).
+- **Footer** (`.footer`) — hairline + page number `n / N` right (caption
+  muted), optional deck title left. **Content slides only** — title,
+  dividers, and closing carry no footer / page number.
 
 Title slide, section dividers, quote slide, and closing slide
 intentionally break the grid — those are the dramatic beats.
 
-**Asymmetric margins by intent.** Equal margins on all four sides
-read "safely centered" — fine for academic decks, monotonous
-elsewhere. Pick *one* axis of asymmetry per deck (wider-left + tighter-
-right, or wider-bottom + tighter-top, etc.) and apply it consistently.
-Don't randomize per slide.
+**Asymmetric margins by intent.** Equal margins on all four sides read
+"safely centered" — fine for academic decks, monotonous elsewhere. Pick
+*one* axis of asymmetry per deck and apply it consistently; don't
+randomize per slide.
+
+**Fill the canvas — the most common failure.** The body area is ~500 px
+tall (y 154 → 658); short content top-aligned in it leaves a dead bottom
+third. **That blank lower band is the #1 complaint — treat it as a
+defect to fix in verify-B, not a style choice.** Use the whole 1280×720:
+
+- **Never stretch a tall container around short content.** A `.card` or
+  column that spans the full `.body-area` height but holds 3 short lines
+  leaves a dead bottom. Either **size the container to its content**
+  (let it be short) or **distribute/vertically-center** the content
+  (`justify-content: space-between` / `center`) so it uses the height.
+- Spread content across **both axes**. If the left column is full and
+  the right is empty (or top full / bottom empty), rebalance: widen
+  columns, add a supporting visual, enlarge type, or increase spacing.
+- A two-column split should have **both columns roughly balanced** in
+  height — don't put 6 bullets left and 2 right with the rest blank.
+- Prefer fewer, larger, well-spaced elements over a tight cluster
+  floating in a sea of white. Generous *balanced* whitespace is design;
+  a blank lower half is a hole.
 
 ---
 
-## Rendering notes — correctness, not style
+## Authoring notes — correctness, not style
 
-These aren't design choices; they're things python-pptx leaves to you
-that quietly ruin a deck if missed.
+These quietly ruin a deck if missed.
 
-### CJK text — set Latin + EA typeface on every run
+### Geometry — keep px→inch exact
+Slides are 1280×720 px and the converter maps 96 px → 1 inch. Anything
+that warps that mapping corrupts every position: **no** `transform`,
+`zoom`, or `devicePixelRatio` tricks on slide content. Position with
+`absolute`/flex/grid in plain px. Stack slides vertically in the
+document; the converter screenshots each `.slide` independently.
 
-`font.name` only sets the Latin typeface; the East-Asian face
-(`<a:ea>` in the run XML) stays unset and the viewer falls back to
-whatever it has. For every CJK-containing run, set both Latin and
-EA typefaces in a helper. The same applies to *chart text
-elements* — see Charts section below.
+### What becomes editable vs raster
+The converter decomposes each slide (see the four bullets at the top):
+- **Text** → editable boxes. Each *text block* (element with direct
+  text) is one box; inline children (`<b>`, `<span>`) become separate
+  runs, so keep per-run styling on the block or its inline children.
+  **Line breaks are frozen** at the browser's positions (hard `<a:br/>`,
+  auto-wrap off) so the pptx matches the browser exactly — text stays
+  editable, though typing into a box reflows only within that box.
+- **Simple shapes** → native autoshapes. An element counts as a simple
+  shape when it has a solid `background-color` and/or solid `border`(s)
+  and **no** `background-image`/gradient, `box-shadow`, or `opacity<1`.
+  Borders map to lines (uniform border → the shape's outline; a single
+  side like `border-top` → a thin bar, i.e. hairlines & card strips).
+  Bullet markers written as absolutely-positioned `::before` pseudo-
+  elements are synthesized into real autoshapes automatically.
+- **Charts / images / SVG** → each its own picture. The slide's solid
+  background becomes a native fill; only un-modelable content
+  (gradient / shadow / `opacity<1`) falls back to a base picture.
+- **SVG `<text>` / `<canvas>` text stays raster** — don't rely on chart
+  labels being editable.
+- Don't overlap text boxes you intend to stay separate. (Line breaks are
+  frozen, so soffice won't re-wrap them; `verify_pptx` + visual `read`
+  remain the safety net.)
 
-**`verify_pptx`'s `fonts` check accepts either run-level
-`<a:rPr><a:ea typeface=...>` OR paragraph-level
-`<a:pPr><a:defRPr><a:ea typeface=...>` — but not the theme
-`fontScheme`, and not python-pptx's `paragraph.font.name` API
-(which only writes `<a:latin>`, never `<a:ea>`).** The simplest
-reliable approach is run-level: walk every run and set both
-`<a:latin>` and `<a:ea>` typefaces explicitly. Paragraph-defRPr is
-fine too, but you have to write the XML yourself; you can't just
-call `paragraph.font.name = 'Noto Sans CJK KR'`.
+### CJK fonts — set the exact family
+Author CSS must use `'Noto Sans CJK KR'` (or JP/SC/TC) — the `CJK`
+infix is mandatory; `'Noto Sans KR'` will not resolve and renders tofu
+in both Chromium and soffice. The converter copies the computed
+font-family onto each run's Latin **and** EA typeface, so a correct CSS
+family is all you need. `verify_pptx`'s `fonts` check gates this.
 
-`fonts-noto-cjk` ships in the sandbox image. Use the exact family
-name fontconfig registers (with the `CJK` infix): `'Noto Sans CJK
-KR'`, `'Noto Sans CJK JP'`, `'Noto Sans CJK SC'`, or `'Noto Sans
-CJK TC'`. Other names (e.g. `'Noto Sans KR'`) will not match and
-soffice falls back to DejaVu → CJK tofu in the rendered PNGs.
+### Charts — Chart.js / SVG (own raster picture)
+Native chart editability is **not** required. Render charts however
+looks best:
+- **Chart.js** (`<canvas>`): set `animation:false`, `responsive:true`,
+  `maintainAspectRatio:false` inside a sized container; pull series
+  colors from the palette CSS variables; set `font.family` to the CJK
+  family on ticks/legend; signal `window.__pptx_ready = true` after
+  paint. (See `template.html`.)
+- **Inline SVG** or a **static `<img>`** also work and need no readiness
+  flag (but still wait on `document.fonts.ready`, which the converter
+  does).
+Max 3 series for readability; a 4th → use a table. Reserve the chart's
+box and keep narrative/insight text outside it.
 
-### Charts — native python-pptx for editability
-
-Charts are rendered as **native python-pptx chart objects**
-(`slide.shapes.add_chart(...)`) so the user can edit chart data,
-labels, and colors directly in PowerPoint (right-click → Edit Data).
-The trade-off: python-pptx leaves three critical things unhandled
-that you MUST set yourself, every time.
-
-**1. CJK font on every chart text element**
-
-`font.name` only sets Latin. Without explicit East-Asian typeface,
-PowerPoint falls back to whatever the opener has — typically tofu
-on Korean / Japanese / Chinese axes and labels. Apply EA typeface
-to every text element on the chart: category axis, value axis,
-data labels, legend, chart title.
-
-```python
-from pptx.oxml.ns import qn
-from pptx.oxml.xmlchemy import OxmlElement
-from pptx.util import Pt
-from pptx.dml.color import RGBColor
-
-def set_chart_text_font(font, typeface='Noto Sans CJK KR', size_pt=11):
-    """Set Latin + EA + CS typefaces on a chart font."""
-    font.name = typeface
-    font.size = Pt(size_pt)
-    # `font._element` IS the rPr/defRPr; don't call `.get_or_add_rPr()`.
-    rPr = font._element
-    for tag in ('latin', 'ea', 'cs'):
-        el = rPr.find(qn(f'a:{tag}'))
-        if el is None:
-            el = OxmlElement(f'a:{tag}')
-            rPr.append(el)
-        el.set('typeface', typeface)
-
-for axis in (chart.category_axis, chart.value_axis):
-    set_chart_text_font(axis.tick_labels.font, size_pt=11)
-if chart.has_legend:
-    set_chart_text_font(chart.legend.font, size_pt=11)
-if chart.has_title:
-    set_chart_text_font(
-        chart.chart_title.text_frame.paragraphs[0].runs[0].font, size_pt=14)
-for ser in chart.series:
-    if ser.data_labels:
-        set_chart_text_font(ser.data_labels.font, size_pt=11)
-```
-
-**2. Patch chart XML for strict-mode PowerPoint**
-
-python-pptx leaves two things out that strict-mode PowerPoint
-rejects (Google Slides / LibreOffice / soffice ignore them, so the
-deck looks fine until you actually open it in PowerPoint and the
-recovery dialog strips the chart, leaving an apparently-blank slide):
-
-1. **`<a:endParaRPr>` missing `lang`** — bar/line/scatter templates
-   emit `<a:endParaRPr lang="en-US"/>`, but **doughnut/pie emit
-   `<a:endParaRPr/>` with no `lang`**.
-2. **`<c:dPt>` missing `<c:bubble3D>`** — when per-slice colors are
-   set via `c:dPt` (the recommended pattern for doughnut/pie), each
-   `<c:dPt>` needs `<c:bubble3D val="0"/>` between `<c:idx>` and
-   `<c:spPr>`. The ECMA schema marks it optional; strict-mode PowerPoint
-   does not.
-
-One helper handles both, idempotently:
-
-```python
-def patch_chart_xml(chart, lang='en-US'):
-    """Add the bits strict-mode PowerPoint requires but
-    python-pptx (and per-slice-color code) leaves out. Idempotent —
-    call once per chart, right after `add_chart()`."""
-    cs = chart._chartSpace
-    for ep in cs.iter(qn('a:endParaRPr')):
-        if ep.get('lang') is None:
-            ep.set('lang', lang)
-    for dPt in cs.iter(qn('c:dPt')):
-        if dPt.find(qn('c:bubble3D')) is None:
-            b = OxmlElement('c:bubble3D'); b.set('val', '0')
-            idx_el = dPt.find(qn('c:idx'))
-            if idx_el is not None:
-                idx_el.addnext(b)
-            else:
-                dPt.insert(0, b)
-
-patch_chart_xml(chart)
-```
-
-Call once per chart, right after `add_chart()`. Cheap and idempotent.
-
-**3. Series colors must be explicit — every series, every time**
-
-Without explicit fill, python-pptx falls back to PowerPoint theme
-colors (default blue / orange / gray) — leaks regardless of the
-deck's chosen palette. Set every series:
-
-```python
-PALETTE_ORDER = ['Secondary', 'Accent', 'Primary']  # max 3 series
-for ser, role in zip(chart.series, PALETTE_ORDER):
-    hex_ = palette[role]
-    ser.format.fill.solid()
-    ser.format.fill.fore_color.rgb = RGBColor.from_string(hex_)
-    ser.format.line.color.rgb = RGBColor.from_string(hex_)
-```
-
-**Bbox + adjacency math — chart bbox and narrative bbox computed**
-
-```python
-from pptx.enum.chart import XL_CHART_TYPE
-from pptx.chart.data import CategoryChartData
-
-chart_x, chart_y, chart_w, chart_h = 0.6, 1.7, 7.5, 3.0
-GUTTER = 0.3
-insight_y = chart_y + chart_h + GUTTER   # adjacency math, computed not eyeballed
-
-data = CategoryChartData()
-data.categories = ['Q1', 'Q2', 'Q3', 'Q4']
-data.add_series('2025', (142, 158, 165, 175))
-data.add_series('2026', (187, 0, 0, 0))
-
-chart = slide.shapes.add_chart(
-    XL_CHART_TYPE.COLUMN_CLUSTERED,
-    Inches(chart_x), Inches(chart_y),
-    Inches(chart_w), Inches(chart_h),
-    data,
-).chart
-# … then apply CJK font helper + patch_chart_xml + series colors above …
-```
-
-**Supported chart types** — Column (vertical) and Bar (horizontal),
-each clustered or stacked; Line, Pie, Doughnut, Area, Scatter, Combo
-(column + line). For data that doesn't fit one of these (Treemap,
-Waterfall, Sunburst patterns) — convert to a styled table or
-decompose into a simpler chart type. Don't mix matplotlib PNGs in:
-it breaks the editability promise.
-
-**Data label format** — use PowerPoint number-format masks:
-```python
-ser.data_labels.show_value = True
-ser.data_labels.number_format = '#,##0"억 원"'    # → 187억 원
-# Or '0.0%' for percentages, '+#,##0;-#,##0' for signed deltas.
-```
-
-### Text-box sizing — fixed-height boxes, no autosize for short elements
-
-python-pptx doesn't render text; an undersized box silently clips
-when PowerPoint opens. **Design boxes generously up front; do not
-lean on autosize.** `MSO_AUTO_SIZE.SHAPE_TO_FIT_TEXT` is a trap on
-short fixed-shape elements — autogrowth overlaps neighbors and
-breaks the grid.
-
-**Set `text_frame.word_wrap = True` explicitly** on every text box.
-Explicit `False` is the failure mode: strict-mode PowerPoint respects it
-literally and grows the shape *horizontally* to fit text on one
-line, silently pushing a multi-line body or KPI description past
-the designed card edge onto neighbors. soffice / Google Slides
-force-wrap regardless so the failure is invisible until the deck
-opens in strict-mode PowerPoint. (Unset / `None` defaults to wrap-on per
-OOXML and is safe, but setting `True` makes the intent explicit and
-survives copy-paste through code that flips defaults.)
-
-Korean / CJK glyphs occupy ~2× ASCII width: a 2.5" box holds ~14
-Korean chars per line at 14 pt body, *not* 30. And CJK wraps where
-the estimator predicts one line. **For CJK decks, assume every
-content-slide title is 2 lines** — size title bands accordingly, or
-step title size 32 → 26–28 pt to fit one line reliably.
-
-Rules by element:
-- **Titles, KPI values, tags, chips, captions** — fixed height, no
-  autosize. Tag chips ≥ 0.45" tall; KPI cards ≥ 1.5". When the box
-  is taller than the text inside (KPI cards especially), set
-  `text_frame.vertical_anchor = MSO_ANCHOR.MIDDLE` — the default
-  (TOP) glues text to the top edge and leaves dead whitespace below.
-- **Bullets / body paragraphs** — size to `(line_count + 1) *
-  line_height` minimum. Estimate `line_count` inline from the
-  CJK-aware width formula above (Korean ≈ 14 chars / 2.5" at 14 pt
-  body; scale by box width and font size). Autosize allowed *only
-  here*, only with verified neighbor clearance.
-- **Hero text** (Display, Number Cover, quote glyph) — text drives
-  the box; size the box to the text.
-
-`verify_pptx`'s `overflow` check must return empty before delivery.
-Autosize-grow that overlaps a neighbor is left to visual PNG
-inspection (Step 3.B) — it's a geometric question `verify_pptx`
-deliberately doesn't try to answer.
-
-### Other pitfalls
-Every shape inherits a default shadow on creation — set
-`shape.shadow.inherit = False` on every shape or the banned effects
-sneak back. Layer order: place full-slide background, anchor blocks,
-edge strips, and card fills *before* any text or the text disappears
-under shapes drawn after it.
+### Don't fight the converter
+- One `.slide` per slide; nothing outside `.slide` is captured.
+- Hidden elements (`display:none`, `visibility:hidden`, `opacity:0`) are
+  skipped — use them for notes you don't want in the deck.
+- Fully-transparent text color is treated as "no text" — don't hide
+  real content that way.
 
 ---
 
 ## Slide patterns
 
-Pick by the slide's *job*, not by what looks pretty. Each pattern is
-a starting point — compose freshly within it, don't trace the same
-layout every deck.
+Pick by the slide's *job*, not by what looks pretty. Compose freshly
+within each — don't trace the same layout every deck.
 
-- **Title slide (slide 1)** — deck's visual signature. Anchor shape +
-  three-tier text (eyebrow caption-Accent → Display-Primary title →
-  Body-Muted subtitle) + a small Accent signature mark. **Compose
-  freshly each time**; defaulting to "filled rectangle in one corner"
-  is the AI tell. No page number.
-- **Section divider** — full-bleed Primary BG, huge numeral ("01") at
-  3–4× Title size in lightened Secondary at left, section title at
-  right (Display, white), Accent strip beneath. No page number.
-- **Content slide** — left edge strip + title band + bulleted body.
-  **4–6 bullets max** (cap at 3–4 for CJK / Korean). Title = takeaway
-  sentence, not topic.
-- **Two-column comparison** — vertical hairline split, Category tag
-  atop each column (Secondary left, Accent right), 3–5 bullets each.
-  Keep left/right meaning consistent across all comparison slides.
-  *Wins / concerns variant:* drop tags, swap markers for ✓ / ✕.
-- **KPI showcase** — 2–4 cards, 0.3" gutters. Each: Surface fill, no
-  shadow, 0.5pt Hairline border, 0.12" Secondary top strip, Display
-  value (44 pt if 4 cards) + caption-uppercase label (Muted) +
-  optional delta. Pick top-strip or left-strip orientation per deck.
-- **Quote slide** — oversized `"` glyph (≈4× Display, Accent toward
-  Background), quote at Title size ≤ 4 lines, attribution (Body,
-  Muted) right-aligned below a short Accent strip.
-- **Chart slide** — title = takeaway ("Paid users overtook free in
-  Q2"), not subject ("MAU by tier"). Native `add_chart` (see
-  Rendering notes — Charts); series palette = Secondary, Accent,
-  Primary in that order; **max 3 series** (4th → use a table). Set
-  EA typeface on every chart text element AND explicit fill on every
-  series AND call `patch_chart_xml(chart)` — otherwise CJK tofu /
-  default theme color leak / doughnut-pie slides open blank. Reserve
-  the chart bbox and compute `insight_y` from `chart_y + chart_h +
-  GUTTER` to avoid overrun.
-- **Timeline** — horizontal hairline track + 3–6 evenly-spaced event
-  markers. Period label (caption, Accent) above, milestone label
-  (Body bold, Primary) + optional caption-Muted detail below. One
-  marker may swap to Accent for "current."
-- **Closing slide (slide N)** — mirrors the title composition (same
-  palette, same shapes, position flipped — opposite corner / panel /
-  quadrant). Display message ("Thank you.", "Questions?") in the
-  title's position-equivalent. No page number. *Action-plan variant:*
-  dark Primary BG, numbered action cards left + risk bullets right +
-  bottom Accent-tinted "Decisions needed" strip.
+- **Title slide (slide 1)** — deck's visual signature: anchor shape +
+  three-tier text (eyebrow `.t-caption .c-accent` → `.t-display
+  .c-primary` title → `.t-body .c-muted` subtitle) + a small Accent
+  signature mark. Compose freshly; "filled rectangle in one corner" is
+  the AI tell. No page number.
+- **Section divider** — full-bleed Primary background, huge numeral
+  ("01") at 3–4× title in lightened Secondary left, section title right
+  (Display, Surface), Accent strip beneath. No page number.
+- **Content slide** — `.edge-strip` + `.band-title` + `.bullets` body.
+  4–6 bullets max (3–4 for CJK). Title = takeaway sentence.
+- **Two-column comparison** — vertical hairline split, category tag atop
+  each column (Secondary left, Accent right), 3–5 bullets each. Keep
+  left/right meaning consistent across all comparison slides.
+- **Metrics** — present numbers as a **styled table** or a **compact
+  inline stat row** (`.stat-row` → `.stat-value` + uppercase
+  `.stat-label` + optional `.stat-delta`). Do **not** use big "KPI
+  card" tiles — tall metric cards read as empty and monotonous. Vary
+  the metric treatment across the deck.
+- **Quote slide** — oversized `"` glyph (~4× Display, Accent toward
+  Background), quote at Title size ≤ 4 lines, attribution (Body, Muted)
+  right-aligned below a short Accent strip.
+- **Chart slide** — title = takeaway ("Paid users overtook free in Q2"),
+  not subject ("MAU by tier"). Chart in a sized container; series colors
+  from the palette; reserve the box so narrative text never overlaps it.
+- **Timeline** — horizontal hairline track + 3–6 evenly-spaced markers;
+  period label (caption, Accent) above, milestone (Body bold, Primary) +
+  caption-Muted detail below. One marker may swap to Accent for "current."
+- **Closing slide (slide N)** — mirrors the title (same palette/shapes,
+  position flipped to the opposite corner). Display message ("Thank
+  you.", "Questions?") in the title's position-equivalent. No page
+  number. *Action-plan variant:* dark Primary background, numbered action
+  cards left + risk bullets right + bottom Accent-tinted strip.
 
 ---
 
 ## Anti-patterns — refuse to ship
 
 - Text-only slide (no shapes doing work)
-- Default bullet characters (`●` `-` `>` `■`)
+- Default bullet characters (`●` `-` `>` `■`) — use `.bullets` markers
 - Third font, or 5+ sizes *from the four-step scale* on one slide
-  (dramatic-beat scenography sizes don't count)
-- Centered body text (only KPI values and divider numerals center)
+  (dramatic-beat sizes don't count)
+- Centered body text (only big stat values and divider numerals center)
+- Big "KPI card" metric tiles — use a styled table or a compact
+  `.stat-row` instead (tall metric cards read as empty / monotonous)
 - 7+ bullets on a content slide
-- Drop shadows, glow, gradients, 3D, clipart, SmartArt, curved
-  decorative lines, default PowerPoint placeholders
-- Default PowerPoint chart colors
+- Drop shadows, glow, gradients, 3D, clipart, SmartArt, default
+  PowerPoint placeholders
+- Default PowerPoint / Chart.js theme colors leaking through (always set
+  series colors from the palette)
 - Page number on title / divider / closing slides
 - Two patterns merged into one slide
-- New hex color introduced mid-deck
-- Relying on `MSO_AUTO_SIZE` for titles, KPI values, tags, captions,
-  or any short fixed-shape element (autogrowth overlaps neighbors)
-- Native `add_chart()` without explicit EA typeface on every chart
-  text element (axes / legend / data labels / title) — silent CJK
-  tofu in PowerPoint
-- Native `add_chart()` without explicit `fill.fore_color.rgb` on
-  every series — PowerPoint theme defaults (blue / orange / gray)
-  leak through and break the deck palette
-- Any `add_chart()` without `patch_chart_xml(chart)` — doughnut/pie
-  `endParaRPr` ships without `lang`, and per-slice-color `c:dPt`
-  ships without `c:bubble3D`; strict-mode PowerPoint rejects
-  either, fires the recovery dialog, and strips the chart →
-  apparently-blank slide. Other parsers ignore both, so the failure
-  is invisible until the deck opens in PowerPoint.
-- Text boxes with `word_wrap = False` — strict-mode PowerPoint grows the
-  shape horizontally past the designed width to fit text on one
-  line, pushing the text over neighboring elements. soffice / Google
-  Slides force-wrap so this is invisible in the sandbox PNG.
-- Multiple files in `artifacts/` — only the final `.pptx` belongs
-  there. Chart PNGs, verify PDFs/PNGs, helper scripts, and
-  `outline.md` all stay in the working directory.
+- New hex color introduced mid-deck (one locked theme)
+- Content extending past the 1280×720 canvas (right/bottom edge) — it
+  gets clipped and reads as "cut off"; keep every element inside
+- Relying on chart `<canvas>` / SVG text being editable — it's baked
+
+(The geometry/font/artifact hard rules at the top also still apply.)
 
 ---
 
-A quiet, consistent deck reads as designed. A loud, varied deck reads
-as assembled.
+A quiet, consistent deck reads as designed. A loud, varied deck reads as
+assembled.

--- a/agent-k/src/agents/skill/pptx/SKILL.md
+++ b/agent-k/src/agents/skill/pptx/SKILL.md
@@ -253,9 +253,12 @@ consumes them:
 **Compose like this:**
 1. Pick a **hue family from the subject's world** (its key art, packaging,
    industry, mood) — not a reflex default.
-2. Set **Background + Surface** as near-neutral members of that family (a
-   warm off-white, a cool paper, a deliberate dark) — not plain `#FFFFFF`
-   unless that's a real choice.
+2. **Background / Surface**: the ground is yours to choose from the subject —
+   white, a clean tint, or a deliberate dark all work. Keep Surface a touch
+   lighter than Background (often `#FFFFFF`) so cards read against it. The one
+   thing to avoid is a **muddy, dingy off-white** (a dull cream/beige that
+   reads "dirty" rather than intentional) — if you tint the ground, keep it
+   crisp; when in doubt, near-white reads clean.
 3. Choose **one Accent with genuine contrast** against the background.
 4. Keep hues **tonal, not pure-saturation** (`#2563EB`, not `#0000FF`).
 5. Confirm **text-on-background contrast** is comfortably readable.

--- a/agent-k/src/agents/skill/pptx/script/components.css
+++ b/agent-k/src/agents/skill/pptx/script/components.css
@@ -1,11 +1,12 @@
 /* components.css — the design-system library for HTML-authored decks.
  *
- * Link this once, pick ONE palette theme on the <body> (or per .slide),
- * and compose slides from the variables + helper classes below. The
+ * Link this once, define a per-deck palette (the nine role variables — see
+ * the palette block below and SKILL.md), then compose slides from those
+ * variables + the helper classes below. The
  * html2pptx.py converter rasterises everything except text; text becomes
  * editable PowerPoint boxes. So you may add any extra HTML/CSS/SVG/Chart.js
- * you like — this file just locks the palette, type scale, and grid so the
- * deck reads "designed, not assembled".
+ * you like — this file locks the type scale, grid, and palette ROLES (you
+ * compose the colors per deck) so the deck reads "designed, not assembled".
  *
  * HARD GEOMETRY RULES (the converter depends on these):
  *   - Every slide is exactly 1280x720 px (16:9). Authored at 96 px/in.
@@ -18,50 +19,36 @@
 /* ----------------------------------------------------------------- reset */
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
-/* --------------------------------------------------------------- palettes
- * Role structure is fixed; pick the theme whose MOOD fits the deck.
- * Apply a theme class to <body>:  <body class="theme-corporate-slate">
- * Compose a new theme by copying a block and changing the hues. */
-
-.theme-corporate-slate {            /* restrained, authoritative, financial */
-  --primary:#0F172A; --secondary:#2563EB; --accent:#F59E0B;
-  --bg:#F8FAFC; --surface:#FFFFFF; --muted:#64748B;
-  --hairline:#E2E8F0; --positive:#10B981; --negative:#EF4444;
-}
-.theme-midnight-keynote {           /* cinematic, bold, on-stage (dark) */
-  --primary:#0B1220; --secondary:#818CF8; --accent:#22D3EE;
-  --bg:#0B1220; --surface:#1F2937; --muted:#94A3B8;
-  --hairline:#1F2937; --positive:#34D399; --negative:#F87171;
-}
-.theme-warm-editorial {             /* magazine-like, narrative, hospitable */
-  --primary:#7C2D12; --secondary:#EA580C; --accent:#FACC15;
-  --bg:#FFF7ED; --surface:#FFFFFF; --muted:#9A3412;
-  --hairline:#FED7AA; --positive:#15803D; --negative:#B91C1C;
-}
-.theme-forest-research {            /* calm, considered, exact (academic) */
-  --primary:#1F2937; --secondary:#047857; --accent:#D97706;
-  --bg:#FFFFFF; --surface:#F9FAFB; --muted:#6B7280;
-  --hairline:#E5E7EB; --positive:#059669; --negative:#DC2626;
-}
-.theme-mono-editorial {             /* typographic, silent, luxury */
-  --primary:#111827; --secondary:#111827; --accent:#111827;
-  --bg:#FFFFFF; --surface:#FFFFFF; --muted:#6B7280;
-  --hairline:#E5E7EB; --positive:#059669; --negative:#DC2626;
-}
-.theme-playful-violet {             /* lively, contemporary, consumer */
-  --primary:#4C1D95; --secondary:#14B8A6; --accent:#F472B6;
-  --bg:#FAF5FF; --surface:#FFFFFF; --muted:#6D28D9;
-  --hairline:#E9D5FF; --positive:#16A34A; --negative:#E11D48;
-}
-.theme-sand-ink {                   /* quiet, journalistic, considered */
-  --primary:#1C1917; --secondary:#57534E; --accent:#B45309;
-  --bg:#FAFAF9; --surface:#FFFFFF; --muted:#78716C;
-  --hairline:#E7E5E4; --positive:#15803D; --negative:#B91C1C;
-}
-.theme-glacier {                    /* clean, scientific, optimistic */
-  --primary:#0E7490; --secondary:#0891B2; --accent:#F97316;
-  --bg:#F0F9FF; --surface:#FFFFFF; --muted:#475569;
-  --hairline:#BAE6FD; --positive:#16A34A; --negative:#DC2626;
+/* ----------------------------------------------------------- palette roles
+ * COMPOSE a palette PER DECK from its subject (see SKILL.md "Palette") and
+ * define the nine role variables ONCE at the top of your deck, inside a
+ * style block in <head>. Do NOT reuse a stock set — colors derived from the
+ * subject are what make a deck its own. Fill every <...> with a real hex
+ * DERIVED FROM THE SUBJECT; these are placeholders, not a palette — don't
+ * ship them and don't copy a previous deck's palette (two decks on the same
+ * set look identical):
+ *
+ *       :root{
+ *         --primary:<deepest subject hue>;    --secondary:<principal accent>;
+ *         --accent:<one contrasting pop>;     --bg:<near-neutral of the family>;
+ *         --surface:<card fill>;              --muted:<quiet gray>;
+ *         --hairline:<faint rule>;            --positive:#16804A; --negative:#B23A30;
+ *       }
+ *
+ * Roles — primary: anchor / titles / deepest text · secondary: principal
+ * accent (edge strip, strips, 1st chart series, tags) · accent: one warm or
+ * contrasting pop (eyebrows, signature; use sparingly) · bg: page · surface:
+ * card / tile fill · muted: subtitles / captions / axis labels · hairline:
+ * dividers / borders · positive / negative: green / red deltas only.
+ * Rule of three: ≤ 3 colored fills per slide. Keep hues tonal (avoid pure
+ * saturation), and keep text-on-bg contrast clearly readable.
+ *
+ * The values below are an INERT neutral fallback so an unset deck still
+ * renders — always OVERRIDE them per deck with your composed palette. */
+:root{
+  --primary:#1B1B1B;  --secondary:#444444;  --accent:#B5532A;
+  --bg:#FAFAF8;       --surface:#FFFFFF;    --muted:#6B6B6B;
+  --hairline:#E4E2DC; --positive:#2F7D4F;   --negative:#B23A30;
 }
 
 /* ----------------------------------------------------------------- canvas

--- a/agent-k/src/agents/skill/pptx/script/components.css
+++ b/agent-k/src/agents/skill/pptx/script/components.css
@@ -1,0 +1,144 @@
+/* components.css — the design-system library for HTML-authored decks.
+ *
+ * Link this once, pick ONE palette theme on the <body> (or per .slide),
+ * and compose slides from the variables + helper classes below. The
+ * html2pptx.py converter rasterises everything except text; text becomes
+ * editable PowerPoint boxes. So you may add any extra HTML/CSS/SVG/Chart.js
+ * you like — this file just locks the palette, type scale, and grid so the
+ * deck reads "designed, not assembled".
+ *
+ * HARD GEOMETRY RULES (the converter depends on these):
+ *   - Every slide is exactly 1280x720 px (16:9). Authored at 96 px/in.
+ *   - No `transform: scale()` / `zoom` on slide content (breaks px->inch).
+ *   - Use the CJK family names with the `CJK` infix exactly:
+ *       'Noto Sans CJK KR' / 'JP' / 'SC' / 'TC'
+ *     ('Noto Sans KR' will NOT match in the sandbox → tofu).
+ */
+
+/* ----------------------------------------------------------------- reset */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+/* --------------------------------------------------------------- palettes
+ * Role structure is fixed; pick the theme whose MOOD fits the deck.
+ * Apply a theme class to <body>:  <body class="theme-corporate-slate">
+ * Compose a new theme by copying a block and changing the hues. */
+
+.theme-corporate-slate {            /* restrained, authoritative, financial */
+  --primary:#0F172A; --secondary:#2563EB; --accent:#F59E0B;
+  --bg:#F8FAFC; --surface:#FFFFFF; --muted:#64748B;
+  --hairline:#E2E8F0; --positive:#10B981; --negative:#EF4444;
+}
+.theme-midnight-keynote {           /* cinematic, bold, on-stage (dark) */
+  --primary:#0B1220; --secondary:#818CF8; --accent:#22D3EE;
+  --bg:#0B1220; --surface:#1F2937; --muted:#94A3B8;
+  --hairline:#1F2937; --positive:#34D399; --negative:#F87171;
+}
+.theme-warm-editorial {             /* magazine-like, narrative, hospitable */
+  --primary:#7C2D12; --secondary:#EA580C; --accent:#FACC15;
+  --bg:#FFF7ED; --surface:#FFFFFF; --muted:#9A3412;
+  --hairline:#FED7AA; --positive:#15803D; --negative:#B91C1C;
+}
+.theme-forest-research {            /* calm, considered, exact (academic) */
+  --primary:#1F2937; --secondary:#047857; --accent:#D97706;
+  --bg:#FFFFFF; --surface:#F9FAFB; --muted:#6B7280;
+  --hairline:#E5E7EB; --positive:#059669; --negative:#DC2626;
+}
+.theme-mono-editorial {             /* typographic, silent, luxury */
+  --primary:#111827; --secondary:#111827; --accent:#111827;
+  --bg:#FFFFFF; --surface:#FFFFFF; --muted:#6B7280;
+  --hairline:#E5E7EB; --positive:#059669; --negative:#DC2626;
+}
+.theme-playful-violet {             /* lively, contemporary, consumer */
+  --primary:#4C1D95; --secondary:#14B8A6; --accent:#F472B6;
+  --bg:#FAF5FF; --surface:#FFFFFF; --muted:#6D28D9;
+  --hairline:#E9D5FF; --positive:#16A34A; --negative:#E11D48;
+}
+.theme-sand-ink {                   /* quiet, journalistic, considered */
+  --primary:#1C1917; --secondary:#57534E; --accent:#B45309;
+  --bg:#FAFAF9; --surface:#FFFFFF; --muted:#78716C;
+  --hairline:#E7E5E4; --positive:#15803D; --negative:#B91C1C;
+}
+.theme-glacier {                    /* clean, scientific, optimistic */
+  --primary:#0E7490; --secondary:#0891B2; --accent:#F97316;
+  --bg:#F0F9FF; --surface:#FFFFFF; --muted:#475569;
+  --hairline:#BAE6FD; --positive:#16A34A; --negative:#DC2626;
+}
+
+/* ----------------------------------------------------------------- canvas
+ * One slide = one 1280x720 box. Stack slides vertically in the document;
+ * the converter screenshots each .slide separately. */
+body { background:#525659; }        /* viewer chrome only — never captured */
+
+.slide {
+  position: relative;
+  width: 1280px;
+  height: 720px;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--primary);
+  font-family: 'Noto Sans CJK KR', Calibri, Arial, sans-serif;
+  margin: 24px auto;                /* gap between slides in the viewer */
+}
+
+/* ------------------------------------------------------------ type scale
+ * Four steps only. Dramatic-beat sizes (divider numerals, hero numbers,
+ * quote glyphs) sit OUTSIDE the scale and are allowed on top of it. */
+.t-display { font-size: 54px; font-weight: 700; line-height: 1.05; }
+.t-title   { font-size: 32px; font-weight: 700; line-height: 1.05; }
+.t-body    { font-size: 18px; font-weight: 400; line-height: 1.15; }
+.t-caption { font-size: 11px; font-weight: 700; line-height: 1.2;
+             text-transform: uppercase; letter-spacing: 0.06em; }
+
+/* Korean reads "floaty" untuned — tighten tracking/leading on CJK runs. */
+:lang(ko) .t-title, :lang(ko) .t-display { letter-spacing: -0.02em; line-height: 1.05; }
+:lang(ko) .t-body { letter-spacing: -0.01em; }
+
+/* ------------------------------------------------------------------- grid
+ * Content area inside margins: 0.6" L/R, 0.5" T, 0.45" B → in px:
+ * L/R 57.6, T 48, B 43.2. Title band ~1.1" (106px). Body starts y~154px. */
+.pad   { padding: 48px 58px 43px; }
+.band-title { position:absolute; left:58px; right:58px; top:48px; }
+.body-area  { position:absolute; left:58px; right:58px; top:154px; bottom:62px; }
+
+/* color helpers */
+.c-primary{color:var(--primary)} .c-secondary{color:var(--secondary)}
+.c-accent{color:var(--accent)}   .c-muted{color:var(--muted)}
+.c-surface{color:var(--surface)} .c-positive{color:var(--positive)}
+.c-negative{color:var(--negative)}
+.bg-primary{background:var(--primary)} .bg-secondary{background:var(--secondary)}
+.bg-accent{background:var(--accent)}   .bg-surface{background:var(--surface)}
+
+/* ------------------------------------------------------- shape vocabulary
+ * These do "work" so slides are never text-only. */
+.edge-strip { position:absolute; left:0; top:0; bottom:0; width:8px;
+              background:var(--secondary); }
+.hairline   { border:none; border-top:1px solid var(--hairline); }
+.card       { background:var(--surface); border:1px solid var(--hairline);
+              border-radius:8px; }
+.card-strip { border-top:4px solid var(--secondary); }   /* on a .card */
+.tag        { display:inline-block; padding:5px 12px; border-radius:999px;
+              background:var(--secondary); color:var(--surface);
+              font-size:11px; font-weight:700; text-transform:uppercase;
+              letter-spacing:0.06em; }
+
+/* Metrics — use a styled table or this COMPACT inline stat row.
+ * (No big "KPI cards": tall metric tiles read as empty and monotonous.) */
+.stat-row   { display:flex; gap:56px; align-items:flex-start; }
+.stat-value { font-size:40px; font-weight:700; color:var(--primary); line-height:1; }
+.stat-label { font-size:11px; font-weight:700; text-transform:uppercase;
+              letter-spacing:0.06em; color:var(--muted); margin-top:10px; }
+.stat-delta { font-size:14px; font-weight:700; margin-top:6px; }
+
+/* bullets with markers that do work (no default • - > ■) */
+.bullets { list-style:none; }
+.bullets li { position:relative; padding-left:22px; margin-bottom:12px;
+              font-size:18px; line-height:1.3; }
+.bullets li::before { content:''; position:absolute; left:0; top:9px;
+              width:8px; height:8px; background:var(--accent); border-radius:2px; }
+
+/* footer (content slides only — never on title/divider/closing) */
+.footer { position:absolute; left:58px; right:58px; bottom:30px;
+          display:flex; justify-content:space-between; align-items:center;
+          border-top:1px solid var(--hairline); padding-top:8px;
+          font-size:11px; font-weight:700; text-transform:uppercase;
+          letter-spacing:0.06em; color:var(--muted); }

--- a/agent-k/src/agents/skill/pptx/script/components.css
+++ b/agent-k/src/agents/skill/pptx/script/components.css
@@ -5,8 +5,9 @@
  * variables + the helper classes below. The
  * html2pptx.py converter rasterises everything except text; text becomes
  * editable PowerPoint boxes. So you may add any extra HTML/CSS/SVG/Chart.js
- * you like — this file locks the type scale, grid, and palette ROLES (you
- * compose the colors per deck) so the deck reads "designed, not assembled".
+ * you like — this file fixes the grid and the palette/type-scale ROLES (you
+ * compose the colors and sizes per deck) so the deck reads "designed, not
+ * assembled".
  *
  * HARD GEOMETRY RULES (the converter depends on these):
  *   - Every slide is exactly 1280x720 px (16:9). Authored at 96 px/in.
@@ -20,13 +21,10 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 /* ----------------------------------------------------------- palette roles
- * COMPOSE a palette PER DECK from its subject (see SKILL.md "Palette") and
- * define the nine role variables ONCE at the top of your deck, inside a
- * style block in <head>. Do NOT reuse a stock set — colors derived from the
- * subject are what make a deck its own. Fill every <...> with a real hex
- * DERIVED FROM THE SUBJECT; these are placeholders, not a palette — don't
- * ship them and don't copy a previous deck's palette (two decks on the same
- * set look identical):
+ * Compose a 9-role palette PER DECK (rules in SKILL.md "Palette") and define
+ * these variables ONCE in a <style> in your deck's <head>. Fill every <...>
+ * with a real hex derived from the subject — these are placeholders, not a
+ * palette to ship:
  *
  *       :root{
  *         --primary:<deepest subject hue>;    --secondary:<principal accent>;
@@ -35,20 +33,17 @@
  *         --hairline:<faint rule>;            --positive:#16804A; --negative:#B23A30;
  *       }
  *
- * Roles — primary: anchor / titles / deepest text · secondary: principal
- * accent (edge strip, strips, 1st chart series, tags) · accent: one warm or
- * contrasting pop (eyebrows, signature; use sparingly) · bg: page · surface:
- * card / tile fill · muted: subtitles / captions / axis labels · hairline:
- * dividers / borders · positive / negative: green / red deltas only.
- * Rule of three: ≤ 3 colored fills per slide. Keep hues tonal (avoid pure
- * saturation), and keep text-on-bg contrast clearly readable.
- *
  * The values below are an INERT neutral fallback so an unset deck still
- * renders — always OVERRIDE them per deck with your composed palette. */
+ * renders — always OVERRIDE them per deck. */
 :root{
   --primary:#1B1B1B;  --secondary:#444444;  --accent:#B5532A;
   --bg:#FAFAF8;       --surface:#FFFFFF;    --muted:#6B6B6B;
   --hairline:#E4E2DC; --positive:#2F7D4F;   --negative:#B23A30;
+  /* Type scale — COMPOSE per deck (see SKILL.md "Type scale"): set these four
+   * to fit the deck's density (dense data → smaller, sparse/exec → larger),
+   * then leave them locked. Ranges: display 48–72 / title 30–44 / body 18–24
+   * / caption 10–13 px. These slide-appropriate defaults apply if unset. */
+  --fs-display:60px;  --fs-title:38px;  --fs-body:20px;  --fs-caption:12px;
 }
 
 /* ----------------------------------------------------------------- canvas
@@ -68,12 +63,13 @@ body { background:#525659; }        /* viewer chrome only — never captured */
 }
 
 /* ------------------------------------------------------------ type scale
- * Four steps only. Dramatic-beat sizes (divider numerals, hero numbers,
- * quote glyphs) sit OUTSIDE the scale and are allowed on top of it. */
-.t-display { font-size: 54px; font-weight: 700; line-height: 1.05; }
-.t-title   { font-size: 32px; font-weight: 700; line-height: 1.05; }
-.t-body    { font-size: 18px; font-weight: 400; line-height: 1.15; }
-.t-caption { font-size: 11px; font-weight: 700; line-height: 1.2;
+ * Four steps only, sizes from the per-deck variables above. Dramatic-beat
+ * sizes (divider numerals, hero numbers, quote glyphs) sit OUTSIDE the scale
+ * and are allowed on top of it. */
+.t-display { font-size: var(--fs-display); font-weight: 700; line-height: 1.05; }
+.t-title   { font-size: var(--fs-title);   font-weight: 700; line-height: 1.05; }
+.t-body    { font-size: var(--fs-body);    font-weight: 400; line-height: 1.15; }
+.t-caption { font-size: var(--fs-caption); font-weight: 700; line-height: 1.2;
              text-transform: uppercase; letter-spacing: 0.06em; }
 
 /* Korean reads "floaty" untuned — tighten tracking/leading on CJK runs. */
@@ -105,21 +101,21 @@ body { background:#525659; }        /* viewer chrome only — never captured */
 .card-strip { border-top:4px solid var(--secondary); }   /* on a .card */
 .tag        { display:inline-block; padding:5px 12px; border-radius:999px;
               background:var(--secondary); color:var(--surface);
-              font-size:11px; font-weight:700; text-transform:uppercase;
+              font-size:var(--fs-caption); font-weight:700; text-transform:uppercase;
               letter-spacing:0.06em; }
 
 /* Metrics — use a styled table or this COMPACT inline stat row.
  * (No big "KPI cards": tall metric tiles read as empty and monotonous.) */
 .stat-row   { display:flex; gap:56px; align-items:flex-start; }
 .stat-value { font-size:40px; font-weight:700; color:var(--primary); line-height:1; }
-.stat-label { font-size:11px; font-weight:700; text-transform:uppercase;
+.stat-label { font-size:var(--fs-caption); font-weight:700; text-transform:uppercase;
               letter-spacing:0.06em; color:var(--muted); margin-top:10px; }
 .stat-delta { font-size:14px; font-weight:700; margin-top:6px; }
 
 /* bullets with markers that do work (no default • - > ■) */
 .bullets { list-style:none; }
 .bullets li { position:relative; padding-left:22px; margin-bottom:12px;
-              font-size:18px; line-height:1.3; }
+              font-size:var(--fs-body); line-height:1.3; }
 .bullets li::before { content:''; position:absolute; left:0; top:9px;
               width:8px; height:8px; background:var(--accent); border-radius:2px; }
 
@@ -127,5 +123,5 @@ body { background:#525659; }        /* viewer chrome only — never captured */
 .footer { position:absolute; left:58px; right:58px; bottom:30px;
           display:flex; justify-content:space-between; align-items:center;
           border-top:1px solid var(--hairline); padding-top:8px;
-          font-size:11px; font-weight:700; text-transform:uppercase;
+          font-size:var(--fs-caption); font-weight:700; text-transform:uppercase;
           letter-spacing:0.06em; color:var(--muted); }

--- a/agent-k/src/agents/skill/pptx/script/components.css
+++ b/agent-k/src/agents/skill/pptx/script/components.css
@@ -59,6 +59,7 @@ body { background:#525659; }        /* viewer chrome only — never captured */
   background: var(--bg);
   color: var(--primary);
   font-family: 'Noto Sans CJK KR', Calibri, Arial, sans-serif;
+  word-break: keep-all;             /* break Korean at word (space) boundaries — never split a syllable run like "배|송" */
   margin: 24px auto;                /* gap between slides in the viewer */
 }
 

--- a/agent-k/src/agents/skill/pptx/script/contact_sheet.py
+++ b/agent-k/src/agents/skill/pptx/script/contact_sheet.py
@@ -1,0 +1,86 @@
+"""contact_sheet.py — montage slide PNGs into ONE labelled grid image.
+
+The verify-B visual pass is the most token-expensive step: reading every
+slide PNG individually is N multimodal inputs. Instead, build one contact
+sheet, `read` it ONCE for the whole-deck overview (tofu, empty space,
+alignment, off-canvas, chart colors), then deep-`read` only the slides that
+look suspect. Cuts vision inputs ~N→1 for the overview pass.
+
+Usage (Pillow ships with python-pptx, so no extra install):
+    python contact_sheet.py slide-1.png slide-2.png ... -o contact.png
+    python contact_sheet.py --glob "slide*.png" -o contact.png --cols 3
+
+Each cell is labelled with its slide number so you can say "deep-read
+slide 7" and map it back to `slide-7.png`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob as globmod
+import re
+import sys
+from pathlib import Path
+
+
+def _natkey(p: str):
+    """Sort slide-2.png before slide-10.png (natural numeric order)."""
+    nums = re.findall(r"\d+", Path(p).name)
+    return (int(nums[-1]) if nums else 0, p)
+
+
+def build(paths: list[str], out: str, cols: int, thumb_w: int, pad: int = 16) -> int:
+    from PIL import Image, ImageDraw
+
+    paths = sorted(paths, key=_natkey)
+    if not paths:
+        print("contact_sheet: no input images", file=sys.stderr)
+        return 2
+
+    thumbs = []
+    for p in paths:
+        im = Image.open(p).convert("RGB")
+        h = max(1, round(thumb_w * im.height / im.width))
+        thumbs.append(im.resize((thumb_w, h), Image.LANCZOS))
+
+    cell_w = thumb_w
+    cell_h = max(t.height for t in thumbs)
+    label_h = 26
+    rows = (len(thumbs) + cols - 1) // cols
+    W = pad + cols * (cell_w + pad)
+    H = pad + rows * (cell_h + label_h + pad)
+
+    sheet = Image.new("RGB", (W, H), (82, 86, 89))   # neutral gray gutter
+    draw = ImageDraw.Draw(sheet)
+    for i, t in enumerate(thumbs):
+        r, c = divmod(i, cols)
+        x = pad + c * (cell_w + pad)
+        y = pad + r * (cell_h + label_h + pad)
+        draw.text((x + 2, y), f"slide {i + 1}", fill=(255, 255, 255))
+        sheet.paste(t, (x, y + label_h))
+
+    Path(out).parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(out)
+    print(f"wrote {out} — {len(thumbs)} slides, {cols} cols, {W}x{H}px")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Montage slide PNGs into one contact sheet.")
+    ap.add_argument("images", nargs="*", help="slide PNG paths")
+    ap.add_argument("--glob", default=None, help="glob pattern instead of explicit paths")
+    ap.add_argument("-o", "--out", default="contact.png", help="output PNG (default contact.png)")
+    ap.add_argument("--cols", type=int, default=3, help="columns (default 3)")
+    ap.add_argument("--thumb-w", type=int, default=560, help="per-slide thumbnail width px (default 560)")
+    args = ap.parse_args(argv)
+
+    paths = list(args.images)
+    if args.glob:
+        paths += globmod.glob(args.glob)
+    if not paths:
+        ap.error("provide image paths or --glob")
+    return build(paths, args.out, args.cols, args.thumb_w)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-k/src/agents/skill/pptx/script/contact_sheet.py
+++ b/agent-k/src/agents/skill/pptx/script/contact_sheet.py
@@ -1,40 +1,48 @@
-"""contact_sheet.py — montage slide PNGs into ONE labelled grid image.
+"""contact_sheet.py — render a deck PDF into ONE labelled grid for visual QA.
 
 The verify-B visual pass is the most token-expensive step: reading every
-slide PNG individually is N multimodal inputs. Instead, build one contact
-sheet, `read` it ONCE for the whole-deck overview (tofu, empty space,
-alignment, off-canvas, chart colors), then deep-`read` only the slides that
-look suspect. Cuts vision inputs ~N→1 for the overview pass.
+slide individually is N multimodal inputs. Instead build one contact sheet,
+`read` it ONCE for the whole-deck overview (tofu, empty space, alignment,
+off-canvas, chart colors), then deep-`read` only the slides that look suspect.
 
-Usage (Pillow ships with python-pptx, so no extra install):
-    python contact_sheet.py slide-1.png slide-2.png ... -o contact.png
-    python contact_sheet.py --glob "slide*.png" -o contact.png --cols 3
+    python contact_sheet.py deck.pdf -o contact.png
 
-Each cell is labelled with its slide number so you can say "deep-read
-slide 7" and map it back to `slide-7.png`.
+Renders each PDF page with pypdfium2, writing a slide-N.png beside the PDF
+(so "deep-read slide 7" maps to slide-7.png) and montaging them into one
+sheet with each cell labelled by slide number.
 """
 
 from __future__ import annotations
 
 import argparse
-import glob as globmod
-import re
 import sys
 from pathlib import Path
 
 
-def _natkey(p: str):
-    """Sort slide-2.png before slide-10.png (natural numeric order)."""
-    nums = re.findall(r"\d+", Path(p).name)
-    return (int(nums[-1]) if nums else 0, p)
+def render_pdf(pdf_path: str, dpi: int) -> list[str]:
+    """Render each page to slide-N.png (1-based) beside the PDF; return paths."""
+    import pypdfium2 as pdfium
+
+    pdf = pdfium.PdfDocument(pdf_path)
+    scale = dpi / 72.0
+    out_dir = Path(pdf_path).parent
+    paths = []
+    try:
+        for i in range(len(pdf)):
+            img = pdf[i].render(scale=scale).to_pil()
+            out = out_dir / f"slide-{i + 1}.png"
+            img.save(out)
+            paths.append(str(out))
+    finally:
+        pdf.close()
+    return paths
 
 
 def build(paths: list[str], out: str, cols: int, thumb_w: int, pad: int = 16) -> int:
     from PIL import Image, ImageDraw
 
-    paths = sorted(paths, key=_natkey)
     if not paths:
-        print("contact_sheet: no input images", file=sys.stderr)
+        print("contact_sheet: no pages to montage", file=sys.stderr)
         return 2
 
     thumbs = []
@@ -66,20 +74,14 @@ def build(paths: list[str], out: str, cols: int, thumb_w: int, pad: int = 16) ->
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description="Montage slide PNGs into one contact sheet.")
-    ap.add_argument("images", nargs="*", help="slide PNG paths")
-    ap.add_argument("--glob", default=None, help="glob pattern instead of explicit paths")
+    ap = argparse.ArgumentParser(description="Render a deck PDF into one labelled contact sheet.")
+    ap.add_argument("pdf", help="the soffice-produced deck PDF")
     ap.add_argument("-o", "--out", default="contact.png", help="output PNG (default contact.png)")
     ap.add_argument("--cols", type=int, default=3, help="columns (default 3)")
     ap.add_argument("--thumb-w", type=int, default=560, help="per-slide thumbnail width px (default 560)")
+    ap.add_argument("--dpi", type=int, default=75, help="PDF render resolution (default 75)")
     args = ap.parse_args(argv)
-
-    paths = list(args.images)
-    if args.glob:
-        paths += globmod.glob(args.glob)
-    if not paths:
-        ap.error("provide image paths or --glob")
-    return build(paths, args.out, args.cols, args.thumb_w)
+    return build(render_pdf(args.pdf, args.dpi), args.out, args.cols, args.thumb_w)
 
 
 if __name__ == "__main__":

--- a/agent-k/src/agents/skill/pptx/script/html2pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/html2pptx.py
@@ -122,7 +122,9 @@ SCRAPE_SLIDE_JS = r"""
     return true;
   };
   const isSvgInternal = (el) => !!el.ownerSVGElement;        // inside an <svg>
-  const isMedia = (el) => ['CANVAS', 'IMG', 'SVG'].includes(el.tagName) && !el.ownerSVGElement;
+  // NB: an inline <svg> reports tagName "svg" (lowercase, not HTML-uppercased),
+  // so compare case-insensitively or SVG charts are silently dropped.
+  const isMedia = (el) => ['CANVAS', 'IMG', 'SVG'].includes((el.tagName || '').toUpperCase()) && !el.ownerSVGElement;
 
   const pics = [], shapes = [], texts = [];
   let order = 0;
@@ -223,7 +225,15 @@ SCRAPE_SLIDE_JS = r"""
             right: Math.max(bb.right, rr.right), bottom: Math.max(bb.bottom, rr.bottom),
           } : { left: rr.left, top: rr.top, right: rr.right, bottom: rr.bottom };
         };
-        const segs = [];   // ordered {text, top, style}
+        // Two vertical spans are on the same visual line when they overlap by
+        // more than half the shorter span's height. Same-line size mixes overlap
+        // ~fully (~1.0); even tight-leading wraps overlap little (≲0.15).
+        const samELine = (t1, b1, t2, b2) => {
+          const ov = Math.min(b1, b2) - Math.max(t1, t2);
+          const minH = Math.min(b1 - t1, b2 - t2);
+          return minH > 0 && ov > 0.5 * minH;
+        };
+        const segs = [];   // ordered {text, top, bottom, style}
         const addText = (tn, styleEl) => {
           const s = tn.textContent;
           if (!s) return;
@@ -231,20 +241,29 @@ SCRAPE_SLIDE_JS = r"""
           if (col0 && col0.a < 0.1) return;   // fully-transparent text → no text
           const st = mkStyle(styleEl);
           const rg = document.createRange();
-          let lineStart = 0, curTop = null;
+          let lineStart = 0, curTop = null, curBot = null;
           for (let i = 0; i < s.length; i++) {
             rg.setStart(tn, i); rg.setEnd(tn, i + 1);
             const rects = rg.getClientRects();
             if (!rects.length) continue;
             grow(rects[0]);
-            const top = Math.round(rects[0].top);
-            if (curTop === null) curTop = top;
-            else if (Math.abs(top - curTop) > 2) {
-              segs.push({ text: s.slice(lineStart, i), top: curTop, style: st });
-              lineStart = i; curTop = top;
+            const top = rects[0].top, bot = rects[0].bottom;
+            if (curTop === null) { curTop = top; curBot = bot; }
+            // A real wrap drops to a new line, so the glyph barely overlaps the
+            // current line vertically. A different font size on the SAME line
+            // overlaps heavily (the small run sits inside the tall one), so we
+            // split on overlap FRACTION, not on a raw top change — that keeps a
+            // big number + small unit on one line yet still catches tight-leading
+            // wraps that a plain band-overlap test would wrongly merge.
+            else if (samELine(top, bot, curTop, curBot)) {
+              curTop = Math.min(curTop, top); curBot = Math.max(curBot, bot);
+            } else {
+              segs.push({ text: s.slice(lineStart, i), top: curTop, bottom: curBot, style: st });
+              lineStart = i; curTop = top; curBot = bot;
             }
           }
-          segs.push({ text: s.slice(lineStart), top: curTop === null ? 0 : curTop, style: st });
+          segs.push({ text: s.slice(lineStart), top: curTop === null ? 0 : curTop,
+                      bottom: curBot === null ? 0 : curBot, style: st });
         };
         for (const n of el.childNodes) {
           if (n.nodeType === 3) { if (n.textContent.trim()) addText(n, el); }
@@ -254,15 +273,22 @@ SCRAPE_SLIDE_JS = r"""
               if (m.nodeType === 3 && m.textContent.trim()) { addText(m, n); any = true; }
             if (!any && n.textContent.trim()) {
               const rr = n.getBoundingClientRect(); grow(rr);
-              segs.push({ text: n.textContent, top: Math.round(rr.top), style: mkStyle(n) });
+              segs.push({ text: n.textContent, top: Math.round(rr.top),
+                          bottom: Math.round(rr.bottom), style: mkStyle(n) });
             }
           }
         }
         if (segs.length && bb) {
-          // Group segments into lines by y-top; merge adjacent same-style runs.
-          const rawLines = []; let cur = null, curTop = null;
+          // Group segments into visual lines by the same overlap-fraction test,
+          // then merge adjacent same-style runs. A big number + a small unit
+          // span share a line (heavy overlap); a real wrap starts a new one.
+          const rawLines = []; let cur = null, curTop = null, curBot = null;
           for (const sg of segs) {
-            if (curTop === null || Math.abs(sg.top - curTop) > 2) { cur = []; rawLines.push(cur); curTop = sg.top; }
+            if (cur !== null && samELine(sg.top, sg.bottom, curTop, curBot)) {
+              curTop = Math.min(curTop, sg.top); curBot = Math.max(curBot, sg.bottom);
+            } else {
+              cur = []; rawLines.push(cur); curTop = sg.top; curBot = sg.bottom;
+            }
             const last = cur[cur.length - 1];
             if (last && JSON.stringify(last.style) === JSON.stringify(sg.style)) last.text += sg.text;
             else cur.push({ text: sg.text, style: sg.style });
@@ -576,7 +602,12 @@ def _export_source_html(html_path: Path, out_path: Path) -> None:
         css = base / href.group(1)
         if not css.exists():
             return tag
-        return f"<style>\n{css.read_text(encoding='utf-8')}\n</style>"
+        text = css.read_text(encoding="utf-8")
+        # An inlined <style> is terminated by the FIRST "</style>" the HTML
+        # parser sees — even inside a CSS comment. Neutralize any such literal
+        # so the inlined stylesheet can't close itself early and break the page.
+        text = re.sub(r"</\s*style", r"<\\/style", text, flags=re.I)
+        return f"<style>\n{text}\n</style>"
 
     html = re.sub(r"<link\b[^>]*>", inline, html)
     dest = out_path.with_suffix(".source.html")

--- a/agent-k/src/agents/skill/pptx/script/html2pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/html2pptx.py
@@ -172,7 +172,8 @@ SCRAPE_SLIDE_JS = r"""
     if (complexPaint) hasComplex = true;
     if (el !== slide && !complexPaint && parseFloat(cs.opacity) >= 0.99) {
       const bg = rgba(cs.backgroundColor);
-      const fill = bg && bg.a > 0.1 ? bg.hex : null;
+      const fill = bg && bg.a > 0.04 ? bg.hex : null;
+      const fillAlpha = fill ? bg.a : 1;   // keep faint tints faint (rgba alpha)
       const sides = [];
       for (const sd of ['Top', 'Right', 'Bottom', 'Left']) {
         const w = parseFloat(cs['border' + sd + 'Width']) || 0;
@@ -191,7 +192,7 @@ SCRAPE_SLIDE_JS = r"""
       if (fill || border) {
         el.setAttribute('data-pptx-shape', '1');
         shapes.push({
-          order, ...rel(r), fill, border,
+          order, ...rel(r), fill, fillAlpha, border,
           radius: parseFloat(cs.borderTopLeftRadius) || 0,
         });
       }
@@ -425,6 +426,21 @@ def _set_ea(run, typeface: str) -> None:
         el.set("typeface", typeface)
 
 
+def _set_fill_alpha(shp, alpha: float) -> None:
+    """Apply transparency to a shape's solid fill (DrawingML <a:alpha>), so an
+    rgba()/faint tint in the HTML stays faint instead of rendering fully opaque."""
+    from pptx.oxml.ns import qn
+
+    solid = shp._element.spPr.find(qn("a:solidFill"))
+    if solid is None:
+        return
+    clr = solid.find(qn("a:srgbClr"))
+    if clr is None:
+        return
+    val = max(0, min(100000, int(round(alpha * 100000))))   # 100% = 100000
+    clr.append(clr.makeelement(qn("a:alpha"), {"val": str(val)}))
+
+
 def build_pptx(slides: list[dict], out_path: Path) -> None:
     from pptx import Presentation
     from pptx.dml.color import RGBColor
@@ -444,7 +460,7 @@ def build_pptx(slides: list[dict], out_path: Path) -> None:
     blank = prs.slide_layouts[6]
     warnings: list = []
 
-    def add_rect(slide, l, t, w, h, fill=None, line=None, line_w=0, radius=0, idx=None):
+    def add_rect(slide, l, t, w, h, fill=None, fill_alpha=1.0, line=None, line_w=0, radius=0, idx=None):
         c = _clip(l, t, w, h, warnings, idx, "shape")
         if c is None:
             return None
@@ -457,6 +473,8 @@ def build_pptx(slides: list[dict], out_path: Path) -> None:
         if fill:
             shp.fill.solid()
             shp.fill.fore_color.rgb = RGBColor.from_string(fill)
+            if fill_alpha < 0.97:
+                _set_fill_alpha(shp, fill_alpha)   # preserve rgba transparency
         else:
             shp.fill.background()
         if line:
@@ -476,7 +494,7 @@ def build_pptx(slides: list[dict], out_path: Path) -> None:
         fill, bd, rad = s.get("fill"), s.get("border"), s.get("radius") or 0
         uniform = bd and bd["kind"] == "all"
         if fill or uniform:
-            add_rect(slide, l, t, w, h, fill=fill,
+            add_rect(slide, l, t, w, h, fill=fill, fill_alpha=s.get("fillAlpha", 1.0),
                      line=(bd["color"] if uniform else None),
                      line_w=(bd["w"] if uniform else 0), radius=rad, idx=idx)
         if bd and bd["kind"] == "sides":

--- a/agent-k/src/agents/skill/pptx/script/html2pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/html2pptx.py
@@ -281,9 +281,14 @@ SCRAPE_SLIDE_JS = r"""
           }
         }
         if (segs.length && bb) {
-          // Group segments into visual lines by the same overlap-fraction test,
-          // then merge adjacent same-style runs. A big number + a small unit
-          // span share a line (heavy overlap); a real wrap starts a new one.
+          // Group THIS block's segments into visual lines by the same
+          // overlap-fraction test, then merge adjacent same-style runs. Inline
+          // runs of one block (e.g. a big number + its small unit span) overlap
+          // heavily → one line object; a real wrap starts a new one. Sibling
+          // blocks each become their own text box (promoted above) and are not
+          // merged here — they still share a baseline on render because their
+          // coordinates are preserved. The guarantee is "no spurious <a:br>,
+          // same baseline on render", not "one line object".
           const rawLines = []; let cur = null, curTop = null, curBot = null;
           for (const sg of segs) {
             if (cur !== null && samELine(sg.top, sg.bottom, curTop, curBot)) {
@@ -630,6 +635,7 @@ def _export_source_html(html_path: Path, out_path: Path) -> None:
 
     html = re.sub(r"<link\b[^>]*>", inline, html)
     dest = out_path.with_suffix(".source.html")
+    dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(html, encoding="utf-8")
     print(f"kept self-contained source HTML → {dest}")
 
@@ -661,6 +667,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         slides = render_and_scrape(args.html, work, args.scale)
         if args.dump_json:
+            args.dump_json.parent.mkdir(parents=True, exist_ok=True)
             args.dump_json.write_text(json.dumps(slides, indent=2, ensure_ascii=False),
                                       encoding="utf-8")
         build_pptx(slides, args.out)

--- a/agent-k/src/agents/skill/pptx/script/html2pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/html2pptx.py
@@ -1,0 +1,632 @@
+"""html2pptx — author slides in HTML/CSS, emit an EDITABLE .pptx.
+
+The deck is authored as HTML (one `.slide` element per slide, each
+1280x720 px = 16:9) and DECOMPOSED into native PowerPoint objects rather
+than flattened into one image:
+
+  - **Text blocks**  → native, editable text boxes.
+  - **Simple shapes** (solid-fill boxes, borders, hairline dividers,
+    edge strips, card top-strips, bullet markers) → native autoshapes
+    (rectangles / rounded rectangles / lines) you can move and recolor.
+  - **Charts / images / SVG** (Chart.js `<canvas>`, `<img>`, inline
+    `<svg>`) → each its OWN picture object (separate, movable), not
+    fused into the slide. Their internal text is not editable (raster).
+  - **Page backdrop + anything not otherwise handled** → one full-bleed
+    base picture behind everything (a safety net so nothing vanishes).
+
+Stacking follows document order (backdrop → shapes/pictures in DOM order
+→ text on top), so "photo behind cards behind chart, text on top" works.
+
+Usage (inside the sandbox):
+    pip install python-pptx playwright
+    playwright install chromium --only-shell
+    python html2pptx.py deck.html -o /workspace/artifacts/deck.pptx
+
+px->inch is exact at 96 px/in (1280x720 = 13.333"x7.5"). Do NOT use CSS
+`transform: scale()` / `zoom` on slide content — it breaks the mapping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+EMU_PER_PX = 9525            # 914400 EMU/in ÷ 96 px/in
+SLIDE_W_PX = 1280
+SLIDE_H_PX = 720
+
+# Slack so soffice/PowerPoint font-metric drift (vs Chromium) doesn't
+# re-wrap and clip text. Width slack is centered; height grows down only.
+PAD_W_PX = 8
+PAD_H_PX = 8
+
+def _clip(l, t, w, h, warn=None, slide_idx=None, kind=""):
+    """Clip an element's px rect to the slide bounds (the browser hides
+    overflow via `.slide{overflow:hidden}`; without this, off-canvas
+    elements render INTO the slide in pptx — "punching through" the edge).
+    Returns the clipped (l,t,w,h) or None if fully off-canvas. Records a
+    warning when the element overflowed a bound by more than 16 px so the
+    author can fix the layout (a clipped card still looks cut)."""
+    r, b = l + w, t + h
+    cl, ct, cr, cb = max(0.0, l), max(0.0, t), min(SLIDE_W_PX, r), min(SLIDE_H_PX, b)
+    if warn is not None:
+        over = max(-l, -t, r - SLIDE_W_PX, b - SLIDE_H_PX)
+        if over > 16:
+            warn.append((slide_idx, kind, round(over)))
+    if cr <= cl or cb <= ct:
+        return None
+    return (cl, ct, cr - cl, cb - ct)
+
+
+# --- in-page helpers ----------------------------------------------------------
+
+# Synthesize real <span> elements for absolutely-positioned ::before/::after
+# pseudo-markers (e.g. the bullet dots in components.css) so they become real
+# DOM nodes the shape scraper can promote to native autoshapes, then suppress
+# the original pseudo-element so it doesn't double in the base picture.
+INJECT_MARKERS_JS = r"""
+() => {
+  const kill = document.createElement('style');
+  kill.textContent =
+    '.pptx-kill-before::before{content:none !important}' +
+    '.pptx-kill-after::after{content:none !important}';
+  document.head.appendChild(kill);
+  const opaque = (c) => c && c !== 'transparent' &&
+    !/rgba?\([^)]*,\s*0(\.0+)?\s*\)/.test(c);
+  for (const el of document.querySelectorAll('.slide *')) {
+    for (const pe of ['::before', '::after']) {
+      const s = getComputedStyle(el, pe);
+      if (!s) continue;
+      const w = parseFloat(s.width), h = parseFloat(s.height);
+      if (s.position !== 'absolute' || !opaque(s.backgroundColor)) continue;
+      if (!(w > 0 && h > 0)) continue;
+      if (getComputedStyle(el).position === 'static') el.style.position = 'relative';
+      const span = document.createElement('span');
+      span.style.cssText =
+        `position:absolute;left:${s.left};top:${s.top};width:${s.width};` +
+        `height:${s.height};background:${s.backgroundColor};` +
+        `border-radius:${s.borderTopLeftRadius};pointer-events:none;`;
+      span.setAttribute('data-pptx-synth', '1');
+      el.appendChild(span);
+      el.classList.add(pe === '::before' ? 'pptx-kill-before' : 'pptx-kill-after');
+    }
+  }
+}
+"""
+
+# Per-slide scraper. Marks pictures (data-pptx-pic=idx), shapes
+# (data-pptx-shape), and text blocks (data-pptx-text); returns geometry +
+# styles. `order` is document order, used for z-stacking on emit.
+SCRAPE_SLIDE_JS = r"""
+([slide, picBase]) => {
+  const sb = slide.getBoundingClientRect();
+  const rel = (r) => ({ x: r.left - sb.left, y: r.top - sb.top, w: r.width, h: r.height });
+
+  const rgba = (c) => {
+    const m = (c || '').match(/rgba?\(([^)]+)\)/);
+    if (!m) return null;
+    const p = m[1].split(',').map(s => parseFloat(s.trim()));
+    const a = p.length >= 4 ? p[3] : 1;
+    return { hex: p.slice(0, 3).map(v => Math.round(v).toString(16).padStart(2, '0')).join('').toUpperCase(), a };
+  };
+  const visible = (el) => {
+    const s = getComputedStyle(el);
+    return !(s.display === 'none' || s.visibility === 'hidden' || parseFloat(s.opacity) === 0);
+  };
+  const ancestorsVisible = (el) => {
+    let a = el.parentElement;
+    while (a && a !== slide) { if (!visible(a)) return false; a = a.parentElement; }
+    return true;
+  };
+  const isSvgInternal = (el) => !!el.ownerSVGElement;        // inside an <svg>
+  const isMedia = (el) => ['CANVAS', 'IMG', 'SVG'].includes(el.tagName) && !el.ownerSVGElement;
+
+  const pics = [], shapes = [], texts = [];
+  let order = 0;
+  let picIdx = picBase;
+
+  // Slide backdrop → emitted as a NATIVE solid slide-background fill (no
+  // full-slide "frame" picture). A base picture is only emitted as a
+  // fallback when the slide carries something we can't model natively
+  // (gradient / background-image / shadow): hasComplex flags that.
+  const scs = getComputedStyle(slide);
+  const sbg = rgba(scs.backgroundColor);
+  const bgHex = sbg && sbg.a > 0.3 ? sbg.hex : 'FFFFFF';
+  let hasComplex = scs.backgroundImage !== 'none' || scs.boxShadow !== 'none';
+
+  // Single document-order walk over the slide subtree.
+  const all = slide.querySelectorAll('*');
+  const cand = new Set();                                    // text-block candidates
+  for (const el of all) {
+    if (isSvgInternal(el)) continue;
+    for (const n of el.childNodes)
+      if (n.nodeType === 3 && n.textContent.trim()) { cand.add(el); break; }
+  }
+
+  for (const el of all) {
+    order++;
+    if (isSvgInternal(el)) continue;
+    if (!visible(el) || !ancestorsVisible(el)) continue;
+    const r = el.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) continue;
+
+    // 1) Media → its own picture object.
+    if (isMedia(el)) {
+      el.setAttribute('data-pptx-pic', String(picIdx));
+      pics.push({ order, idx: picIdx, ...rel(r) });
+      picIdx++;
+      continue;
+    }
+
+    const cs = getComputedStyle(el);
+
+    // 2) Simple shape (solid fill and/or solid borders). Skip when the box
+    //    carries a gradient/background-image or shadow — too complex to model;
+    //    it falls through to the base fallback picture instead.
+    const complexPaint = cs.backgroundImage !== 'none' || cs.boxShadow !== 'none';
+    if (complexPaint) hasComplex = true;
+    if (el !== slide && !complexPaint && parseFloat(cs.opacity) >= 0.99) {
+      const bg = rgba(cs.backgroundColor);
+      const fill = bg && bg.a > 0.1 ? bg.hex : null;
+      const sides = [];
+      for (const sd of ['Top', 'Right', 'Bottom', 'Left']) {
+        const w = parseFloat(cs['border' + sd + 'Width']) || 0;
+        const st = cs['border' + sd + 'Style'];
+        const col = rgba(cs['border' + sd + 'Color']);
+        if (w > 0.4 && st !== 'none' && st !== 'hidden' && col && col.a > 0.1)
+          sides.push({ side: sd.toLowerCase(), w, color: col.hex });
+      }
+      let border = null;
+      if (sides.length === 4 && sides.every(s =>
+            Math.round(s.w) === Math.round(sides[0].w) && s.color === sides[0].color))
+        border = { kind: 'all', w: sides[0].w, color: sides[0].color };
+      else if (sides.length)
+        border = { kind: 'sides', sides };
+
+      if (fill || border) {
+        el.setAttribute('data-pptx-shape', '1');
+        shapes.push({
+          order, ...rel(r), fill, border,
+          radius: parseFloat(cs.borderTopLeftRadius) || 0,
+        });
+      }
+    }
+
+    // 3) Text block (topmost text-bearing element in its chain).
+    if (cand.has(el)) {
+      let anc = el.parentElement, nested = false;
+      while (anc && anc !== slide) { if (cand.has(anc)) { nested = true; break; } anc = anc.parentElement; }
+      if (!nested) {
+        // FREEZE the browser's line breaks: split each text node at its
+        // rendered line boundaries (the y-top of a 1-char range changes at a
+        // wrap), so PowerPoint/soffice can't re-wrap CJK differently. Emit
+        // per-line run groups; the emitter joins them with hard <a:br>.
+        const mkStyle = (se) => {
+          const s = getComputedStyle(se);
+          return {
+            font: (s.fontFamily.split(',')[0] || '').replace(/["']/g, '').trim(),
+            size_pt: parseFloat(s.fontSize) * 0.75,
+            bold: (parseInt(s.fontWeight) || 400) >= 600,
+            italic: s.fontStyle === 'italic',
+            color: (rgba(s.color) || {}).hex || null,
+            letter_spacing: s.letterSpacing === 'normal' ? 0 : parseFloat(s.letterSpacing) * 0.75,
+          };
+        };
+        let bb = null;
+        const grow = (rr) => {
+          if (rr.width === 0 && rr.height === 0) return;
+          bb = bb ? {
+            left: Math.min(bb.left, rr.left), top: Math.min(bb.top, rr.top),
+            right: Math.max(bb.right, rr.right), bottom: Math.max(bb.bottom, rr.bottom),
+          } : { left: rr.left, top: rr.top, right: rr.right, bottom: rr.bottom };
+        };
+        const segs = [];   // ordered {text, top, style}
+        const addText = (tn, styleEl) => {
+          const s = tn.textContent;
+          if (!s) return;
+          const col0 = rgba(getComputedStyle(styleEl).color);
+          if (col0 && col0.a < 0.1) return;   // fully-transparent text → no text
+          const st = mkStyle(styleEl);
+          const rg = document.createRange();
+          let lineStart = 0, curTop = null;
+          for (let i = 0; i < s.length; i++) {
+            rg.setStart(tn, i); rg.setEnd(tn, i + 1);
+            const rects = rg.getClientRects();
+            if (!rects.length) continue;
+            grow(rects[0]);
+            const top = Math.round(rects[0].top);
+            if (curTop === null) curTop = top;
+            else if (Math.abs(top - curTop) > 2) {
+              segs.push({ text: s.slice(lineStart, i), top: curTop, style: st });
+              lineStart = i; curTop = top;
+            }
+          }
+          segs.push({ text: s.slice(lineStart), top: curTop === null ? 0 : curTop, style: st });
+        };
+        for (const n of el.childNodes) {
+          if (n.nodeType === 3) { if (n.textContent.trim()) addText(n, el); }
+          else if (n.nodeType === 1 && !n.hasAttribute('data-pptx-synth')) {
+            let any = false;
+            for (const m of n.childNodes)
+              if (m.nodeType === 3 && m.textContent.trim()) { addText(m, n); any = true; }
+            if (!any && n.textContent.trim()) {
+              const rr = n.getBoundingClientRect(); grow(rr);
+              segs.push({ text: n.textContent, top: Math.round(rr.top), style: mkStyle(n) });
+            }
+          }
+        }
+        if (segs.length && bb) {
+          // Group segments into lines by y-top; merge adjacent same-style runs.
+          const rawLines = []; let cur = null, curTop = null;
+          for (const sg of segs) {
+            if (curTop === null || Math.abs(sg.top - curTop) > 2) { cur = []; rawLines.push(cur); curTop = sg.top; }
+            const last = cur[cur.length - 1];
+            if (last && JSON.stringify(last.style) === JSON.stringify(sg.style)) last.text += sg.text;
+            else cur.push({ text: sg.text, style: sg.style });
+          }
+          const lines = [];
+          for (const ln of rawLines) {
+            const runs = ln.map(rn => ({ text: rn.text.replace(/\s+/g, ' '), ...rn.style }))
+                           .filter(rn => rn.text.length);
+            if (runs.length) { runs[0].text = runs[0].text.replace(/^ /, ''); runs[runs.length - 1].text = runs[runs.length - 1].text.replace(/ $/, ''); }
+            if (runs.some(rn => rn.text.trim())) lines.push({ runs });
+          }
+          if (lines.length) {
+            el.setAttribute('data-pptx-text', '1');
+            const fs = parseFloat(cs.fontSize) || 16;
+            texts.push({
+              order, x: bb.left - sb.left, y: bb.top - sb.top, w: bb.right - bb.left, h: bb.bottom - bb.top,
+              align: cs.textAlign === 'start' ? 'left' : cs.textAlign === 'end' ? 'right' : cs.textAlign,
+              line_height: cs.lineHeight === 'normal' ? 1.2 : parseFloat(cs.lineHeight) / fs,
+              lines,
+            });
+          }
+        }
+      }
+    }
+  }
+  return { w: sb.width, h: sb.height, pics, shapes, texts, nextPic: picIdx, bgHex, hasComplex };
+}
+"""
+
+# Visibility control injected as a single mutable <style id=pptx-ctl>.
+MODE_STYLES = {
+    # base picture: hide everything we emit natively, keep slide backdrop
+    "base": "[data-pptx-shape]{background-color:transparent !important;border-color:transparent !important}"
+            "[data-pptx-text]{color:transparent !important;text-shadow:none !important}"
+            "[data-pptx-pic]{visibility:hidden !important}",
+    # picture pass: media visible & isolated (transparent backdrop), shapes/text hidden
+    "pics": "[data-pptx-shape]{background-color:transparent !important;border-color:transparent !important}"
+            "[data-pptx-text]{color:transparent !important;text-shadow:none !important}"
+            ".slide,body{background:transparent !important}",
+}
+SET_MODE_JS = """
+(css) => {
+  let el = document.getElementById('pptx-ctl');
+  if (!el) { el = document.createElement('style'); el.id = 'pptx-ctl'; document.head.appendChild(el); }
+  el.textContent = css;
+}
+"""
+
+
+def render_and_scrape(html_path: Path, png_dir: Path, scale: int) -> list[dict]:
+    from playwright.sync_api import sync_playwright
+
+    url = html_path.resolve().as_uri()
+    slides: list[dict] = []
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(
+            viewport={"width": SLIDE_W_PX, "height": SLIDE_H_PX},
+            device_scale_factor=scale,
+        )
+        page.goto(url, wait_until="networkidle")
+        try:
+            page.evaluate("document.fonts.ready")
+        except Exception:
+            pass
+        try:
+            page.wait_for_function(
+                "window.__pptx_ready === undefined || window.__pptx_ready === true",
+                timeout=5000,
+            )
+        except Exception:
+            pass
+        page.wait_for_timeout(400)
+
+        page.evaluate(INJECT_MARKERS_JS)
+
+        handles = page.query_selector_all(".slide")
+        if not handles:
+            raise SystemExit(
+                'no `.slide` elements found — wrap each slide in '
+                '<div class="slide">…</div> sized 1280x720 px.'
+            )
+
+        # Pass 1: scrape + mark every slide (assign global picture indices).
+        pic_base = 0
+        for h in handles:
+            data = page.evaluate(SCRAPE_SLIDE_JS, [h, pic_base])
+            pic_base = data.pop("nextPic")
+            slides.append(data)
+
+        # Pass 2: base fallback picture — ONLY for slides with un-modelable
+        # content (gradient / background-image / shadow). Solid-color slides
+        # get a native background fill instead (no full-slide "frame" image).
+        if any(s.get("hasComplex") for s in slides):
+            page.evaluate(SET_MODE_JS, MODE_STYLES["base"])
+            page.wait_for_timeout(80)
+            for i, h in enumerate(handles, 1):
+                if not slides[i - 1].get("hasComplex"):
+                    continue
+                png = png_dir / f"base-{i}.png"
+                h.scroll_into_view_if_needed()
+                h.screenshot(path=str(png))
+                slides[i - 1]["background"] = str(png)
+
+        # Pass 3: each media element as its own isolated picture.
+        page.evaluate(SET_MODE_JS, MODE_STYLES["pics"])
+        page.wait_for_timeout(80)
+        for ph in page.query_selector_all("[data-pptx-pic]"):
+            idx = ph.get_attribute("data-pptx-pic")
+            png = png_dir / f"pic-{idx}.png"
+            try:
+                ph.scroll_into_view_if_needed()
+                ph.screenshot(path=str(png), omit_background=True)
+            except Exception:
+                png = None
+            for sd in slides:
+                for p in sd["pics"]:
+                    if str(p["idx"]) == str(idx):
+                        p["png"] = str(png) if png else None
+        browser.close()
+    return slides
+
+
+def _set_ea(run, typeface: str) -> None:
+    """Set Latin + East-Asian + complex-script typefaces on a run (CJK safety)."""
+    from pptx.oxml.ns import qn
+
+    rPr = run._r.get_or_add_rPr()
+    for tag in ("latin", "ea", "cs"):
+        el = rPr.find(qn(f"a:{tag}"))
+        if el is None:
+            el = rPr.makeelement(qn(f"a:{tag}"), {})
+            rPr.append(el)
+        el.set("typeface", typeface)
+
+
+def build_pptx(slides: list[dict], out_path: Path) -> None:
+    from pptx import Presentation
+    from pptx.dml.color import RGBColor
+    from pptx.enum.shapes import MSO_SHAPE
+    from pptx.enum.text import MSO_ANCHOR, MSO_AUTO_SIZE, PP_ALIGN
+    from pptx.util import Emu, Pt
+
+    align_map = {"left": PP_ALIGN.LEFT, "center": PP_ALIGN.CENTER,
+                 "right": PP_ALIGN.RIGHT, "justify": PP_ALIGN.JUSTIFY}
+
+    def emu(px: float) -> Emu:
+        return Emu(int(round(px * EMU_PER_PX)))
+
+    prs = Presentation()
+    prs.slide_width = emu(SLIDE_W_PX)
+    prs.slide_height = emu(SLIDE_H_PX)
+    blank = prs.slide_layouts[6]
+    warnings: list = []
+
+    def add_rect(slide, l, t, w, h, fill=None, line=None, line_w=0, radius=0, idx=None):
+        c = _clip(l, t, w, h, warnings, idx, "shape")
+        if c is None:
+            return None
+        l, t, w, h = c
+        shp = slide.shapes.add_shape(
+            MSO_SHAPE.ROUNDED_RECTANGLE if radius else MSO_SHAPE.RECTANGLE,
+            emu(l), emu(t), emu(max(1, w)), emu(max(1, h)),
+        )
+        shp.shadow.inherit = False
+        if fill:
+            shp.fill.solid()
+            shp.fill.fore_color.rgb = RGBColor.from_string(fill)
+        else:
+            shp.fill.background()
+        if line:
+            shp.line.color.rgb = RGBColor.from_string(line)
+            shp.line.width = emu(max(0.75, line_w))
+        else:
+            shp.line.fill.background()
+        if radius:
+            try:
+                shp.adjustments[0] = max(0.0, min(0.5, radius / max(1.0, min(w, h))))
+            except Exception:
+                pass
+        return shp
+
+    def emit_shape(slide, s, idx):
+        l, t, w, h = s["x"], s["y"], s["w"], s["h"]
+        fill, bd, rad = s.get("fill"), s.get("border"), s.get("radius") or 0
+        uniform = bd and bd["kind"] == "all"
+        if fill or uniform:
+            add_rect(slide, l, t, w, h, fill=fill,
+                     line=(bd["color"] if uniform else None),
+                     line_w=(bd["w"] if uniform else 0), radius=rad, idx=idx)
+        if bd and bd["kind"] == "sides":
+            for sb in bd["sides"]:
+                bw = max(1.0, sb["w"])
+                if sb["side"] == "top":
+                    add_rect(slide, l, t, w, bw, fill=sb["color"], idx=idx)
+                elif sb["side"] == "bottom":
+                    add_rect(slide, l, t + h - bw, w, bw, fill=sb["color"], idx=idx)
+                elif sb["side"] == "left":
+                    add_rect(slide, l, t, bw, h, fill=sb["color"], idx=idx)
+                else:
+                    add_rect(slide, l + w - bw, t, bw, h, fill=sb["color"], idx=idx)
+
+    for si, sd in enumerate(slides, 1):
+        slide = prs.slides.add_slide(blank)
+        # Native solid slide background (no full-slide picture frame).
+        bg = sd.get("bgHex")
+        if bg:
+            slide.background.fill.solid()
+            slide.background.fill.fore_color.rgb = RGBColor.from_string(bg)
+        # Fallback base picture only when the slide has un-modelable content.
+        if sd.get("hasComplex") and sd.get("background"):
+            slide.shapes.add_picture(sd["background"], 0, 0,
+                                     width=prs.slide_width, height=prs.slide_height)
+
+        # Shapes + pictures interleaved in document order (preserves stacking).
+        objs = [("shape", s) for s in sd["shapes"]] + \
+               [("pic", p) for p in sd["pics"] if p.get("png")]
+        objs.sort(key=lambda o: o[1]["order"])
+        for kind, o in objs:
+            if kind == "shape":
+                emit_shape(slide, o, si)
+            else:
+                c = _clip(o["x"], o["y"], o["w"], o["h"], warnings, si, "image")
+                if c is None:
+                    continue
+                slide.shapes.add_picture(o["png"], emu(c[0]), emu(c[1]),
+                                         width=emu(c[2]), height=emu(c[3]))
+
+        # Text on top — frozen line breaks. word_wrap=False so the viewer
+        # renders exactly the lines Chromium produced (no CJK re-wrap), with
+        # hard <a:br> between captured lines. One editable box per block.
+        for tb in sd["texts"]:
+            align = tb.get("align")
+            # Extend the small pad away from the anchored edge so left-aligned
+            # body never shifts onto its bullet marker.
+            if align == "right":
+                x0 = tb["x"] - PAD_W_PX
+            elif align in ("center", "justify"):
+                x0 = tb["x"] - PAD_W_PX / 2
+            else:
+                x0 = tb["x"]
+            c = _clip(x0, tb["y"], tb["w"] + PAD_W_PX, tb["h"] + PAD_H_PX, warnings, si, "text")
+            if c is None:
+                continue
+            box = slide.shapes.add_textbox(emu(c[0]), emu(c[1]), emu(c[2]), emu(c[3]))
+            box.shadow.inherit = False
+            tf = box.text_frame
+            tf.word_wrap = False
+            tf.auto_size = MSO_AUTO_SIZE.NONE
+            tf.margin_left = tf.margin_right = 0
+            tf.margin_top = tf.margin_bottom = 0
+            tf.vertical_anchor = MSO_ANCHOR.TOP
+            p = tf.paragraphs[0]
+            p.alignment = align_map.get(align, PP_ALIGN.LEFT)
+            lh = tb.get("line_height")
+            if lh and lh > 0:
+                p.line_spacing = float(lh)
+            first = True
+            for ln in tb["lines"]:
+                if not first:
+                    p.add_line_break()
+                first = False
+                for r in ln["runs"]:
+                    run = p.add_run()
+                    run.text = r["text"]
+                    if r.get("size_pt"):
+                        run.font.size = Pt(r["size_pt"])
+                    run.font.bold = bool(r.get("bold"))
+                    run.font.italic = bool(r.get("italic"))
+                    if r.get("color"):
+                        run.font.color.rgb = RGBColor.from_string(r["color"])
+                    fam = r.get("font") or "Arial"
+                    run.font.name = fam
+                    _set_ea(run, fam)
+                    spc = r.get("letter_spacing")
+                    if spc:
+                        run._r.get_or_add_rPr().set("spc", str(int(round(spc * 100))))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    prs.save(str(out_path))
+
+    if warnings:
+        worst: dict = {}
+        for idx, kind, over in warnings:
+            if over > worst.get(idx, (0, ""))[0]:
+                worst[idx] = (over, kind)
+        for idx in sorted(worst):
+            over, kind = worst[idx]
+            print(f"WARNING: slide {idx} has a {kind} overflowing the 1280x720 "
+                  f"canvas by ~{over}px (clipped). Fix the layout so all content "
+                  f"fits inside the slide.")
+
+
+def _export_source_html(html_path: Path, out_path: Path) -> None:
+    """Save a self-contained copy of the authored HTML next to the .pptx:
+    inline any linked local stylesheet (e.g. components.css) into a <style>
+    block so the file opens stand-alone. CDN <script> tags are left as-is.
+    Useful for comparing what different models authored."""
+    import re
+
+    html = html_path.read_text(encoding="utf-8")
+    base = html_path.resolve().parent
+
+    def inline(m: "re.Match") -> str:
+        tag = m.group(0)
+        if "stylesheet" not in tag:
+            return tag
+        href = re.search(r'href=["\']([^"\']+)["\']', tag)
+        if not href:
+            return tag
+        css = base / href.group(1)
+        if not css.exists():
+            return tag
+        return f"<style>\n{css.read_text(encoding='utf-8')}\n</style>"
+
+    html = re.sub(r"<link\b[^>]*>", inline, html)
+    dest = out_path.with_suffix(".source.html")
+    dest.write_text(html, encoding="utf-8")
+    print(f"kept self-contained source HTML → {dest}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Convert HTML slides to an editable .pptx.")
+    ap.add_argument("html", type=Path, help="HTML file with one or more .slide elements")
+    ap.add_argument("-o", "--out", type=Path, required=True, help="output .pptx path")
+    ap.add_argument("--work", type=Path, default=None, help="dir for intermediate PNGs")
+    ap.add_argument("--scale", type=int, default=2, help="device scale factor (default 2)")
+    ap.add_argument("--dump-json", type=Path, default=None, help="write scraped slide JSON (debug)")
+    ap.add_argument("--keep-html", action=argparse.BooleanOptionalAction, default=True,
+                    help="save a self-contained copy of the source HTML (linked CSS "
+                         "inlined) next to the output as <out>.source.html "
+                         "(default: on; pass --no-keep-html to skip)")
+    args = ap.parse_args(argv)
+
+    if not args.html.exists():
+        print(f"no such file: {args.html}", file=sys.stderr)
+        return 2
+
+    tmp = None
+    work = args.work
+    if work is None:
+        tmp = tempfile.TemporaryDirectory()
+        work = Path(tmp.name)
+    work.mkdir(parents=True, exist_ok=True)
+
+    try:
+        slides = render_and_scrape(args.html, work, args.scale)
+        if args.dump_json:
+            args.dump_json.write_text(json.dumps(slides, indent=2, ensure_ascii=False),
+                                      encoding="utf-8")
+        build_pptx(slides, args.out)
+        if args.keep_html:
+            _export_source_html(args.html, args.out)
+    finally:
+        if tmp is not None:
+            tmp.cleanup()
+
+    n_text = sum(len(s["texts"]) for s in slides)
+    n_shape = sum(len(s["shapes"]) for s in slides)
+    n_pic = sum(len([p for p in s["pics"] if p.get("png")]) for s in slides)
+    print(f"wrote {args.out} — {len(slides)} slides, {n_text} text boxes, "
+          f"{n_shape} shapes, {n_pic} pictures")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-k/src/agents/skill/pptx/script/html2pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/html2pptx.py
@@ -327,13 +327,18 @@ SCRAPE_SLIDE_JS = r"""
 
 # Visibility control injected as a single mutable <style id=pptx-ctl>.
 MODE_STYLES = {
-    # base picture: hide everything we emit natively, keep slide backdrop
+    # base picture: hide everything we emit natively, keep slide backdrop.
+    # The `[data-pptx-text] *` descendant rule matters: a child run such as
+    # <span style="color:…"> carries its own inline color, which a bare
+    # [data-pptx-text] rule would NOT override — so it leaks into the base
+    # raster and doubles the native text. The !important stylesheet rule wins
+    # over the inline (non-important) color.
     "base": "[data-pptx-shape]{background-color:transparent !important;border-color:transparent !important}"
-            "[data-pptx-text]{color:transparent !important;text-shadow:none !important}"
+            "[data-pptx-text],[data-pptx-text] *{color:transparent !important;text-shadow:none !important}"
             "[data-pptx-pic]{visibility:hidden !important}",
     # picture pass: media visible & isolated (transparent backdrop), shapes/text hidden
     "pics": "[data-pptx-shape]{background-color:transparent !important;border-color:transparent !important}"
-            "[data-pptx-text]{color:transparent !important;text-shadow:none !important}"
+            "[data-pptx-text],[data-pptx-text] *{color:transparent !important;text-shadow:none !important}"
             ".slide,body{background:transparent !important}",
 }
 SET_MODE_JS = """

--- a/agent-k/src/agents/skill/pptx/script/html2pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/html2pptx.py
@@ -11,10 +11,11 @@ than flattened into one image:
   - **Charts / images / SVG** (Chart.js `<canvas>`, `<img>`, inline
     `<svg>`) → each its OWN picture object (separate, movable), not
     fused into the slide. Their internal text is not editable (raster).
-  - **Page backdrop + anything not otherwise handled** → one full-bleed
-    base picture behind everything (a safety net so nothing vanishes).
+  - **Page backdrop** → the slide's solid background becomes a native
+    slide fill. Only un-modelable content (gradient / shadow /
+    background-image) falls back to a full-bleed base picture.
 
-Stacking follows document order (backdrop → shapes/pictures in DOM order
+Stacking follows document order (background → shapes/pictures in DOM order
 → text on top), so "photo behind cards behind chart, text on top" works.
 
 Usage (inside the sandbox):

--- a/agent-k/src/agents/skill/pptx/script/template.html
+++ b/agent-k/src/agents/skill/pptx/script/template.html
@@ -13,14 +13,17 @@
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="components.css">
-  <!-- This deck's COMPOSED palette + a Latin font (override components.css).
-       For a calm, financial Q1 review we go deep-ink + slate teal with one
-       clay accent on warm paper — deliberately not the default navy/blue/amber. -->
+  <!-- This deck's COMPOSED palette + type scale + a Latin font (override
+       components.css). For a calm, financial Q1 review we go deep-ink + slate
+       teal with one clay accent on warm paper — deliberately not the default
+       navy/blue/amber — and a moderate scale (this deck is fairly data-dense). -->
   <style>
     :root{
       --primary:#16242B;   --secondary:#2F6E6A;  --accent:#C2542B;
       --bg:#F2EDE3;        --surface:#FFFFFF;    --muted:#6E7A78;
       --hairline:#DED8C9;  --positive:#2F7D4F;   --negative:#B23A30;
+      /* type scale composed for this deck (see SKILL.md "Type scale") */
+      --fs-display:58px;   --fs-title:34px;  --fs-body:19px;  --fs-caption:11px;
     }
     .slide{ font-family:'Calibri','Carlito',Arial,Helvetica,sans-serif; }
   </style>

--- a/agent-k/src/agents/skill/pptx/script/template.html
+++ b/agent-k/src/agents/skill/pptx/script/template.html
@@ -15,13 +15,14 @@
   <link rel="stylesheet" href="components.css">
   <!-- This deck's COMPOSED palette + type scale + a Latin font (override
        components.css). For a calm, financial Q1 review we go deep-ink + slate
-       teal with one clay accent on warm paper — deliberately not the default
-       navy/blue/amber — and a moderate scale (this deck is fairly data-dense). -->
+       teal with one clay accent on a near-white ground — deliberately not the
+       default navy/blue/amber — and a moderate scale (fairly data-dense). The
+       ground is a barely-there off-white so white cards still read. -->
   <style>
     :root{
       --primary:#16242B;   --secondary:#2F6E6A;  --accent:#C2542B;
-      --bg:#F2EDE3;        --surface:#FFFFFF;    --muted:#6E7A78;
-      --hairline:#DED8C9;  --positive:#2F7D4F;   --negative:#B23A30;
+      --bg:#FAFAFA;        --surface:#FFFFFF;    --muted:#6E7A78;
+      --hairline:#E6E4E0;  --positive:#2F7D4F;   --negative:#B23A30;
       /* type scale composed for this deck (see SKILL.md "Type scale") */
       --fs-display:58px;   --fs-title:34px;  --fs-body:19px;  --fs-caption:11px;
     }

--- a/agent-k/src/agents/skill/pptx/script/template.html
+++ b/agent-k/src/agents/skill/pptx/script/template.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<!-- template.html — a 4-slide reference deck for html2pptx.py.
+     Author your deck the same way: one <div class="slide"> per slide,
+     pick a theme on <body>, set lang for CJK, compose from components.css.
+     Convert:  python html2pptx.py template.html -o deck.pptx -->
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="components.css">
+  <!-- Chart.js is fine: it renders to <canvas>, which bakes into the slide
+       background as an image. Only text needs to stay editable. -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+</head>
+<body class="theme-corporate-slate">
+
+  <!-- ===== Slide 1 — title (no footer / page number) ===== -->
+  <div class="slide">
+    <div class="edge-strip"></div>
+    <div style="position:absolute; left:90px; top:250px; right:90px;">
+      <div class="t-caption c-accent" style="margin-bottom:18px;">Pixellife Inc.</div>
+      <div class="t-display c-primary">2026년 1분기 사업 리뷰</div>
+      <div class="t-body c-muted" style="margin-top:18px;">경영진 회의용 — 매출·수익성·다음 분기 계획</div>
+    </div>
+    <div style="position:absolute; right:90px; bottom:80px; width:60px; height:8px;
+                background:var(--accent);"></div>
+  </div>
+
+  <!-- ===== Slide 2 — metrics (compact stat row, NOT big KPI cards) ===== -->
+  <div class="slide">
+    <div class="band-title">
+      <div class="t-caption c-secondary" style="margin-bottom:8px;">Executive Summary</div>
+      <div class="t-title c-primary">매출 31.7% 성장, 수익성도 함께 개선됐다</div>
+    </div>
+    <div class="body-area">
+      <div class="stat-row">
+        <div>
+          <div class="stat-value">187억</div>
+          <div class="stat-label">1분기 매출</div>
+          <div class="stat-delta c-positive">+31.7%</div>
+        </div>
+        <div>
+          <div class="stat-value">24.1%</div>
+          <div class="stat-label">영업이익률</div>
+          <div class="stat-delta c-positive">+3.4pp</div>
+        </div>
+        <div>
+          <div class="stat-value">42만</div>
+          <div class="stat-label">월간 활성 사용자</div>
+          <div class="stat-delta c-positive">+18%</div>
+        </div>
+      </div>
+      <hr class="hairline" style="margin-top:44px;">
+      <ul class="bullets" style="margin-top:28px;">
+        <li>매출 성장과 수익성 개선이 같은 분기에 함께 일어났다.</li>
+        <li>활성 사용자 증가가 그 성장의 기반이 됐다.</li>
+      </ul>
+    </div>
+    <div class="footer"><span>2026 Q1 Review</span><span>2 / 4</span></div>
+  </div>
+
+  <!-- ===== Slide 3 — chart + narrative (chart = Chart.js canvas) ===== -->
+  <div class="slide">
+    <div class="band-title">
+      <div class="t-caption c-secondary" style="margin-bottom:8px;">Revenue by Quarter</div>
+      <div class="t-title c-primary">유료 전환이 4개 분기 연속 성장을 이끌었다</div>
+    </div>
+    <div class="body-area" style="display:flex; gap:32px;">
+      <div style="flex:1.4; position:relative;">
+        <canvas id="rev"></canvas>
+      </div>
+      <ul class="bullets" style="flex:1; align-self:center;">
+        <li>유료 사용자가 2분기에 무료를 추월했다.</li>
+        <li>객단가(ARPU)는 전년 대비 12% 상승.</li>
+        <li>이탈률은 3.1%로 역대 최저 수준.</li>
+      </ul>
+    </div>
+    <div class="footer"><span>2026 Q1 Review</span><span>3 / 4</span></div>
+  </div>
+
+  <!-- ===== Slide 4 — closing (mirrors title, no footer) ===== -->
+  <div class="slide">
+    <div style="position:absolute; right:90px; top:280px; left:90px; text-align:right;">
+      <div class="t-display c-primary">감사합니다.</div>
+      <div class="t-body c-muted" style="margin-top:16px;">질문이 있으신가요?</div>
+    </div>
+    <div style="position:absolute; left:90px; bottom:80px; width:60px; height:8px;
+                background:var(--accent);"></div>
+  </div>
+
+  <script>
+    // Render charts, then signal the converter that capture can proceed.
+    const css = getComputedStyle(document.body);
+    const secondary = css.getPropertyValue('--secondary').trim();
+    const accent = css.getPropertyValue('--accent').trim();
+    new Chart(document.getElementById('rev'), {
+      type: 'bar',
+      data: {
+        labels: ['1분기', '2분기', '3분기', '4분기'],
+        datasets: [
+          { label: '무료', data: [120, 110, 98, 90], backgroundColor: accent },
+          { label: '유료', data: [60, 115, 150, 180], backgroundColor: secondary },
+        ],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        animation: false,                       // must be off for a clean capture
+        plugins: { legend: { labels: { font: { family: 'Noto Sans CJK KR' } } } },
+        scales: {
+          x: { ticks: { font: { family: 'Noto Sans CJK KR' } } },
+          y: { ticks: { font: { family: 'Noto Sans CJK KR' } } },
+        },
+      },
+    });
+    // html2pptx.py waits for window.__pptx_ready before screenshotting.
+    requestAnimationFrame(() => requestAnimationFrame(() => { window.__pptx_ready = true; }));
+  </script>
+</body>
+</html>

--- a/agent-k/src/agents/skill/pptx/script/template.html
+++ b/agent-k/src/agents/skill/pptx/script/template.html
@@ -1,25 +1,42 @@
 <!doctype html>
-<!-- template.html — a 4-slide reference deck for html2pptx.py.
-     Author your deck the same way: one <div class="slide"> per slide,
-     pick a theme on <body>, set lang for CJK, compose from components.css.
+<!-- template.html — a MECHANICS reference for html2pptx.py, NOT a look to copy.
+     It shows the WIRING: one <div class="slide"> per slide (any number — the
+     converter processes them all), how to define a per-deck palette (<style>
+     below), the components.css classes, and the Chart.js readiness flag.
+     Do NOT reproduce this deck's palette, slide order, or layouts — if every
+     deck copies this, every deck looks the same. Compose your own palette and
+     vary the layouts to fit YOUR subject (see SKILL.md "Ground it in the
+     subject" + "Palette"). For a CJK deck, set <html lang="ko"> and a
+     'Noto Sans CJK KR/JP/SC/TC' font instead of the Latin stack here.
      Convert:  python html2pptx.py template.html -o deck.pptx -->
-<html lang="ko">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="components.css">
+  <!-- This deck's COMPOSED palette + a Latin font (override components.css).
+       For a calm, financial Q1 review we go deep-ink + slate teal with one
+       clay accent on warm paper — deliberately not the default navy/blue/amber. -->
+  <style>
+    :root{
+      --primary:#16242B;   --secondary:#2F6E6A;  --accent:#C2542B;
+      --bg:#F2EDE3;        --surface:#FFFFFF;    --muted:#6E7A78;
+      --hairline:#DED8C9;  --positive:#2F7D4F;   --negative:#B23A30;
+    }
+    .slide{ font-family:'Calibri','Carlito',Arial,Helvetica,sans-serif; }
+  </style>
   <!-- Chart.js is fine: it renders to <canvas>, which bakes into the slide
-       background as an image. Only text needs to stay editable. -->
+       as its own image. Only text needs to stay editable. -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 </head>
-<body class="theme-corporate-slate">
+<body>
 
   <!-- ===== Slide 1 — title (no footer / page number) ===== -->
   <div class="slide">
     <div class="edge-strip"></div>
     <div style="position:absolute; left:90px; top:250px; right:90px;">
       <div class="t-caption c-accent" style="margin-bottom:18px;">Pixellife Inc.</div>
-      <div class="t-display c-primary">2026년 1분기 사업 리뷰</div>
-      <div class="t-body c-muted" style="margin-top:18px;">경영진 회의용 — 매출·수익성·다음 분기 계획</div>
+      <div class="t-display c-primary">2026 Q1 Business Review</div>
+      <div class="t-body c-muted" style="margin-top:18px;">For the exec meeting — revenue, margin, and the next-quarter plan</div>
     </div>
     <div style="position:absolute; right:90px; bottom:80px; width:60px; height:8px;
                 background:var(--accent);"></div>
@@ -29,30 +46,30 @@
   <div class="slide">
     <div class="band-title">
       <div class="t-caption c-secondary" style="margin-bottom:8px;">Executive Summary</div>
-      <div class="t-title c-primary">매출 31.7% 성장, 수익성도 함께 개선됐다</div>
+      <div class="t-title c-primary">Revenue grew 31.7%, with margin improving in step</div>
     </div>
     <div class="body-area">
       <div class="stat-row">
         <div>
-          <div class="stat-value">187억</div>
-          <div class="stat-label">1분기 매출</div>
+          <div class="stat-value">$14.2M</div>
+          <div class="stat-label">Q1 revenue</div>
           <div class="stat-delta c-positive">+31.7%</div>
         </div>
         <div>
           <div class="stat-value">24.1%</div>
-          <div class="stat-label">영업이익률</div>
+          <div class="stat-label">Operating margin</div>
           <div class="stat-delta c-positive">+3.4pp</div>
         </div>
         <div>
-          <div class="stat-value">42만</div>
-          <div class="stat-label">월간 활성 사용자</div>
+          <div class="stat-value">420K</div>
+          <div class="stat-label">Monthly active users</div>
           <div class="stat-delta c-positive">+18%</div>
         </div>
       </div>
       <hr class="hairline" style="margin-top:44px;">
       <ul class="bullets" style="margin-top:28px;">
-        <li>매출 성장과 수익성 개선이 같은 분기에 함께 일어났다.</li>
-        <li>활성 사용자 증가가 그 성장의 기반이 됐다.</li>
+        <li>Revenue growth and margin improvement landed in the same quarter.</li>
+        <li>Active-user growth was the base under that revenue.</li>
       </ul>
     </div>
     <div class="footer"><span>2026 Q1 Review</span><span>2 / 4</span></div>
@@ -62,16 +79,16 @@
   <div class="slide">
     <div class="band-title">
       <div class="t-caption c-secondary" style="margin-bottom:8px;">Revenue by Quarter</div>
-      <div class="t-title c-primary">유료 전환이 4개 분기 연속 성장을 이끌었다</div>
+      <div class="t-title c-primary">Paid conversion drove four straight quarters of growth</div>
     </div>
     <div class="body-area" style="display:flex; gap:32px;">
       <div style="flex:1.4; position:relative;">
         <canvas id="rev"></canvas>
       </div>
       <ul class="bullets" style="flex:1; align-self:center;">
-        <li>유료 사용자가 2분기에 무료를 추월했다.</li>
-        <li>객단가(ARPU)는 전년 대비 12% 상승.</li>
-        <li>이탈률은 3.1%로 역대 최저 수준.</li>
+        <li>Paid users overtook free in Q2.</li>
+        <li>ARPU rose 12% year over year.</li>
+        <li>Churn fell to 3.1% — an all-time low.</li>
       </ul>
     </div>
     <div class="footer"><span>2026 Q1 Review</span><span>3 / 4</span></div>
@@ -80,8 +97,8 @@
   <!-- ===== Slide 4 — closing (mirrors title, no footer) ===== -->
   <div class="slide">
     <div style="position:absolute; right:90px; top:280px; left:90px; text-align:right;">
-      <div class="t-display c-primary">감사합니다.</div>
-      <div class="t-body c-muted" style="margin-top:16px;">질문이 있으신가요?</div>
+      <div class="t-display c-primary">Thank you.</div>
+      <div class="t-body c-muted" style="margin-top:16px;">Questions?</div>
     </div>
     <div style="position:absolute; left:90px; bottom:80px; width:60px; height:8px;
                 background:var(--accent);"></div>
@@ -95,19 +112,21 @@
     new Chart(document.getElementById('rev'), {
       type: 'bar',
       data: {
-        labels: ['1분기', '2분기', '3분기', '4분기'],
+        labels: ['Q1', 'Q2', 'Q3', 'Q4'],
         datasets: [
-          { label: '무료', data: [120, 110, 98, 90], backgroundColor: accent },
-          { label: '유료', data: [60, 115, 150, 180], backgroundColor: secondary },
+          { label: 'Free', data: [120, 110, 98, 90], backgroundColor: accent },
+          { label: 'Paid', data: [60, 115, 150, 180], backgroundColor: secondary },
         ],
       },
       options: {
         responsive: true, maintainAspectRatio: false,
         animation: false,                       // must be off for a clean capture
-        plugins: { legend: { labels: { font: { family: 'Noto Sans CJK KR' } } } },
+        // Latin deck → 'Arial'. For a CJK deck use 'Noto Sans CJK KR'
+        // (or JP/SC/TC) here, or the chart's axis/legend labels render as tofu.
+        plugins: { legend: { labels: { font: { family: 'Arial' } } } },
         scales: {
-          x: { ticks: { font: { family: 'Noto Sans CJK KR' } } },
-          y: { ticks: { font: { family: 'Noto Sans CJK KR' } } },
+          x: { ticks: { font: { family: 'Arial' } } },
+          y: { ticks: { font: { family: 'Arial' } } },
         },
       },
     });

--- a/agent-k/src/agents/skill/pptx/script/verify_pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/verify_pptx.py
@@ -8,8 +8,9 @@ Usage (inside the sandbox):
     issues = verify("/workspace/artifacts/deck.pptx")
     print(summarize(issues))
 
-`verify()` returns a dict with five check keys: `palette`, `fonts`,
-`sizes`, `page_numbers`, `overlap`. An empty list per key = passed.
+`verify()` returns a dict with `slide_count` plus five check keys:
+`palette`, `fonts`, `sizes`, `page_numbers`, `overlap`. An empty list
+per check = passed.
 Heuristic: catches the most-violated SKILL.md rules, not every nuance.
 
 Decks are built by html2pptx.py, which DECOMPOSES each slide into native
@@ -24,7 +25,7 @@ whether the palette fits the subject.
 
 There is no `overflow` check (boxes are sized to browser-measured text,
 and frozen lines can't re-wrap), no `word_wrap` check (`word_wrap=False`
-is now the intended design everywhere), and no native-chart check (charts
+is the intended design everywhere), and no native-chart check (charts
 are raster pictures).
 """
 

--- a/agent-k/src/agents/skill/pptx/script/verify_pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/verify_pptx.py
@@ -8,10 +8,11 @@ Usage (inside the sandbox):
     issues = verify("/workspace/artifacts/deck.pptx")
     print(summarize(issues))
 
-`verify()` returns a dict with `slide_count` plus six check keys:
-`palette`, `fonts`, `sizes`, `page_numbers`, `overlap`, `dead_bottom`.
-An empty list per check = passed.
-Heuristic: catches the most-violated SKILL.md rules, not every nuance.
+`verify()` returns a dict with `slide_count` plus five check keys:
+`palette`, `fonts`, `sizes`, `page_numbers`, `overlap`. An empty list
+per check = passed. Heuristic: catches the most-violated SKILL.md rules,
+not every nuance. (Empty lower bands / dead space are left to the visual
+contact-sheet read — geometry can't tell hollow from full.)
 
 Decks are built by html2pptx.py, which DECOMPOSES each slide into native
 objects: editable text boxes (with FROZEN line breaks — `word_wrap=False`
@@ -453,52 +454,6 @@ def check_overlap(prs) -> list[tuple[int, str, str, float]]:
     return issues
 
 
-def check_dead_bottom(prs) -> list[tuple[int, int]]:
-    """Flag content slides whose real content ends high, leaving a big empty
-    band at the bottom (the recurring "dead-bottom" — short content top-aligned,
-    lower third blank). "Real content" = text boxes (excluding the footer band)
-    plus pictures/charts; empty container shapes and edge strips don't count, so
-    a stretched-but-hollow card is still caught.
-
-    Conservative — skips slide 1 (title), slide N (closing), and dramatic-beat
-    slides (a >= 56pt run marks a divider / hero / quote, which use space on
-    purpose). Returns list of (slide_idx, content_bottom_px).
-    """
-    PICTURE = 13               # MSO_SHAPE_TYPE.PICTURE
-    EMU_PX = 9525              # EMU per px at 96 dpi
-    FOOTER_TOP_PX = 620        # text starting below this is footer / page number
-    CONTENT_FLOOR_PX = 640     # content should reach near here (above the footer)
-    DEAD_BAND_PX = 200         # empty band below content larger than this → flag
-
-    n = len(prs.slides)
-    issues: list[tuple[int, int]] = []
-    for i, slide in enumerate(prs.slides, 1):
-        if i == 1 or i == n:
-            continue
-        max_bottom = 0.0
-        max_font = 0.0
-        has_content = False
-        for sh in slide.shapes:
-            if sh.top is None or sh.height is None:
-                continue
-            top = sh.top / EMU_PX
-            bottom = top + sh.height / EMU_PX
-            has_text = sh.has_text_frame and sh.text_frame.text.strip()
-            if has_text:
-                for para in sh.text_frame.paragraphs:
-                    for run in para.runs:
-                        if run.font.size:
-                            max_font = max(max_font, run.font.size.pt)
-            if (has_text and top < FOOTER_TOP_PX) or sh.shape_type == PICTURE:
-                has_content = True
-                max_bottom = max(max_bottom, bottom)
-        if not has_content or max_font >= 56:
-            continue
-        if CONTENT_FLOOR_PX - max_bottom > DEAD_BAND_PX:
-            issues.append((i, round(max_bottom)))
-    return issues
-
-
 # --- top-level ----------------------------------------------------------------
 
 def verify(pptx_path: str | Path) -> dict[str, Any]:
@@ -516,7 +471,6 @@ def verify(pptx_path: str | Path) -> dict[str, Any]:
         "sizes": check_size_discipline(prs),
         "page_numbers": check_page_numbers(prs),
         "overlap": check_overlap(prs),
-        "dead_bottom": check_dead_bottom(prs),
     }
 
 
@@ -535,8 +489,6 @@ def summarize(issues: dict[str, Any]) -> str:
         flags.append(f"{len(issues['page_numbers'])} page-number violations")
     if issues.get("overlap"):
         flags.append(f"{len(issues['overlap'])} text overlaps")
-    if issues.get("dead_bottom"):
-        flags.append(f"{len(issues['dead_bottom'])} slides with a dead bottom band")
     if not flags:
         return f"{n} slides — all checks passed ({p['distinct']} palette colors)."
     return f"{n} slides — issues: {' · '.join(flags)}"

--- a/agent-k/src/agents/skill/pptx/script/verify_pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/verify_pptx.py
@@ -8,10 +8,22 @@ Usage (inside the sandbox):
     issues = verify("/workspace/artifacts/deck.pptx")
     print(summarize(issues))
 
-`verify()` returns a dict with eight check keys: `palette`, `fonts`,
-`sizes`, `overflow`, `page_numbers`, `overlap`, `chart_strict`,
-`word_wrap`. An empty list per key = passed. Heuristic: catches the
-most-violated SKILL.md rules, not every nuance.
+`verify()` returns a dict with five check keys: `palette`, `fonts`,
+`sizes`, `page_numbers`, `overlap`. An empty list per key = passed.
+Heuristic: catches the most-violated SKILL.md rules, not every nuance.
+
+Decks are built by html2pptx.py, which DECOMPOSES each slide into native
+objects: editable text boxes (with FROZEN line breaks — `word_wrap=False`
++ hard `<a:br/>`, so the viewer can't re-wrap CJK), native autoshapes for
+simple boxes/borders/markers, a picture per chart/image, and a native
+solid slide-background fill. `fonts`/`sizes`/`page_numbers`/`overlap`
+apply to the text boxes; `palette` reflects text-run colors (advisory —
+lean on visual inspection).
+
+There is no `overflow` check (boxes are sized to browser-measured text,
+and frozen lines can't re-wrap), no `word_wrap` check (`word_wrap=False`
+is now the intended design everywhere), and no native-chart check (charts
+are raster pictures).
 """
 
 from __future__ import annotations
@@ -20,7 +32,6 @@ from pathlib import Path
 from typing import Any
 
 from pptx import Presentation
-from pptx.enum.text import MSO_AUTO_SIZE
 from pptx.oxml.ns import qn
 
 
@@ -241,90 +252,6 @@ def check_size_discipline(prs) -> list[tuple[int, list[int]]]:
     return issues
 
 
-def check_overflow(prs) -> list[tuple[int, str, str]]:
-    """Estimate text clipping in fixed-size text boxes.
-
-    A box overflows when the estimated rendered height exceeds the
-    drawable height (box minus internal margins). Korean glyphs count
-    as 2 ASCII widths. Autosize boxes are skipped — `SHAPE_TO_FIT_TEXT`
-    grows the box (geometric overlap is a visual-inspection question)
-    and `TEXT_TO_FIT_SHAPE` shrinks the text (our pt-based estimate
-    would always over-report clipping).
-
-    Returns list of (slide_idx, snippet, reason).
-    """
-    AUTOSIZE_SKIP = {MSO_AUTO_SIZE.SHAPE_TO_FIT_TEXT, MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE}
-    issues: list[tuple[int, str, str]] = []
-    for i, slide in enumerate(prs.slides, 1):
-        for shape in slide.shapes:
-            if not shape.has_text_frame:
-                continue
-            try:
-                w_in = shape.width / 914400 if shape.width else 0
-                h_in = shape.height / 914400 if shape.height else 0
-            except (AttributeError, TypeError):
-                continue
-            if w_in <= 0 or h_in <= 0:
-                continue
-            tf = shape.text_frame
-
-            # Skip autosize boxes (see docstring for why).
-            try:
-                if tf.auto_size in AUTOSIZE_SKIP:
-                    continue
-            except AttributeError:
-                pass
-
-            # Subtract internal margins so the estimate reflects drawable
-            # area. python-pptx default: L/R 0.1", T/B 0.05".
-            try:
-                ml = (tf.margin_left or 0) / 914400
-                mr = (tf.margin_right or 0) / 914400
-                mt = (tf.margin_top or 0) / 914400
-                mb = (tf.margin_bottom or 0) / 914400
-            except AttributeError:
-                ml = mr = 0.1
-                mt = mb = 0.05
-            effective_w = max(0.1, w_in - ml - mr)
-            effective_h = max(0.1, h_in - mt - mb)
-
-            total_h = 0.0
-            sample = ""
-            for para in tf.paragraphs:
-                run_texts = [r.text for r in para.runs if r.text]
-                if not run_texts:
-                    continue
-                text = "".join(run_texts)
-                font_pt = 14
-                for r in para.runs:
-                    try:
-                        if r.font.size:
-                            font_pt = max(font_pt, round(r.font.size.pt))
-                    except AttributeError:
-                        pass
-                ls = 1.2
-                try:
-                    if para.line_spacing and isinstance(para.line_spacing, float):
-                        ls = para.line_spacing
-                except AttributeError:
-                    pass
-                units = sum(2 if ord(ch) > 0x7F else 1 for ch in text)
-                chars_per_line = max(1, int(effective_w * 12 * 14 / font_pt))
-                lines = max(1, -(-units // chars_per_line))
-                total_h += lines * font_pt * ls / 72
-                if not sample:
-                    sample = text.strip()[:40]
-
-            grow_abs = total_h - effective_h
-            grow_ratio = total_h / effective_h if effective_h > 0 else 1
-            if grow_abs > 0.1 or grow_ratio > 1.25:
-                issues.append((
-                    i, sample,
-                    f"text needs {total_h:.2f}\" but box is {effective_h:.2f}\""
-                ))
-    return issues
-
-
 def check_page_numbers(prs) -> list[tuple[int, str]]:
     """Title (slide 1) and closing (slide N) must not carry a page number.
 
@@ -472,7 +399,9 @@ def check_overlap(prs) -> list[tuple[int, str, str, float]]:
         min_w = min(aw, bw)
         if min_h <= 0 or min_w <= 0:
             return False
-        return (y_overlap / min_h) < 0.30 and (x_overlap / min_w) > 0.80
+        # 0.45 tolerance absorbs the small CJK height cushion html2pptx
+        # adds, which would otherwise flag eyebrow+title stacks as collisions.
+        return (y_overlap / min_h) < 0.45 and (x_overlap / min_w) > 0.70
 
     def classify(sh, b):
         """Return (kind, label) or (None, None) if not a candidate."""
@@ -554,95 +483,6 @@ def check_overlap(prs) -> list[tuple[int, str, str, float]]:
     return issues
 
 
-def check_chart_strict(prs) -> list[tuple[int, str, str]]:
-    """Flag chart XML that strict-mode PowerPoint will reject.
-
-    Two known bits python-pptx (and per-slice-color helper code) leaves
-    out — Google Slides / LibreOffice / soffice ignore them, but
-    PowerPoint fires the recovery dialog and strips the chart,
-    leaving an apparently-blank slide:
-
-      1. `<a:endParaRPr>` missing `lang` (doughnut/pie templates).
-      2. `<c:dPt>` missing `<c:bubble3D>` (per-slice color setup).
-
-    Patch chart XML with `patch_chart_xml()` (see SKILL.md Charts
-    section) right after `add_chart()`.
-
-    Returns (slide_idx, chart_name, issue).
-    """
-    issues: list[tuple[int, str, str]] = []
-    for idx, slide in enumerate(prs.slides, start=1):
-        for sh in slide.shapes:
-            if not getattr(sh, "has_chart", False):
-                continue
-            cs = sh.chart._chartSpace
-            for ep in cs.iter(qn("a:endParaRPr")):
-                if ep.get("lang") is None:
-                    issues.append((idx, sh.name, "endParaRPr missing lang"))
-                    break
-            for dPt in cs.iter(qn("c:dPt")):
-                if dPt.find(qn("c:bubble3D")) is None:
-                    issues.append((idx, sh.name, "dPt missing bubble3D"))
-                    break
-    return issues
-
-
-def check_word_wrap(prs) -> list[tuple[int, str]]:
-    """Flag text frames with `word_wrap = False` whose text won't fit on one line.
-
-    strict-mode PowerPoint respects `word_wrap = False` literally and grows the
-    shape *horizontally* to fit text on a single line — pushing text
-    past the designed box width onto neighboring elements. soffice and
-    Google Slides force-wrap regardless, so the failure is invisible
-    in the sandbox PNG.
-
-    Short labels ("Q1", "3 / 10", "187억") fit on one line anyway and
-    pass; only multi-token bodies whose single-line estimate exceeds
-    box width are flagged.
-
-    Returns (slide_idx, snippet).
-    """
-    issues: list[tuple[int, str]] = []
-    for i, slide in enumerate(prs.slides, 1):
-        for shape in slide.shapes:
-            if not shape.has_text_frame:
-                continue
-            tf = shape.text_frame
-            if tf.word_wrap is not False:
-                continue
-            text = tf.text.strip()
-            if not text:
-                continue
-            try:
-                w_in = shape.width / 914400 if shape.width else 0
-            except (AttributeError, TypeError):
-                continue
-            if w_in <= 0:
-                continue
-            try:
-                ml = (tf.margin_left or 0) / 914400
-                mr = (tf.margin_right or 0) / 914400
-            except AttributeError:
-                ml = mr = 0.1
-            effective_w = max(0.1, w_in - ml - mr)
-            font_pt = 14
-            for para in tf.paragraphs:
-                for r in para.runs:
-                    try:
-                        if r.font.size:
-                            font_pt = max(font_pt, round(r.font.size.pt))
-                    except AttributeError:
-                        pass
-            # CJK glyphs count as 2 ASCII widths; ~12 ASCII units per inch at 14pt.
-            units = sum(2 if ord(ch) > 0x7F else 1 for ch in text)
-            chars_per_line = max(1, int(effective_w * 12 * 14 / font_pt))
-            # Flag only when the deficit is clear (>30% over). Borderline
-            # one-line labels (e.g. "32.4%" in a 0.45" box at 18pt) pass.
-            if units > chars_per_line * 1.3:
-                issues.append((i, text[:40].replace("\n", " ")))
-    return issues
-
-
 # --- top-level ----------------------------------------------------------------
 
 def verify(pptx_path: str | Path) -> dict[str, Any]:
@@ -658,11 +498,8 @@ def verify(pptx_path: str | Path) -> dict[str, Any]:
         "palette": check_palette(prs),
         "fonts": check_fonts(prs),
         "sizes": check_size_discipline(prs),
-        "overflow": check_overflow(prs),
         "page_numbers": check_page_numbers(prs),
         "overlap": check_overlap(prs),
-        "chart_strict": check_chart_strict(prs),
-        "word_wrap": check_word_wrap(prs),
     }
 
 
@@ -677,22 +514,10 @@ def summarize(issues: dict[str, Any]) -> str:
         flags.append(f"{len(issues['fonts'])} CJK runs missing EA typeface")
     if issues["sizes"]:
         flags.append(f"{len(issues['sizes'])} slides with 5+ scale sizes")
-    if issues["overflow"]:
-        flags.append(f"{len(issues['overflow'])} fixed-size text boxes clip")
     if issues["page_numbers"]:
         flags.append(f"{len(issues['page_numbers'])} page-number violations")
     if issues.get("overlap"):
-        flags.append(f"{len(issues['overlap'])} shape overlaps")
-    if issues.get("chart_strict"):
-        flags.append(
-            f"{len(issues['chart_strict'])} chart XML violations "
-            "(strict PowerPoint strips them)"
-        )
-    if issues.get("word_wrap"):
-        flags.append(
-            f"{len(issues['word_wrap'])} text boxes with word_wrap=False "
-            "overflow horizontally in strict-mode PowerPoint"
-        )
+        flags.append(f"{len(issues['overlap'])} text overlaps")
     if not flags:
         return f"{n} slides — all checks passed ({p['matched']})."
     return f"{n} slides — issues: {' · '.join(flags)}"

--- a/agent-k/src/agents/skill/pptx/script/verify_pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/verify_pptx.py
@@ -8,9 +8,9 @@ Usage (inside the sandbox):
     issues = verify("/workspace/artifacts/deck.pptx")
     print(summarize(issues))
 
-`verify()` returns a dict with `slide_count` plus five check keys:
-`palette`, `fonts`, `sizes`, `page_numbers`, `overlap`. An empty list
-per check = passed.
+`verify()` returns a dict with `slide_count` plus six check keys:
+`palette`, `fonts`, `sizes`, `page_numbers`, `overlap`, `dead_bottom`.
+An empty list per check = passed.
 Heuristic: catches the most-violated SKILL.md rules, not every nuance.
 
 Decks are built by html2pptx.py, which DECOMPOSES each slide into native
@@ -453,6 +453,52 @@ def check_overlap(prs) -> list[tuple[int, str, str, float]]:
     return issues
 
 
+def check_dead_bottom(prs) -> list[tuple[int, int]]:
+    """Flag content slides whose real content ends high, leaving a big empty
+    band at the bottom (the recurring "dead-bottom" — short content top-aligned,
+    lower third blank). "Real content" = text boxes (excluding the footer band)
+    plus pictures/charts; empty container shapes and edge strips don't count, so
+    a stretched-but-hollow card is still caught.
+
+    Conservative — skips slide 1 (title), slide N (closing), and dramatic-beat
+    slides (a >= 56pt run marks a divider / hero / quote, which use space on
+    purpose). Returns list of (slide_idx, content_bottom_px).
+    """
+    PICTURE = 13               # MSO_SHAPE_TYPE.PICTURE
+    EMU_PX = 9525              # EMU per px at 96 dpi
+    FOOTER_TOP_PX = 620        # text starting below this is footer / page number
+    CONTENT_FLOOR_PX = 640     # content should reach near here (above the footer)
+    DEAD_BAND_PX = 200         # empty band below content larger than this → flag
+
+    n = len(prs.slides)
+    issues: list[tuple[int, int]] = []
+    for i, slide in enumerate(prs.slides, 1):
+        if i == 1 or i == n:
+            continue
+        max_bottom = 0.0
+        max_font = 0.0
+        has_content = False
+        for sh in slide.shapes:
+            if sh.top is None or sh.height is None:
+                continue
+            top = sh.top / EMU_PX
+            bottom = top + sh.height / EMU_PX
+            has_text = sh.has_text_frame and sh.text_frame.text.strip()
+            if has_text:
+                for para in sh.text_frame.paragraphs:
+                    for run in para.runs:
+                        if run.font.size:
+                            max_font = max(max_font, run.font.size.pt)
+            if (has_text and top < FOOTER_TOP_PX) or sh.shape_type == PICTURE:
+                has_content = True
+                max_bottom = max(max_bottom, bottom)
+        if not has_content or max_font >= 56:
+            continue
+        if CONTENT_FLOOR_PX - max_bottom > DEAD_BAND_PX:
+            issues.append((i, round(max_bottom)))
+    return issues
+
+
 # --- top-level ----------------------------------------------------------------
 
 def verify(pptx_path: str | Path) -> dict[str, Any]:
@@ -470,6 +516,7 @@ def verify(pptx_path: str | Path) -> dict[str, Any]:
         "sizes": check_size_discipline(prs),
         "page_numbers": check_page_numbers(prs),
         "overlap": check_overlap(prs),
+        "dead_bottom": check_dead_bottom(prs),
     }
 
 
@@ -488,6 +535,8 @@ def summarize(issues: dict[str, Any]) -> str:
         flags.append(f"{len(issues['page_numbers'])} page-number violations")
     if issues.get("overlap"):
         flags.append(f"{len(issues['overlap'])} text overlaps")
+    if issues.get("dead_bottom"):
+        flags.append(f"{len(issues['dead_bottom'])} slides with a dead bottom band")
     if not flags:
         return f"{n} slides — all checks passed ({p['distinct']} palette colors)."
     return f"{n} slides — issues: {' · '.join(flags)}"

--- a/agent-k/src/agents/skill/pptx/script/verify_pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/verify_pptx.py
@@ -17,8 +17,10 @@ objects: editable text boxes (with FROZEN line breaks — `word_wrap=False`
 + hard `<a:br/>`, so the viewer can't re-wrap CJK), native autoshapes for
 simple boxes/borders/markers, a picture per chart/image, and a native
 solid slide-background fill. `fonts`/`sizes`/`page_numbers`/`overlap`
-apply to the text boxes; `palette` reflects text-run colors (advisory —
-lean on visual inspection).
+apply to the text boxes; `palette` checks DISCIPLINE — that the deck uses a
+small, locked set of colors (composed per deck, not a fixed gallery), not
+that it matches a known palette. Advisory; lean on visual inspection for
+whether the palette fits the subject.
 
 There is no `overflow` check (boxes are sized to browser-measured text,
 and frozen lines can't re-wrap), no `word_wrap` check (`word_wrap=False`
@@ -35,43 +37,8 @@ from pptx import Presentation
 from pptx.oxml.ns import qn
 
 
-# --- palette gallery (mirrors SKILL.md) ---------------------------------------
-
-GALLERY: dict[str, set[str]] = {
-    "Corporate Slate": {
-        "0F172A", "2563EB", "F59E0B", "F8FAFC", "FFFFFF",
-        "64748B", "E2E8F0", "10B981", "EF4444",
-    },
-    "Midnight Keynote": {
-        "0B1220", "818CF8", "22D3EE", "1F2937", "94A3B8",
-        "34D399", "F87171",
-    },
-    "Warm Editorial": {
-        "7C2D12", "EA580C", "FACC15", "FFF7ED", "FFFFFF",
-        "9A3412", "FED7AA", "15803D", "B91C1C",
-    },
-    "Forest Research": {
-        "1F2937", "047857", "D97706", "FFFFFF", "F9FAFB",
-        "6B7280", "E5E7EB", "059669", "DC2626",
-    },
-    "Mono Editorial": {
-        "111827", "FFFFFF", "6B7280", "E5E7EB", "059669", "DC2626",
-    },
-    "Playful Violet": {
-        "4C1D95", "14B8A6", "F472B6", "FAF5FF", "FFFFFF",
-        "6D28D9", "E9D5FF", "16A34A", "E11D48",
-    },
-    "Sand & Ink": {
-        "1C1917", "57534E", "B45309", "FAFAF9", "FFFFFF",
-        "78716C", "E7E5E4", "15803D", "B91C1C",
-    },
-    "Glacier": {
-        "0E7490", "0891B2", "F97316", "F0F9FF", "FFFFFF",
-        "475569", "BAE6FD", "16A34A", "DC2626",
-    },
-}
-
-# Pure white / black aren't brand colours; exclude from off-gallery.
+# Pure white / black are neutrals, not brand colours; excluded from the
+# palette-discipline count below.
 NEUTRAL_TOLERATED: set[str] = {"FFFFFF", "000000"}
 
 
@@ -116,72 +83,71 @@ def _iter_runs(slide):
                 yield shape, para, run
 
 
-def _collect_fills(prs) -> list[str]:
-    """All solid fill hex colors across the deck, uppercased."""
-    out: list[str] = []
-    for slide in prs.slides:
-        for shape in slide.shapes:
-            try:
-                if shape.fill.type == 1:  # solid
-                    out.append(str(shape.fill.fore_color.rgb).upper())
-            except (AttributeError, TypeError):
-                # No fill / theme-based fill / placeholder without fill.
-                pass
-            if shape.has_text_frame:
-                for para in shape.text_frame.paragraphs:
-                    for run in para.runs:
-                        try:
-                            rgb = run.font.color.rgb
-                            if rgb is not None:
-                                out.append(str(rgb).upper())
-                        except (AttributeError, TypeError):
-                            # Run inherits color from theme — no rgb to read.
-                            pass
-    return out
+def _slide_colors(slide) -> set[str]:
+    """Distinct non-neutral solid-fill + text-run colors on one slide."""
+    cols: set[str] = set()
+    for shape in slide.shapes:
+        try:
+            if shape.fill.type == 1:  # solid
+                h = str(shape.fill.fore_color.rgb).upper()
+                if h not in NEUTRAL_TOLERATED:
+                    cols.add(h)
+        except (AttributeError, TypeError):
+            pass  # no fill / theme fill / placeholder
+        if shape.has_text_frame:
+            for para in shape.text_frame.paragraphs:
+                for run in para.runs:
+                    try:
+                        rgb = run.font.color.rgb
+                        if rgb is not None:
+                            h = str(rgb).upper()
+                            if h not in NEUTRAL_TOLERATED:
+                                cols.add(h)
+                    except (AttributeError, TypeError):
+                        pass  # inherits theme color
+    return cols
 
 
 # --- checks -------------------------------------------------------------------
 
+# A composed palette runs ~7-10 non-neutral colors (primary/secondary/accent/
+# muted/hairline/positive/negative, plus a tinted bg/surface and maybe a chart
+# tint — only pure #FFFFFF/#000000 are treated as neutral). Past this it reads
+# as palette sprawl, not a locked palette. Kept generous so a legitimately
+# composed warm/tinted palette isn't flagged.
+PALETTE_LIMIT = 12
+
+
 def check_palette(prs) -> dict[str, Any]:
-    """Detect which gallery palette is in use, and report off-gallery colors.
+    """Palette DISCIPLINE — a composed deck should use a small, locked set of
+    colors, consistent across slides. (There is no fixed gallery to match;
+    palettes are composed per deck from the subject — see SKILL.md.)
 
-    Coverage is *frequency-weighted* — each fill occurrence counts, so one
-    stray hex on one slide of a 30-slide deck stays near 1.0 (a set-based
-    score would crash). Compliant = coverage >= 0.85 against one palette.
+    Collects distinct non-neutral solid-fill + text-run colors per slide.
+    Reports the distinct count, the colors, and any `stray` color that appears
+    on only ONE slide (a new hex introduced mid-deck). Compliant when the
+    distinct count is small (<= PALETTE_LIMIT). Advisory — visual inspection
+    judges whether the palette actually fits the subject.
 
-    Returns {"matched": <name>|"custom"|"none", "coverage": float,
-              "off_gallery": [hex, ...]}.
+    Returns {"distinct": int, "colors": [hex,...], "stray": [hex,...],
+              "ok": bool}.
     """
     from collections import Counter
 
-    fills = [f for f in _collect_fills(prs) if f not in NEUTRAL_TOLERATED]
-    if not fills:
-        return {"matched": "none", "coverage": 0.0, "off_gallery": []}
+    n_slides = len(prs.slides)
+    appears_on: Counter = Counter()
+    for slide in prs.slides:
+        for h in _slide_colors(slide):
+            appears_on[h] += 1
 
-    counts = Counter(fills)
-    total = sum(counts.values())
-    best_name = "custom"
-    best_coverage = 0.0
-    best_off: set[str] = set(counts)
-
-    for name, palette in GALLERY.items():
-        matched = sum(c for h, c in counts.items() if h in palette)
-        coverage = matched / total if total else 0.0
-        if coverage > best_coverage:
-            best_coverage = coverage
-            best_name = name
-            best_off = {h for h in counts if h not in palette}
-
-    if best_coverage < 0.5:
-        return {
-            "matched": "custom",
-            "coverage": round(best_coverage, 2),
-            "off_gallery": sorted(counts),
-        }
+    distinct = sorted(appears_on)
+    # A color on a single slide of a multi-slide deck = introduced mid-deck.
+    stray = sorted(h for h, c in appears_on.items() if c == 1) if n_slides >= 3 else []
     return {
-        "matched": best_name,
-        "coverage": round(best_coverage, 2),
-        "off_gallery": sorted(best_off),
+        "distinct": len(distinct),
+        "colors": distinct,
+        "stray": stray,
+        "ok": len(distinct) <= PALETTE_LIMIT,
     }
 
 
@@ -508,8 +474,8 @@ def summarize(issues: dict[str, Any]) -> str:
     n = issues["slide_count"]
     p = issues["palette"]
     flags = []
-    if p["matched"] not in {"none"} and p["coverage"] < 0.85:
-        flags.append(f"palette drift ({p['coverage']:.0%})")
+    if not p.get("ok", True):
+        flags.append(f"palette sprawl ({p['distinct']} distinct colors)")
     if issues["fonts"]:
         flags.append(f"{len(issues['fonts'])} CJK runs missing EA typeface")
     if issues["sizes"]:
@@ -519,7 +485,7 @@ def summarize(issues: dict[str, Any]) -> str:
     if issues.get("overlap"):
         flags.append(f"{len(issues['overlap'])} text overlaps")
     if not flags:
-        return f"{n} slides — all checks passed ({p['matched']})."
+        return f"{n} slides — all checks passed ({p['distinct']} palette colors)."
     return f"{n} slides — issues: {' · '.join(flags)}"
 
 

--- a/agent-k/src/agents/skill/pptx/script/verify_pptx.py
+++ b/agent-k/src/agents/skill/pptx/script/verify_pptx.py
@@ -165,18 +165,19 @@ def check_fonts(prs) -> list[tuple[int, str]]:
             if _ea_typeface(run) is None:
                 snippet = text.strip()[:40]
                 issues.append((i, snippet))
-                # one report per run is enough; continue
     return issues
 
 
 def check_size_discipline(prs) -> list[tuple[int, list[int]]]:
     """Flag slides that mix too many tier / out-of-tier sizes.
 
-    Tier bounds (~±30% around canonical pt): caption 8-15, body 16-24,
-    title 25-44, display 45-90. Sizes in the same tier collapse to one;
-    out-of-tier sizes count individually. Flag at 5+ distinct classes
-    per slide — with only four tiers, that requires all four plus a
-    stray size.
+    The scale is composed per deck (SKILL.md "Type scale"), so tiers are wide
+    bands covering its ranges: caption ≤11, body 12-20, title 21-35, display
+    36-90 pt. Sizes in the same tier collapse to one; out-of-tier sizes count
+    individually, except the first off-scale size per slide is a permitted
+    dramatic beat (hero number / divider numeral / quote glyph) and is not
+    counted. Flag at 5+ classes per slide — with only four tiers, that needs
+    all four plus 2+ off-scale sizes.
 
     Returns list of (slide_idx, sizes_found_on_slide).
     """
@@ -184,13 +185,13 @@ def check_size_discipline(prs) -> list[tuple[int, list[int]]]:
     def tier(pt: int) -> str | None:
         if pt <= 0:
             return None
-        if 8 <= pt <= 15:
+        if pt <= 11:
             return "caption"
-        if 16 <= pt <= 24:
+        if pt <= 20:
             return "body"
-        if 25 <= pt <= 44:
+        if pt <= 35:
             return "title"
-        if 45 <= pt <= 90:
+        if pt <= 90:
             return "display"
         return None  # outside scale → dramatic-beat or out-of-range
 
@@ -212,7 +213,9 @@ def check_size_discipline(prs) -> list[tuple[int, list[int]]]:
                         all_sizes.add(pt)
             except AttributeError:
                 continue
-        classes = len(tiers_used) + len(out_of_tier)
+        # One off-scale size per slide is an allowed dramatic beat (hero
+        # number, divider numeral, quote glyph) — don't count the first.
+        classes = len(tiers_used) + max(0, len(out_of_tier) - 1)
         if classes >= 5:
             issues.append((i, sorted(all_sizes)))
     return issues

--- a/agent-k/src/bin/test_case.rs
+++ b/agent-k/src/bin/test_case.rs
@@ -390,8 +390,17 @@ async fn build_corpus_store(
 
 async fn stream_turn(agent: &mut Agent, query: Message, log_prefix: &str) -> anyhow::Result<()> {
     let mut stream = agent.run(query);
+    let (mut lm_calls, mut tok_in, mut tok_out, mut tok_cr, mut tok_cw) =
+        (0u64, 0u64, 0u64, 0u64, 0u64);
     while let Some(event) = stream.next().await {
         let event = event?;
+        if let Some(u) = &event.usage {
+            lm_calls += 1;
+            tok_in += u.input_tokens;
+            tok_out += u.output_tokens;
+            tok_cr += u.cache_read_input_tokens.unwrap_or(0);
+            tok_cw += u.cache_creation_input_tokens.unwrap_or(0);
+        }
         let msg = &event.message;
         match msg.role {
             Role::Assistant => {
@@ -426,6 +435,11 @@ async fn stream_turn(agent: &mut Agent, query: Message, log_prefix: &str) -> any
             _ => {}
         }
     }
+    println!(
+        "[{log_prefix}] TOKENS turn — lm_calls:{lm_calls} input:{tok_in} output:{tok_out} \
+         cache_read:{tok_cr} cache_write:{tok_cw} billable:{}",
+        tok_in + tok_out
+    );
     println!();
     Ok(())
 }

--- a/agent-k/src/bin/test_case.rs
+++ b/agent-k/src/bin/test_case.rs
@@ -165,6 +165,7 @@ async fn main() -> anyhow::Result<()> {
     }
     let case = cases.swap_remove(case_no);
 
+    sweep_orphan_sandboxes();
     prepare_dir(ARTIFACT_DIR);
     prepare_dir(DATA_DIR);
     prepare_dir(SHARED_DATA_DIR);
@@ -315,6 +316,51 @@ fn prepare_dir(dir: &str) {
     }
     if let Err(e) = std::fs::create_dir_all(path) {
         println!("[warn] failed to create {}: {e}", path.display());
+    }
+}
+
+/// Prune leftover `ailoy-*` sandbox dirs from prior runs that were force-killed
+/// before `Sandbox`'s `Drop` (the only place non-persist cleanup happens) could
+/// run. Skips entirely if any `msb` process is alive, and only removes dirs that
+/// haven't been touched for a few minutes — so a concurrent run's freshly-created
+/// sandbox is never deleted, even in the gap between `pgrep` and a real launch.
+/// Best-effort: failures are logged, never fatal.
+fn sweep_orphan_sandboxes() {
+    const STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(300);
+    let Some(home) = std::env::var_os("HOME") else { return };
+    let dir = std::path::Path::new(&home).join(".microsandbox/sandboxes");
+    let Ok(entries) = std::fs::read_dir(&dir) else { return };
+    let msb_alive = std::process::Command::new("pgrep")
+        .args(["-f", "microsandbox/bin/msb"])
+        .output()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(true);
+    if msb_alive {
+        return;
+    }
+    let now = std::time::SystemTime::now();
+    let mut pruned = 0;
+    for entry in entries.flatten() {
+        if !entry.file_name().to_string_lossy().starts_with("ailoy-") {
+            continue;
+        }
+        // Only sweep dirs idle for STALE_AFTER — never a sandbox mid-startup.
+        let recent = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| now.duration_since(t).ok())
+            .map(|age| age < STALE_AFTER)
+            .unwrap_or(true);
+        if recent {
+            continue;
+        }
+        if std::fs::remove_dir_all(entry.path()).is_ok() {
+            pruned += 1;
+        }
+    }
+    if pruned > 0 {
+        println!("[sweep] pruned {pruned} orphan sandbox dir(s)");
     }
 }
 


### PR DESCRIPTION
## Summary

Reworks the `pptx` coworker skill from "the model writes python-pptx code with hand-computed coordinates" to "the model authors each slide in **HTML/CSS** (charts via Chart.js / SVG / images), then converts to an **editable** `.pptx` and verifies it in LibreOffice."

Text and simple shapes round-trip as **native, editable** PowerPoint objects. only chart/image internals stay raster. Design fidelity is exactly what Chromium renders.

BEFORE:  model → outline.md → python-pptx code (manual x/y/w/h) → .pptx → verify
AFTER:   model → HTML/CSS → html2pptx.py (Chromium → native objects) → editable .pptx → verify + contact-sheet

## What's in here

**New converter — `script/html2pptx.py`**
- Renders each `.slide` (1280×720, 96px/in) in headless Chromium and decomposes it into native objects: text boxes, autoshapes (boxes/borders/bullet markers), one picture per chart/img/svg, and a native slide-background fill.
- **Frozen line breaks**: text is emitted `word_wrap=off` with hard `<a:br/>` at the browser's exact break positions, so soffice/PowerPoint can't re-wrap CJK differently from what was authored.
- Line grouping uses a **vertical-overlap fraction** so a big number + a small unit span sharing a baseline stays on one line, while genuine wraps are kept.
- Faint `rgba()` fills keep their transparency (`<a:alpha>`) so a light tint stays light instead of rendering opaque and hiding the text on it.
- Inline `<svg>` is detected as media. Auto-saves a self-contained `<out>.source.html` sidecar for review.

**Skill guidance — `SKILL.md`, `components.css`, `template.html`**
- Per-deck **palette composition** (fixed role structure, hex values derived from the subject) instead of a fixed gallery, plus a distinctiveness self-check and a subject-grounding step.
- Type scale is composed per deck too — four `--fs-*` size variables sized to the deck's density and locked, mirroring the palette; `components.css` and its helper classes consume them.
- `components.css` is a role-variable system (type scale, grid, shape vocabulary) so decks read "designed, not assembled."
- Authors `deck.html` straight from the source (no intermediate outline file). bookend/takeaway-title rules folded into the authoring step.
- Design guidance to **fill the canvas**: use the space at scale, carry a sparse slide with a chart/table instead of white space, and anchor two-column cards and exec-summary stat rows so the lower half isn't dead. (See before/after.)
- A **completion guard** — the deliverable is the `.pptx`, not the HTML. the run isn't done until the file exists and verify passes.
- Requires the full toolchain install up front (incl. `playwright install-deps`) so the first conversion can't fail on missing browser libraries.

**Verification — `script/verify_pptx.py`, `script/contact_sheet.py`**
- Five checks (fonts/sizes/page_numbers/overlap/palette-discipline).
- `contact_sheet.py` renders the soffice-produced PDF with **pypdfium2** (writing a `slide-N.png` per page) and montages them into one sheet for cheap visual QA
  — `read` the sheet once, deep-read only suspect slides.

**Harness — `src/bin/test_case.rs`**
- Per-turn token-usage logging; startup sweep of orphaned `ailoy-*` sandbox dirs.

## Dependencies / licensing

Runtime tools are installed in the sandbox, not vendored. All permissive — no strong copyleft: python-pptx (MIT), playwright + Chromium (Apache-2.0 / BSD), pypdfium2 / PDFium (Apache-2.0 / BSD), Pillow (HPND). The image bakes in LibreOffice (MPL-2.0) and Noto/Liberation fonts (OFL). poppler (GPL) was dropped in favor of pypdfium2.

## Results (case 20, billable tokens / LM calls)

| Model  | Old (python-pptx) | New (HTML-authored) |
|--------|-------------------|---------------------|
| claude | 1,919,338 / 39    | 484K–1.14M / 14–28  |
| gemini | 2,107,522 / 45    | 899K–1.07M / 20–32  |
| openai | 1,213,234 / 37    | 726,029 / 27        |

~40–75% fewer tokens than the old python-pptx skill across all three models (run-to-run variance from QA-fix loops). Decks verified clean and rendered correctly in LibreOffice for claude, gemini, and openai. The design guidance (fill-the-canvas, type scale) lands well on stronger models; faster/weaker models (gemini-flash) follow it partially — it's prose guidance, not a hard gate.


<details>
<summary><h3>Image</h3></summary>

-gemini-
-before-
<img width="943" height="535" alt="스크린샷 2026-06-23 오전 10 30 47" src="https://github.com/user-attachments/assets/7fd21382-10ef-487b-a63f-04a82ce736b3" />
-after-
<img width="938" height="528" alt="스크린샷 2026-06-23 오전 10 30 55" src="https://github.com/user-attachments/assets/1692ac7b-39de-4e50-945a-5d24b4f65920" />


-gpt-
-before-
<img width="952" height="540" alt="스크린샷 2026-06-23 오전 10 35 19" src="https://github.com/user-attachments/assets/fd6ff990-256b-4c36-b7a4-18b8c2169110" />
<img width="261" height="263" alt="스크린샷 2026-06-23 오전 10 37 05" src="https://github.com/user-attachments/assets/e443d6ce-ffa2-424b-9109-e1c6f42aca7c" />
-after-
<img width="944" height="531" alt="스크린샷 2026-06-23 오전 10 35 51" src="https://github.com/user-attachments/assets/cfe014db-be29-4cfc-ad18-9783f9a56c97" />


-claude-
-before-
<img width="949" height="532" alt="스크린샷 2026-06-23 오전 10 41 19" src="https://github.com/user-attachments/assets/9bbd31c9-43d3-4698-bed0-f2837d653d05" />
-after-
<img width="946" height="532" alt="스크린샷 2026-06-23 오전 10 41 01" src="https://github.com/user-attachments/assets/fccfd4ad-beb3-407c-b4a2-10d96cb15cc5" />

</details>

Resolved #195