### PR TITLE
feat: live token streaming for agent responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=7edb361f2c984d788b64f7d4987ad5e8c28467a7#7edb361f2c984d788b64f7d4987ad5e8c28467a7"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=d22f76b2e3949778b671418eabd38463c6b012fc#d22f76b2e3949778b671418eabd38463c6b012fc"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=2086bfdac663f81d3ca230b7fb4856a702576577#2086bfdac663f81d3ca230b7fb4856a702576577"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=226d1a6ab841ddd77f37e82814166044112dfd3e#226d1a6ab841ddd77f37e82814166044112dfd3e"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=226d1a6ab841ddd77f37e82814166044112dfd3e#226d1a6ab841ddd77f37e82814166044112dfd3e"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=dc3d7bc19e400a4d0d4d850e55bec80bfa95aa8b#dc3d7bc19e400a4d0d4d850e55bec80bfa95aa8b"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=d22f76b2e3949778b671418eabd38463c6b012fc#d22f76b2e3949778b671418eabd38463c6b012fc"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=2086bfdac663f81d3ca230b7fb4856a702576577#2086bfdac663f81d3ca230b7fb4856a702576577"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=74f4e238070d2cec752285394b527a86c023a082#74f4e238070d2cec752285394b527a86c023a082"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=7edb361f2c984d788b64f7d4987ad5e8c28467a7#7edb361f2c984d788b64f7d4987ad5e8c28467a7"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=dc3d7bc19e400a4d0d4d850e55bec80bfa95aa8b#dc3d7bc19e400a4d0d4d850e55bec80bfa95aa8b"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=5c2133ade78f84f88519e459c3f758ebe8fd204e#5c2133ade78f84f88519e459c3f758ebe8fd204e"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "ailoy"
 version = "0.3.0"
-source = "git+https://github.com/brekkylab/ailoy.git?rev=5c2133ade78f84f88519e459c3f758ebe8fd204e#5c2133ade78f84f88519e459c3f758ebe8fd204e"
+source = "git+https://github.com/brekkylab/ailoy.git?rev=cdccbc4596ea836cc62f097bbaf6303a902e1c35#cdccbc4596ea836cc62f097bbaf6303a902e1c35"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "74f4e238070d2cec752285394b527a86c023a082", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "7edb361f2c984d788b64f7d4987ad5e8c28467a7", features = ["sandbox"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "226d1a6ab841ddd77f37e82814166044112dfd3e", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "dc3d7bc19e400a4d0d4d850e55bec80bfa95aa8b", features = ["sandbox"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "7edb361f2c984d788b64f7d4987ad5e8c28467a7", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "d22f76b2e3949778b671418eabd38463c6b012fc", features = ["sandbox"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "2086bfdac663f81d3ca230b7fb4856a702576577", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "226d1a6ab841ddd77f37e82814166044112dfd3e", features = ["sandbox"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "d22f76b2e3949778b671418eabd38463c6b012fc", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "2086bfdac663f81d3ca230b7fb4856a702576577", features = ["sandbox"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "5c2133ade78f84f88519e459c3f758ebe8fd204e", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "cdccbc4596ea836cc62f097bbaf6303a902e1c35", features = ["sandbox"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 
 [workspace.dependencies]
 agent-k = { path = "./agent-k" }
-ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "dc3d7bc19e400a4d0d4d850e55bec80bfa95aa8b", features = ["sandbox"] }
+ailoy = { git = "https://github.com/brekkylab/ailoy.git", rev = "5c2133ade78f84f88519e459c3f758ebe8fd204e", features = ["sandbox"] }

--- a/agent-k/src/bin/run.rs
+++ b/agent-k/src/bin/run.rs
@@ -10,8 +10,8 @@ use std::io::{self, BufRead, IsTerminal, Read, Write};
 
 use agent_k::agents::get_coworker_agent;
 use ailoy::{
-    agent::Agent,
-    message::{Message, Part, Role},
+    agent::{Agent, AgentEvent},
+    message::{Message, Part, PartDelta, Role},
 };
 use futures::StreamExt;
 
@@ -194,42 +194,62 @@ fn prepare_dir(dir: &str) {
 
 async fn stream_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<()> {
     let query = Message::new(Role::User).with_contents([Part::text(user_input)]);
-    let mut stream = agent.run(query);
+    let mut stream = agent.run_stream(query);
+    // Track whether the current assistant line has streamed text so we can
+    // terminate it with a newline before tool calls / the next turn.
+    let mut line_open = false;
     while let Some(event) = stream.next().await {
-        let event = event?;
-        let msg = &event.message;
-        match msg.role {
-            Role::Assistant => {
-                for part in &msg.contents {
-                    if let Some(t) = part.as_text() {
-                        if !t.is_empty() {
-                            println!("{t}");
+        match event? {
+            // Live token fragments: print assistant text as it arrives.
+            AgentEvent::Delta(d) => {
+                for part in &d.delta.contents {
+                    if let PartDelta::Text { text } = part {
+                        if !text.is_empty() {
+                            print!("{text}");
                             io::stdout().flush().ok();
-                        }
-                    }
-                }
-                if let Some(tcs) = &msg.tool_calls {
-                    for tc in tcs {
-                        if let Some((_id, name, args)) = tc.as_function() {
-                            let args_json = serde_json::to_string(args)
-                                .unwrap_or_else(|_| "<unprintable>".into());
-                            println!("[coworker] tool: {name} {args_json}");
+                            line_open = true;
                         }
                     }
                 }
             }
-            Role::Tool => {
-                for part in &msg.contents {
-                    if let Some(t) = part.as_text() {
-                        println!("[coworker] tool result: {t}");
-                    } else if let Some(v) = part.as_value() {
-                        let s = serde_json::to_string(v).unwrap_or_else(|_| "<unprintable>".into());
-                        println!("[coworker] tool result: {s}");
+            // Completed turn: assistant text already streamed above, so here we
+            // only close the line and surface tool calls / tool results.
+            AgentEvent::Message(event) => {
+                let msg = &event.message;
+                match msg.role {
+                    Role::Assistant => {
+                        if line_open {
+                            println!();
+                            line_open = false;
+                        }
+                        if let Some(tcs) = &msg.tool_calls {
+                            for tc in tcs {
+                                if let Some((_id, name, args)) = tc.as_function() {
+                                    let args_json = serde_json::to_string(args)
+                                        .unwrap_or_else(|_| "<unprintable>".into());
+                                    println!("[coworker] tool: {name} {args_json}");
+                                }
+                            }
+                        }
                     }
+                    Role::Tool => {
+                        for part in &msg.contents {
+                            if let Some(t) = part.as_text() {
+                                println!("[coworker] tool result: {t}");
+                            } else if let Some(v) = part.as_value() {
+                                let s = serde_json::to_string(v)
+                                    .unwrap_or_else(|_| "<unprintable>".into());
+                                println!("[coworker] tool result: {s}");
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
-            _ => {}
         }
+    }
+    if line_open {
+        println!();
     }
     println!();
     Ok(())

--- a/agent-k/src/bin/run.rs
+++ b/agent-k/src/bin/run.rs
@@ -205,12 +205,14 @@ async fn stream_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<()> 
     while let Some(event) = stream.next().await {
         let delta = event?;
 
-        // Live token fragments: print assistant text as it arrives. A tool result
-        // arrives as its own role=Tool delta and must not print as assistant text;
-        // everything else here is assistant text, so exclude Tool rather than
-        // require Assistant (a provider may stream text before the role marker).
+        // Live token fragments: print top-level assistant text as it arrives.
+        // A tool result (role=Tool) and a sub-agent's re-emitted answer
+        // (role=Assistant, depth >= 1) must not print as the assistant's text;
+        // exclude those rather than require Assistant (a provider may stream
+        // text before the role marker).
         let effective_role = delta.delta.role.as_ref().or(acc.delta.role.as_ref());
-        let is_assistant = !matches!(effective_role, Some(Role::Tool));
+        let is_top_level = matches!(delta.depth.or(acc.depth), None | Some(0));
+        let is_assistant = is_top_level && !matches!(effective_role, Some(Role::Tool));
         if is_assistant {
             for part in &delta.delta.contents {
                 if let PartDelta::Text { text } = part

--- a/agent-k/src/bin/run.rs
+++ b/agent-k/src/bin/run.rs
@@ -11,9 +11,7 @@ use std::io::{self, BufRead, IsTerminal, Read, Write};
 use agent_k::agents::get_coworker_agent;
 use ailoy::{
     agent::Agent,
-    message::{
-        Delta, FinishReason, Message, MessageDeltaOutput, MessageOutput, Part, PartDelta, Role,
-    },
+    message::{Delta, Message, MessageDeltaOutput, MessageOutput, Part, PartDelta, Role},
 };
 use futures::StreamExt;
 
@@ -200,9 +198,9 @@ async fn stream_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<()> 
     // Track whether the current assistant line has streamed text so we can
     // terminate it with a newline before tool calls / the next turn.
     let mut line_open = false;
-    // `run_stream` yields only `MessageDeltaOutput`s now; accumulate deltas and
-    // act on each completed `MessageOutput` at its boundary (a delta carrying
-    // `finish_reason`, or a role change), mirroring ailoy's `into_messages`.
+    // `run_stream` yields only `MessageDeltaOutput`s; per ailoy's stream
+    // contract every message ends with a finish_reason delta, so accumulate and
+    // act on each completed `MessageOutput` at that boundary.
     let mut acc = MessageDeltaOutput::new();
     while let Some(event) = stream.next().await {
         let delta = event?;
@@ -225,17 +223,6 @@ async fn stream_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<()> 
             }
         }
 
-        // A role change with no intervening finish_reason is also a boundary;
-        // flush the in-progress message (finalizing as Stop) before accumulating.
-        if let (Some(cur), Some(incoming)) = (&acc.delta.role, &delta.delta.role)
-            && cur != incoming
-        {
-            let mut done = std::mem::replace(&mut acc, MessageDeltaOutput::new());
-            if done.finish_reason.is_none() {
-                done.finish_reason = Some(FinishReason::Stop {});
-            }
-            report_completed(&done.finish()?, &mut line_open);
-        }
         acc = acc.accumulate(delta)?;
         // Completed turn: assistant text already streamed above, so here we only
         // close the line and surface tool calls / tool results.

--- a/agent-k/src/bin/run.rs
+++ b/agent-k/src/bin/run.rs
@@ -10,8 +10,10 @@ use std::io::{self, BufRead, IsTerminal, Read, Write};
 
 use agent_k::agents::get_coworker_agent;
 use ailoy::{
-    agent::{Agent, AgentEvent},
-    message::{Message, Part, PartDelta, Role},
+    agent::Agent,
+    message::{
+        Delta, FinishReason, Message, MessageDeltaOutput, MessageOutput, Part, PartDelta, Role,
+    },
 };
 use futures::StreamExt;
 
@@ -198,54 +200,48 @@ async fn stream_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<()> 
     // Track whether the current assistant line has streamed text so we can
     // terminate it with a newline before tool calls / the next turn.
     let mut line_open = false;
+    // `run_stream` yields only `MessageDeltaOutput`s now; accumulate deltas and
+    // act on each completed `MessageOutput` at its boundary (a delta carrying
+    // `finish_reason`, or a role change), mirroring ailoy's `into_messages`.
+    let mut acc = MessageDeltaOutput::new();
     while let Some(event) = stream.next().await {
-        match event? {
-            // Live token fragments: print assistant text as it arrives.
-            AgentEvent::Delta(d) => {
-                for part in &d.delta.contents {
-                    if let PartDelta::Text { text } = part {
-                        if !text.is_empty() {
-                            print!("{text}");
-                            io::stdout().flush().ok();
-                            line_open = true;
-                        }
-                    }
+        let delta = event?;
+
+        // Live token fragments: print assistant text as it arrives. A tool result
+        // arrives as its own role=Tool delta and must not print as assistant text;
+        // everything else here is assistant text, so exclude Tool rather than
+        // require Assistant (a provider may stream text before the role marker).
+        let effective_role = delta.delta.role.as_ref().or(acc.delta.role.as_ref());
+        let is_assistant = !matches!(effective_role, Some(Role::Tool));
+        if is_assistant {
+            for part in &delta.delta.contents {
+                if let PartDelta::Text { text } = part
+                    && !text.is_empty()
+                {
+                    print!("{text}");
+                    io::stdout().flush().ok();
+                    line_open = true;
                 }
             }
-            // Completed turn: assistant text already streamed above, so here we
-            // only close the line and surface tool calls / tool results.
-            AgentEvent::Message(event) => {
-                let msg = &event.message;
-                match msg.role {
-                    Role::Assistant => {
-                        if line_open {
-                            println!();
-                            line_open = false;
-                        }
-                        if let Some(tcs) = &msg.tool_calls {
-                            for tc in tcs {
-                                if let Some((_id, name, args)) = tc.as_function() {
-                                    let args_json = serde_json::to_string(args)
-                                        .unwrap_or_else(|_| "<unprintable>".into());
-                                    println!("[coworker] tool: {name} {args_json}");
-                                }
-                            }
-                        }
-                    }
-                    Role::Tool => {
-                        for part in &msg.contents {
-                            if let Some(t) = part.as_text() {
-                                println!("[coworker] tool result: {t}");
-                            } else if let Some(v) = part.as_value() {
-                                let s = serde_json::to_string(v)
-                                    .unwrap_or_else(|_| "<unprintable>".into());
-                                println!("[coworker] tool result: {s}");
-                            }
-                        }
-                    }
-                    _ => {}
-                }
+        }
+
+        // A role change with no intervening finish_reason is also a boundary;
+        // flush the in-progress message (finalizing as Stop) before accumulating.
+        if let (Some(cur), Some(incoming)) = (&acc.delta.role, &delta.delta.role)
+            && cur != incoming
+        {
+            let mut done = std::mem::replace(&mut acc, MessageDeltaOutput::new());
+            if done.finish_reason.is_none() {
+                done.finish_reason = Some(FinishReason::Stop {});
             }
+            report_completed(&done.finish()?, &mut line_open);
+        }
+        acc = acc.accumulate(delta)?;
+        // Completed turn: assistant text already streamed above, so here we only
+        // close the line and surface tool calls / tool results.
+        if acc.finish_reason.is_some() {
+            let done = std::mem::replace(&mut acc, MessageDeltaOutput::new());
+            report_completed(&done.finish()?, &mut line_open);
         }
     }
     if line_open {
@@ -253,4 +249,38 @@ async fn stream_turn(agent: &mut Agent, user_input: &str) -> anyhow::Result<()> 
     }
     println!();
     Ok(())
+}
+
+/// Print the non-text side of a completed turn: an assistant turn's tool calls,
+/// or a tool result's contents. Assistant text has already streamed live.
+fn report_completed(output: &MessageOutput, line_open: &mut bool) {
+    let msg = &output.message;
+    match msg.role {
+        Role::Assistant => {
+            if *line_open {
+                println!();
+                *line_open = false;
+            }
+            if let Some(tcs) = &msg.tool_calls {
+                for tc in tcs {
+                    if let Some((_id, name, args)) = tc.as_function() {
+                        let args_json =
+                            serde_json::to_string(args).unwrap_or_else(|_| "<unprintable>".into());
+                        println!("[coworker] tool: {name} {args_json}");
+                    }
+                }
+            }
+        }
+        Role::Tool => {
+            for part in &msg.contents {
+                if let Some(t) = part.as_text() {
+                    println!("[coworker] tool result: {t}");
+                } else if let Some(v) = part.as_value() {
+                    let s = serde_json::to_string(v).unwrap_or_else(|_| "<unprintable>".into());
+                    println!("[coworker] tool result: {s}");
+                }
+            }
+        }
+        _ => {}
+    }
 }

--- a/app/src/api/backend-types.ts
+++ b/app/src/api/backend-types.ts
@@ -138,33 +138,6 @@ export interface MessageOutput {
   usage?: { input_tokens?: number; output_tokens?: number };
 }
 
-// ── Streaming deltas ─────────────────────────────────────────────────────────
-// Incremental fragments emitted by the agent's run_stream loop. Mirror of
-// ailoy's PartDelta/MessageDelta/MessageDeltaOutput (serde tag = "type").
-// Ephemeral: never persisted — the completed MessageOutput is the source of truth.
-
-export type PartDelta =
-  | { type: 'text'; text: string }
-  | { type: 'function'; id?: string | null; function?: unknown }
-  | { type: 'value'; value: unknown }
-  | { type: 'null' }
-  | { type?: string; [k: string]: unknown };
-
-export interface MessageDelta {
-  role?: string | null;
-  contents?: PartDelta[];
-  id?: string | null;
-  thinking?: string | null;
-  tool_calls?: PartDelta[];
-  signature?: string | null;
-}
-
-export interface MessageDeltaOutput {
-  delta: MessageDelta;
-  finish_reason?: { type?: string } | null;
-  usage?: { input_tokens?: number; output_tokens?: number } | null;
-}
-
 // ── Automation ─────────────────────────────────────────────────────────────
 // Mirrors backend/src/model/automation.rs. snake_case is preserved here;
 // transformers.ts maps these onto camelCase domain types.

--- a/app/src/api/backend-types.ts
+++ b/app/src/api/backend-types.ts
@@ -138,6 +138,33 @@ export interface MessageOutput {
   usage?: { input_tokens?: number; output_tokens?: number };
 }
 
+// ── Streaming deltas ─────────────────────────────────────────────────────────
+// Incremental fragments emitted by the agent's run_stream loop. Mirror of
+// ailoy's PartDelta/MessageDelta/MessageDeltaOutput (serde tag = "type").
+// Ephemeral: never persisted — the completed MessageOutput is the source of truth.
+
+export type PartDelta =
+  | { type: 'text'; text: string }
+  | { type: 'function'; id?: string | null; function?: unknown }
+  | { type: 'value'; value: unknown }
+  | { type: 'null' }
+  | { type?: string; [k: string]: unknown };
+
+export interface MessageDelta {
+  role?: string | null;
+  contents?: PartDelta[];
+  id?: string | null;
+  thinking?: string | null;
+  tool_calls?: PartDelta[];
+  signature?: string | null;
+}
+
+export interface MessageDeltaOutput {
+  delta: MessageDelta;
+  finish_reason?: { type?: string } | null;
+  usage?: { input_tokens?: number; output_tokens?: number } | null;
+}
+
 // ── Automation ─────────────────────────────────────────────────────────────
 // Mirrors backend/src/model/automation.rs. snake_case is preserved here;
 // transformers.ts maps these onto camelCase domain types.

--- a/app/src/api/messages.test.ts
+++ b/app/src/api/messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveStreamState } from './messages';
+import { deriveStreamState, deriveLiveSegments } from './messages';
 import type { MessageOutput } from './backend-types';
 
 // Helper: build a minimal MessageOutput with a depth-0 assistant text message
@@ -169,5 +169,62 @@ describe('deriveStreamState', () => {
     const state = deriveStreamState([{ depth: 0 }]);
     expect(state.text).toBe('');
     expect(state.toolCalls).toEqual([]);
+  });
+});
+
+describe('deriveLiveSegments', () => {
+  const sub = (text: string, agent = 'speedwagon'): MessageOutput => ({
+    message: { role: 'assistant', contents: [{ type: 'text', text }] },
+    depth: 1,
+    source_agent: agent,
+  });
+
+  it('keeps each committed turn as its own segment (earlier turns never vanish)', () => {
+    const segments = deriveLiveSegments([
+      [0, assistantOutput('turn one')],
+      [1, assistantOutput('turn two')],
+    ]);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ kind: 'turn', seq: 0, text: 'turn one' });
+    expect(segments[1]).toMatchObject({ kind: 'turn', seq: 1, text: 'turn two' });
+  });
+
+  it('pins the sub-agent segment between the turns it interleaves with', () => {
+    // turn 1 (calls sub-agent) → sub-agent answer → turn 2: the final
+    // persisted layout — live rendering must match it, not hoist turn 2 above.
+    const segments = deriveLiveSegments([
+      [0, assistantOutput('looking it up')],
+      [1, sub('sub answer')],
+      [2, assistantOutput('summary')],
+    ]);
+    expect(segments.map((s) => s.kind)).toEqual(['turn', 'sub', 'turn']);
+    expect(segments[1]).toMatchObject({ kind: 'sub', sourceAgent: 'speedwagon', text: 'sub answer' });
+    expect(segments[2]).toMatchObject({ kind: 'turn', text: 'summary' });
+  });
+
+  it('joins repeat sub-agent output into the pinned segment', () => {
+    const segments = deriveLiveSegments([
+      [0, sub('first ')],
+      [1, assistantOutput('between')],
+      [2, sub('second')],
+    ]);
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ kind: 'sub', seq: 0, text: 'first second' });
+    expect(segments[1]).toMatchObject({ kind: 'turn', text: 'between' });
+  });
+
+  it('attaches tool results to the owning turn segment', () => {
+    const segments = deriveLiveSegments([
+      [0, toolCallOutput('call-1', 'shell')],
+      [1, toolResultOutput('call-1', 'ok')],
+      [2, assistantOutput('done')],
+    ]);
+    expect(segments).toHaveLength(2);
+    const first = segments[0];
+    expect(first.kind).toBe('turn');
+    if (first.kind === 'turn') {
+      expect(first.toolCalls).toHaveLength(1);
+      expect(first.toolCalls[0]).toMatchObject({ id: 'call-1', name: 'shell', result: 'ok' });
+    }
   });
 });

--- a/app/src/api/messages.ts
+++ b/app/src/api/messages.ts
@@ -61,6 +61,20 @@ export async function getRunActive(sessionId: string, runId: string): Promise<bo
   return res.active;
 }
 
+// Snapshot of the session's in-flight run (or null). Mirrors what the WS replays
+// (run_started + messages + partial), so the client can render the in-progress
+// turn immediately on load instead of waiting for the WS replay round-trip.
+export interface ActiveRunSnapshot {
+  run_id: string;
+  user_message: { sender_user_id: string; content: string; attachments: string[]; created_at: string };
+  outputs: { seq: number; output: MessageOutput }[];
+  partial: string;
+}
+
+export async function getActiveRunSnapshot(sessionId: string): Promise<ActiveRunSnapshot | null> {
+  return request<ActiveRunSnapshot | null>(`/sessions/${sessionId}/active-run`);
+}
+
 export interface StreamToolCall {
   id: string;
   name: string;

--- a/app/src/api/messages.ts
+++ b/app/src/api/messages.ts
@@ -156,3 +156,97 @@ export function deriveStreamState(
     subagentUpdates,
   };
 }
+
+export interface LiveTurnSegment {
+  kind: 'turn';
+  /** seq of the committed depth-0 assistant message (stable bubble key). */
+  seq: number;
+  text: string;
+  toolCalls: StreamToolCall[];
+}
+
+export interface LiveSubSegment {
+  kind: 'sub';
+  /** seq at which this sub-agent first appeared (chronological position). */
+  seq: number;
+  sourceAgent: string;
+  text: string;
+}
+
+export type LiveSegment = LiveTurnSegment | LiveSubSegment;
+
+/**
+ * Derives the chronological live transcript from seq-ordered `[seq, output]`
+ * entries: one 'turn' segment per committed depth-0 assistant message (carrying
+ * its tool calls; tool results attach to the owning turn), and one 'sub'
+ * segment per sub-agent at its first appearance. This mirrors the persisted
+ * transcript's final layout, so live rendering doesn't reflow when the run
+ * completes — unlike `deriveStreamState`, which collapses all turns into a
+ * single text (an earlier turn's text vanished while the next streamed, and a
+ * post-sub-agent turn rendered *above* the sub-agent bubble then jumped down
+ * on completion). Pure — no side effects.
+ */
+export function deriveLiveSegments(entries: Array<[number, MessageOutput]>): LiveSegment[] {
+  const segments: LiveSegment[] = [];
+  const subByAgent = new Map<string, LiveSubSegment>();
+  const toolCallIndex = new Map<string, StreamToolCall>();
+
+  for (const [seq, output] of entries) {
+    if (!output?.message) continue;
+
+    const depth = output.depth ?? 0;
+    const sourceAgent = output.source_agent ?? null;
+    const msg = output.message as AiloyMessage;
+
+    if (depth >= 1) {
+      // Sub-agent output: one bubble per agent, pinned where it first appeared.
+      if (msg.role === 'assistant' && sourceAgent) {
+        const text = aiMessageText(msg.contents as AiloyPart[] | undefined);
+        const existing = subByAgent.get(sourceAgent);
+        if (existing) {
+          existing.text += text;
+        } else {
+          const seg: LiveSubSegment = { kind: 'sub', seq, sourceAgent, text };
+          subByAgent.set(sourceAgent, seg);
+          segments.push(seg);
+        }
+      }
+      continue;
+    }
+
+    if (msg.role === 'assistant') {
+      const toolCalls: StreamToolCall[] = [];
+      for (const call of (msg.tool_calls ?? []) as AiloyToolCall[]) {
+        if (!call.id || !call.function?.name) continue;
+        const tc: StreamToolCall = { id: call.id, name: call.function.name, arguments: call.function.arguments };
+        toolCalls.push(tc);
+        toolCallIndex.set(call.id, tc);
+      }
+      segments.push({
+        kind: 'turn',
+        seq,
+        text: aiMessageText(msg.contents as AiloyPart[] | undefined),
+        toolCalls,
+      });
+    } else if (msg.role === 'tool') {
+      if (!msg.id) continue;
+      const resultText = aiMessageText(msg.contents as AiloyPart[] | undefined) || '[done]';
+      let tc = toolCallIndex.get(msg.id);
+      if (!tc) {
+        console.warn(`[deriveLiveSegments] tool result id=${msg.id} arrived without matching tool_call; rendering as stub`);
+        tc = { id: msg.id, name: '(pending)' };
+        toolCallIndex.set(msg.id, tc);
+        // Attach the stub to the most recent turn (or synthesize one).
+        const lastTurn = [...segments].reverse().find((s): s is LiveTurnSegment => s.kind === 'turn');
+        if (lastTurn) {
+          lastTurn.toolCalls.push(tc);
+        } else {
+          segments.push({ kind: 'turn', seq, text: '', toolCalls: [tc] });
+        }
+      }
+      tc.result = resultText;
+    }
+  }
+
+  return segments;
+}

--- a/app/src/api/ws.ts
+++ b/app/src/api/ws.ts
@@ -1,6 +1,6 @@
 import { ApiError, BASE_URL, getToken, notifyUnauthorized } from './client';
 import { getMe } from './auth';
-import type { MessageOutput } from './backend-types';
+import type { MessageOutput, MessageDeltaOutput } from './backend-types';
 
 export interface SessionTitleUpdatedEvent {
   type: 'session_title_updated';
@@ -31,6 +31,16 @@ export interface AgentMessageEvent {
   output: MessageOutput;
 }
 
+// Live token fragment for the in-progress assistant turn. Ephemeral — not
+// persisted and carries no seq; the client accumulates deltas for live
+// rendering and is reconciled by the completed `agent_message` that follows.
+export interface AgentDeltaEvent {
+  type: 'agent_delta';
+  session_id: string;
+  run_id: string;
+  delta: MessageDeltaOutput;
+}
+
 export interface AgentErrorEvent {
   type: 'agent_error';
   session_id: string;
@@ -50,7 +60,7 @@ export interface AgentRunIdleEvent {
   session_id: string;
 }
 
-export type AppWsEvent = SessionTitleUpdatedEvent | AgentRunStartedEvent | AgentMessageEvent | AgentErrorEvent | AgentRunDoneEvent | AgentRunIdleEvent;
+export type AppWsEvent = SessionTitleUpdatedEvent | AgentRunStartedEvent | AgentMessageEvent | AgentDeltaEvent | AgentErrorEvent | AgentRunDoneEvent | AgentRunIdleEvent;
 
 type Handler = (event: AppWsEvent) => void;
 

--- a/app/src/api/ws.ts
+++ b/app/src/api/ws.ts
@@ -1,6 +1,6 @@
 import { ApiError, BASE_URL, getToken, notifyUnauthorized } from './client';
 import { getMe } from './auth';
-import type { MessageOutput, MessageDeltaOutput } from './backend-types';
+import type { MessageOutput } from './backend-types';
 
 export interface SessionTitleUpdatedEvent {
   type: 'session_title_updated';
@@ -31,14 +31,18 @@ export interface AgentMessageEvent {
   output: MessageOutput;
 }
 
-// Live token fragment for the in-progress assistant turn. Ephemeral — not
-// persisted and carries no seq; the client accumulates deltas for live
-// rendering and is reconciled by the completed `agent_message` that follows.
+// Incremental text delta for the in-progress assistant turn. Ephemeral — not
+// persisted, no seq. `delta` is the new text; `cum_len` is the turn's total
+// length (UTF-16 units, matching String.length) after it. The client dedups via
+// cum_len across the replay↔live boundary (skip if already applied, slice off
+// overlap). The resume path sends the whole turn as one delta. Reconciled by the
+// completed `agent_message` that follows.
 export interface AgentDeltaEvent {
   type: 'agent_delta';
   session_id: string;
   run_id: string;
-  delta: MessageDeltaOutput;
+  delta: string;
+  cum_len: number;
 }
 
 export interface AgentErrorEvent {

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -211,6 +211,11 @@ function SessionPage() {
   // a mid-stream resume it's the whole backlog, which should appear at once
   // rather than slowly retyping. Subsequent chunks animate. Reset per turn.
   const revealSeededRef = useRef<boolean>(false);
+  // True while a hole-recovery resync (refetch of the server-side partial) is in
+  // flight. After a dropped delta every subsequent delta also reads as a hole,
+  // so this gates the refetch to one at a time — otherwise a fast stream would
+  // fire an HTTP snapshot per token until the first one lands.
+  const resyncingRef = useRef<boolean>(false);
 
   const [composerText, setComposerText] = useState('');
   // Composer layout — false = compact pill (textarea + buttons inline),
@@ -269,6 +274,7 @@ function SessionPage() {
     wsOutputsRef.current.clear();
     maxSeqRef.current = -1;
     pendingDeltaRef.current = '';
+    resyncingRef.current = false;
     optimisticUserIdRef.current = null;
     currentRunIdRef.current = null;
     doneRunIdsRef.current.clear();
@@ -895,6 +901,7 @@ function SessionPage() {
           pendingDeltaRef.current = '';
           revealedTextRef.current = '';
           revealSeededRef.current = false;
+          resyncingRef.current = false;
         }
         currentRunIdRef.current = run_id;
 
@@ -964,6 +971,7 @@ function SessionPage() {
         pendingDeltaRef.current = '';
         revealedTextRef.current = '';
         revealSeededRef.current = false;
+        resyncingRef.current = false;
         if (revealRafRef.current !== null) {
           cancelAnimationFrame(revealRafRef.current);
           revealRafRef.current = null;
@@ -1032,8 +1040,35 @@ function SessionPage() {
         if (cum_len <= applied) return; // already have this text (replay overlap)
         const cumStart = cum_len - delta.length; // length before this delta
         if (cumStart > applied) {
-          // Hole: we missed an earlier delta (e.g. broadcast lag). Can't fill it
-          // safely — leave it; the completed agent_message reconciles the turn.
+          // Hole: an earlier delta was dropped (broadcast lag). Leaving it would
+          // freeze the whole reveal — every later delta reads as a hole too —
+          // until the commit reconciles. Instead refetch the exact server-side
+          // partial and replay it as one catch-up delta (cum_len == length →
+          // cumStart 0 → the append below trims the overlap), so the reveal
+          // recovers now. Guard against a refetch storm: only one resync in
+          // flight, since every post-hole delta lands here until it completes.
+          if (resyncingRef.current) return;
+          resyncingRef.current = true;
+          // Paint the recovered backlog at once instead of slowly retyping it.
+          revealSeededRef.current = false;
+          void getActiveRunSnapshot(sessionId)
+            .then((snap) => {
+              if (snap?.partial && currentRunIdRef.current === run_id) {
+                processEvent({
+                  type: 'agent_delta',
+                  session_id: sessionId,
+                  run_id,
+                  delta: snap.partial,
+                  cum_len: snap.partial.length,
+                });
+              }
+            })
+            .catch(() => {
+              /* best-effort recovery; the commit still reconciles the turn */
+            })
+            .finally(() => {
+              resyncingRef.current = false;
+            });
           return;
         }
         // Slice off any overlap already applied, then append the new tail.

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -193,6 +193,13 @@ function SessionPage() {
   // resets, so each turn streams from empty. The committed agent_message is the
   // source of truth — deltas only drive the live "typing" preview.
   const pendingDeltaRef = useRef<string>('');
+  // Smooth reveal: pendingDeltaRef is the *target* (text received so far);
+  // revealedTextRef is what's actually painted. A rAF loop walks the revealed
+  // text toward the target a few chars per frame so bursty network chunks
+  // surface as a steady typewriter effect instead of jumping in blocks.
+  const revealedTextRef = useRef<string>('');
+  const revealRafRef = useRef<number | null>(null);
+  const lastRevealTsRef = useRef<number>(0);
 
   const [composerText, setComposerText] = useState('');
   // Composer layout — false = compact pill (textarea + buttons inline),
@@ -791,6 +798,46 @@ function SessionPage() {
   useEffect(() => {
     if (!sessionId) return;
 
+    const aiId = `live-ai-${sessionId}`;
+
+    // Walk revealedTextRef toward pendingDeltaRef (the target) a few chars at a
+    // time. Self-healing: when a new turn replaces the target, the old revealed
+    // text is no longer a prefix, so we restart the reveal from empty — no
+    // explicit reset needed at run-reset points.
+    const stepReveal = (ts: number) => {
+      // Throttle to ~33fps so a long streaming message isn't re-rendered (and
+      // re-parsed as markdown) 60×/sec.
+      if (ts - lastRevealTsRef.current < 28) {
+        revealRafRef.current = requestAnimationFrame(stepReveal);
+        return;
+      }
+      lastRevealTsRef.current = ts;
+
+      const target = pendingDeltaRef.current;
+      let shown = revealedTextRef.current;
+      if (!target.startsWith(shown)) shown = ''; // new turn → restart
+
+      if (shown.length >= target.length) {
+        revealedTextRef.current = shown;
+        revealRafRef.current = null; // caught up; next delta restarts the loop
+        return;
+      }
+
+      // Reveal proportional to the backlog (with a floor) so a fast stream
+      // never lags far behind, while a trickle still types out smoothly.
+      const remaining = target.length - shown.length;
+      const step = Math.max(3, Math.ceil(remaining / 5));
+      const next = target.slice(0, shown.length + step);
+      revealedTextRef.current = next;
+      setLiveMessages((prev) =>
+        prev.map((m) => (m.id === aiId ? { ...m, body: next, status: 'streaming' as const } : m)),
+      );
+      revealRafRef.current = requestAnimationFrame(stepReveal);
+    };
+    const kickReveal = () => {
+      if (revealRafRef.current === null) revealRafRef.current = requestAnimationFrame(stepReveal);
+    };
+
     const unsubscribe = appWs.subscribe((event: AppWsEvent) => {
       // Ignore events unrelated to this session
       if (!('session_id' in event) || event.session_id !== sessionId) return;
@@ -874,9 +921,15 @@ function SessionPage() {
         armWatchdog(run_id);
         wsOutputsRef.current.set(seq, output);
         // This turn just committed — its full text is now in wsOutputsRef and
-        // becomes the source of truth. Clear the live delta buffer so the next
-        // turn streams from empty (and we don't double-render the same text).
+        // becomes the source of truth. Stop the reveal loop and clear the live
+        // delta buffers so the next turn streams from empty (the setLiveMessages
+        // below snaps the bubble to the committed text).
         pendingDeltaRef.current = '';
+        revealedTextRef.current = '';
+        if (revealRafRef.current !== null) {
+          cancelAnimationFrame(revealRafRef.current);
+          revealRafRef.current = null;
+        }
 
         // Fast path: if seq is strictly greater than maxSeqRef (the common
         // in-order case), Map insertion order is already sorted — no sort needed.
@@ -941,18 +994,12 @@ function SessionPage() {
           .join('');
         if (!frag) return;
 
+        // Append to the target and let the rAF reveal loop paint it smoothly.
+        // The bubble body (current turn's text, replace semantics) is driven by
+        // stepReveal; toolCalls are left untouched — they belong to committed
+        // messages.
         pendingDeltaRef.current += frag;
-        const liveText = pendingDeltaRef.current;
-
-        // Replace the bubble body with the in-progress turn's text (matching
-        // deriveStreamState's replace semantics). toolCalls are left untouched —
-        // they belong to already-committed messages.
-        const aiId = `live-ai-${sessionId}`;
-        setLiveMessages((prev) =>
-          prev.map((m) =>
-            m.id === aiId ? { ...m, body: liveText, status: 'streaming' as const } : m,
-          ),
-        );
+        kickReveal();
       }
 
       if (event.type === 'agent_error') {
@@ -1046,6 +1093,10 @@ function SessionPage() {
       if (wsInactivityTimerRef.current) {
         clearTimeout(wsInactivityTimerRef.current);
         wsInactivityTimerRef.current = null;
+      }
+      if (revealRafRef.current !== null) {
+        cancelAnimationFrame(revealRafRef.current);
+        revealRafRef.current = null;
       }
     };
   }, [sessionId, sessionPrefix, projectSlug, projectId, queryClient, showToast, t, armWatchdog, fetchPreviousPage]);

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -167,6 +167,12 @@ function SessionPage() {
   // Id of the first rendered message. When it changes the list grew from the
   // top (older-page prepend), not the tail — used to suppress auto-follow there.
   const prevFirstIdRef = useRef<string | undefined>(undefined);
+  // Whether streaming/new-message growth should stick the viewport to the
+  // bottom. Stays true while the user rides the tail; a deliberate upward
+  // scroll (wheel/touch) turns it off so tokens stop yanking them down
+  // mid-read, and returning to the bottom re-engages it. See the scroll
+  // listener below.
+  const autoFollowRef = useRef(true);
 
   // WS-driven: outputs map keyed by seq (for idempotent catch-up + live merging)
   const wsOutputsRef = useRef<Map<number, MessageOutput>>(new Map());
@@ -271,6 +277,7 @@ function SessionPage() {
     prevFirstIdRef.current = undefined;
     prependAnchorRef.current = null;
     didInitialScrollRef.current = false;
+    autoFollowRef.current = true;
   }
 
   // On entering a session, mark it read on the server with a lightweight POST
@@ -340,6 +347,7 @@ function SessionPage() {
     // Own send — jump to the bottom immediately, even if scrolled far up.
     if (forceScrollRef.current) {
       forceScrollRef.current = false;
+      autoFollowRef.current = true;
       scrollToTail(el, 'instant');
       setShowNewMsgPill(false);
       return;
@@ -358,11 +366,17 @@ function SessionPage() {
       return;
     }
 
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distanceFromBottom <= 700) {
-      scrollToTail(el, 'smooth');
+    // Follow the tail only while the user hasn't deliberately scrolled up. The
+    // scroll listener flips `autoFollowRef` off on an upward wheel/touch gesture
+    // and back on once they return to the bottom — so a streaming reply no
+    // longer drags the viewport down while they're reading earlier text.
+    if (autoFollowRef.current) {
+      // Instant (not smooth) while streaming: a per-token smooth animation is
+      // always in flight and fights a user trying to scroll up — they'd have to
+      // outrun it. Instant means a small upward scroll sticks immediately.
+      scrollToTail(el, streaming ? 'instant' : 'smooth');
     } else if (allMessages.length > prevCount) {
-      // Scrolled too far up to auto-follow — surface a "new message" pill instead.
+      // Opted out of follow — surface a "new message" pill instead.
       setShowNewMsgPill(true);
     }
   }, [allMessages.length, streaming, contentVersion]);
@@ -372,11 +386,23 @@ function SessionPage() {
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
+    let lastTop = el.scrollTop;
     const onScroll = () => {
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom <= 40) {
-        setShowNewMsgPill(false);
+      const top = el.scrollTop;
+      const distanceFromBottom = el.scrollHeight - top - el.clientHeight;
+      // Direction-based follow detection. The streaming auto-scroll only ever
+      // moves scrollTop *down* (toward the tail) and growing content fires no
+      // scroll event, so any decrease in scrollTop is the user scrolling up —
+      // by any means (wheel, trackpad, scrollbar, keys). Stop following on the
+      // slightest upward move; re-engage only once they're back at the very
+      // bottom. The 0.5px epsilon ignores sub-pixel jitter at rest.
+      if (top < lastTop - 0.5) {
+        autoFollowRef.current = false;
+      } else if (distanceFromBottom <= 1) {
+        autoFollowRef.current = true;
       }
+      lastTop = top;
+      if (distanceFromBottom <= 40) setShowNewMsgPill(false);
       setShowScrollDown(distanceFromBottom > 700);
     };
     el.addEventListener('scroll', onScroll, { passive: true });
@@ -385,6 +411,7 @@ function SessionPage() {
 
   const scrollToBottom = useCallback(() => {
     setShowNewMsgPill(false);
+    autoFollowRef.current = true;
     scrollToTail(scrollContainerRef.current, 'instant');
   }, []);
 

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -188,6 +188,11 @@ function SessionPage() {
   // doneRunIdsRef: set of run_ids we've already processed a Done for.
   const currentRunIdRef = useRef<string | null>(null);
   const doneRunIdsRef = useRef<Set<string>>(new Set());
+  // Accumulates streamed text fragments (agent_delta) for the in-progress
+  // assistant turn. Reset whenever a turn commits (agent_message) or the run
+  // resets, so each turn streams from empty. The committed agent_message is the
+  // source of truth — deltas only drive the live "typing" preview.
+  const pendingDeltaRef = useRef<string>('');
 
   const [composerText, setComposerText] = useState('');
   // Composer layout — false = compact pill (textarea + buttons inline),
@@ -245,6 +250,7 @@ function SessionPage() {
     setShowScrollDown(false);
     wsOutputsRef.current.clear();
     maxSeqRef.current = -1;
+    pendingDeltaRef.current = '';
     optimisticUserIdRef.current = null;
     currentRunIdRef.current = null;
     doneRunIdsRef.current.clear();
@@ -523,6 +529,7 @@ function SessionPage() {
     setLiveMessages([]);
     wsOutputsRef.current.clear();
     maxSeqRef.current = -1;
+    pendingDeltaRef.current = '';
     currentRunIdRef.current = null;
     optimisticUserIdRef.current = null;
     if (sessionId) void queryClient.refetchQueries({ queryKey: ['messages', sessionId] });
@@ -679,6 +686,7 @@ function SessionPage() {
       setOwnedRunId(null);
       setLiveMessages([]);
       wsOutputsRef.current.clear();
+      pendingDeltaRef.current = '';
       optimisticUserIdRef.current = null;
     }
     // On success: the WS event (agent_run_done) handles completion. No finally block.
@@ -802,6 +810,7 @@ function SessionPage() {
         if (isNewRun) {
           wsOutputsRef.current.clear();
           maxSeqRef.current = -1;
+          pendingDeltaRef.current = '';
         }
         currentRunIdRef.current = run_id;
 
@@ -864,6 +873,10 @@ function SessionPage() {
         }
         armWatchdog(run_id);
         wsOutputsRef.current.set(seq, output);
+        // This turn just committed — its full text is now in wsOutputsRef and
+        // becomes the source of truth. Clear the live delta buffer so the next
+        // turn streams from empty (and we don't double-render the same text).
+        pendingDeltaRef.current = '';
 
         // Fast path: if seq is strictly greater than maxSeqRef (the common
         // in-order case), Map insertion order is already sorted — no sort needed.
@@ -910,6 +923,38 @@ function SessionPage() {
         });
       }
 
+      if (event.type === 'agent_delta') {
+        const { run_id, delta } = event;
+        // Claim the run on first event, or ignore deltas from a stale/other run
+        // (same guard as agent_message).
+        if (currentRunIdRef.current === null) {
+          currentRunIdRef.current = run_id;
+        } else if (run_id !== currentRunIdRef.current) {
+          return;
+        }
+        armWatchdog(run_id);
+
+        // Only text fragments drive the live preview. Tool-call/value fragments
+        // are ignored here — tool calls render from the committed agent_message.
+        const frag = (delta.delta?.contents ?? [])
+          .map((p) => (p.type === 'text' && typeof p.text === 'string' ? p.text : ''))
+          .join('');
+        if (!frag) return;
+
+        pendingDeltaRef.current += frag;
+        const liveText = pendingDeltaRef.current;
+
+        // Replace the bubble body with the in-progress turn's text (matching
+        // deriveStreamState's replace semantics). toolCalls are left untouched —
+        // they belong to already-committed messages.
+        const aiId = `live-ai-${sessionId}`;
+        setLiveMessages((prev) =>
+          prev.map((m) =>
+            m.id === aiId ? { ...m, body: liveText, status: 'streaming' as const } : m,
+          ),
+        );
+      }
+
       if (event.type === 'agent_error') {
         const { run_id } = event;
         // [R2-3] Ignore stale errors from a previous run — same guard as agent_run_done.
@@ -927,6 +972,7 @@ function SessionPage() {
         setLiveMessages([]);
         wsOutputsRef.current.clear();
         maxSeqRef.current = -1;
+        pendingDeltaRef.current = '';
         currentRunIdRef.current = null;
         optimisticUserIdRef.current = null;
       }
@@ -956,6 +1002,7 @@ function SessionPage() {
           setLiveMessages([]);
           wsOutputsRef.current.clear();
           maxSeqRef.current = -1;
+          pendingDeltaRef.current = '';
           currentRunIdRef.current = null;
           optimisticUserIdRef.current = null;
           setStreaming(false);
@@ -983,6 +1030,7 @@ function SessionPage() {
           setLiveMessages([]);
           wsOutputsRef.current.clear();
           maxSeqRef.current = -1;
+          pendingDeltaRef.current = '';
           optimisticUserIdRef.current = null;
           currentRunIdRef.current = null;
           setStreaming(false);

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -7,7 +7,7 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tansta
 import { useTranslation } from 'react-i18next';
 import { localizedNoun } from '@/i18n';
 import { getSession, markSessionRead, updateSessionShareMode } from '@/api/sessions';
-import { listMessageItems, sendMessage, stopRun, getRunActive, deriveStreamState } from '@/api/messages';
+import { listMessageItems, sendMessage, stopRun, getRunActive, getActiveRunSnapshot, deriveStreamState } from '@/api/messages';
 import { appWs } from '@/api/ws';
 import type { AppWsEvent } from '@/api/ws';
 import type { MessageOutput } from '@/api/backend-types';
@@ -200,6 +200,11 @@ function SessionPage() {
   const revealedTextRef = useRef<string>('');
   const revealRafRef = useRef<number | null>(null);
   const lastRevealTsRef = useRef<number>(0);
+  // Whether the current turn's first text chunk has been painted. The first
+  // chunk is shown instantly (no animation) — for a fresh turn it's tiny, but on
+  // a mid-stream resume it's the whole backlog, which should appear at once
+  // rather than slowly retyping. Subsequent chunks animate. Reset per turn.
+  const revealSeededRef = useRef<boolean>(false);
 
   const [composerText, setComposerText] = useState('');
   // Composer layout — false = compact pill (textarea + buttons inline),
@@ -841,7 +846,7 @@ function SessionPage() {
       if (revealRafRef.current === null) revealRafRef.current = requestAnimationFrame(stepReveal);
     };
 
-    const unsubscribe = appWs.subscribe((event: AppWsEvent) => {
+    const processEvent = (event: AppWsEvent) => {
       // Ignore events unrelated to this session
       if (!('session_id' in event) || event.session_id !== sessionId) return;
 
@@ -861,6 +866,8 @@ function SessionPage() {
           wsOutputsRef.current.clear();
           maxSeqRef.current = -1;
           pendingDeltaRef.current = '';
+          revealedTextRef.current = '';
+          revealSeededRef.current = false;
         }
         currentRunIdRef.current = run_id;
 
@@ -929,6 +936,7 @@ function SessionPage() {
         // below snaps the bubble to the committed text).
         pendingDeltaRef.current = '';
         revealedTextRef.current = '';
+        revealSeededRef.current = false;
         if (revealRafRef.current !== null) {
           cancelAnimationFrame(revealRafRef.current);
           revealRafRef.current = null;
@@ -980,7 +988,7 @@ function SessionPage() {
       }
 
       if (event.type === 'agent_delta') {
-        const { run_id, delta } = event;
+        const { run_id, delta, cum_len } = event;
         // Claim the run on first event, or ignore deltas from a stale/other run
         // (same guard as agent_message).
         if (currentRunIdRef.current === null) {
@@ -990,19 +998,33 @@ function SessionPage() {
         }
         armWatchdog(run_id);
 
-        // Only text fragments drive the live preview. Tool-call/value fragments
-        // are ignored here — tool calls render from the committed agent_message.
-        const frag = (delta.delta?.contents ?? [])
-          .map((p) => (p.type === 'text' && typeof p.text === 'string' ? p.text : ''))
-          .join('');
-        if (!frag) return;
+        // Append the delta, deduping across the replay↔live boundary via cum_len
+        // (the turn's total length after this delta). pendingDeltaRef holds the
+        // text applied so far, so its .length is what we've applied.
+        const applied = pendingDeltaRef.current.length;
+        if (cum_len <= applied) return; // already have this text (replay overlap)
+        const cumStart = cum_len - delta.length; // length before this delta
+        if (cumStart > applied) {
+          // Hole: we missed an earlier delta (e.g. broadcast lag). Can't fill it
+          // safely — leave it; the completed agent_message reconciles the turn.
+          return;
+        }
+        // Slice off any overlap already applied, then append the new tail.
+        pendingDeltaRef.current += cumStart === applied ? delta : delta.slice(applied - cumStart);
 
-        // Append to the target and let the rAF reveal loop paint it smoothly.
-        // The bubble body (current turn's text, replace semantics) is driven by
-        // stepReveal; toolCalls are left untouched — they belong to committed
-        // messages.
-        pendingDeltaRef.current += frag;
-        kickReveal();
+        if (!revealSeededRef.current) {
+          // First chunk of this turn: paint instantly. Tiny for a fresh turn; for
+          // a mid-stream resume it's the whole backlog, which should appear at
+          // once rather than slowly retyping. Later chunks animate.
+          revealSeededRef.current = true;
+          revealedTextRef.current = pendingDeltaRef.current;
+          const body = pendingDeltaRef.current;
+          setLiveMessages((prev) =>
+            prev.map((m) => (m.id === aiId ? { ...m, body, status: 'streaming' as const } : m)),
+          );
+        } else {
+          kickReveal();
+        }
       }
 
       if (event.type === 'agent_error') {
@@ -1089,7 +1111,40 @@ function SessionPage() {
           setStopping(false);
         }
       }
-    });
+    };
+
+    const unsubscribe = appWs.subscribe(processEvent);
+
+    // Seed the in-flight run from the HTTP snapshot so a refresh mid-stream
+    // renders the in-progress turn immediately (the WS replay arrives a
+    // round-trip later). Feeds the same event shapes through processEvent; it's
+    // idempotent with the replay (run claimed by id, messages keyed by seq,
+    // delta is a length-guarded snapshot).
+    void getActiveRunSnapshot(sessionId)
+      .then((snap) => {
+        if (!snap) return;
+        processEvent({
+          type: 'agent_run_started',
+          session_id: sessionId,
+          run_id: snap.run_id,
+          user_message: snap.user_message,
+        });
+        for (const { seq, output } of snap.outputs) {
+          processEvent({ type: 'agent_message', session_id: sessionId, run_id: snap.run_id, seq, output });
+        }
+        if (snap.partial) {
+          processEvent({
+            type: 'agent_delta',
+            session_id: sessionId,
+            run_id: snap.run_id,
+            delta: snap.partial,
+            cum_len: snap.partial.length,
+          });
+        }
+      })
+      .catch(() => {
+        /* best-effort seed; the WS replay is the fallback */
+      });
 
     return () => {
       unsubscribe();

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -823,10 +823,13 @@ function SessionPage() {
         return;
       }
 
-      // Reveal proportional to the backlog (with a floor) so a fast stream
-      // never lags far behind, while a trickle still types out smoothly.
+      // Reveal proportional to the backlog so a fast stream still catches up,
+      // but with a *gentle* divisor and low floor: this intentionally lags a
+      // little, draining each burst over many frames so the gaps between a slow
+      // model's bursts are filled with steady typing instead of stutter. A cap
+      // keeps a huge backlog (or whole-message arrival) from snapping at once.
       const remaining = target.length - shown.length;
-      const step = Math.max(3, Math.ceil(remaining / 5));
+      const step = Math.min(Math.max(1, Math.ceil(remaining / 10)), 8);
       const next = target.slice(0, shown.length + step);
       revealedTextRef.current = next;
       setLiveMessages((prev) =>

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -1182,9 +1182,10 @@ function SessionPage() {
     // round-trip later). Feeds the same event shapes through processEvent; it's
     // idempotent with the replay (run claimed by id, messages keyed by seq,
     // delta is a length-guarded snapshot).
+    let ignoreSnapshot = false;
     void getActiveRunSnapshot(sessionId)
       .then((snap) => {
-        if (!snap) return;
+        if (ignoreSnapshot || !snap) return;
         processEvent({
           type: 'agent_run_started',
           session_id: sessionId,
@@ -1209,6 +1210,7 @@ function SessionPage() {
       });
 
     return () => {
+      ignoreSnapshot = true;
       unsubscribe();
       if (wsInactivityTimerRef.current) {
         clearTimeout(wsInactivityTimerRef.current);

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -1053,7 +1053,7 @@ function SessionPage() {
           revealSeededRef.current = false;
           void getActiveRunSnapshot(sessionId)
             .then((snap) => {
-              if (snap?.partial && currentRunIdRef.current === run_id) {
+              if (snap?.partial && snap.run_id === run_id && currentRunIdRef.current === run_id) {
                 processEvent({
                   type: 'agent_delta',
                   session_id: sessionId,

--- a/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
+++ b/app/src/routes/_app.projects.$projectSlug.sessions.$sessionPrefix.tsx
@@ -7,7 +7,7 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tansta
 import { useTranslation } from 'react-i18next';
 import { localizedNoun } from '@/i18n';
 import { getSession, markSessionRead, updateSessionShareMode } from '@/api/sessions';
-import { listMessageItems, sendMessage, stopRun, getRunActive, getActiveRunSnapshot, deriveStreamState } from '@/api/messages';
+import { listMessageItems, sendMessage, stopRun, getRunActive, getActiveRunSnapshot, deriveLiveSegments } from '@/api/messages';
 import { appWs } from '@/api/ws';
 import type { AppWsEvent } from '@/api/ws';
 import type { MessageOutput } from '@/api/backend-types';
@@ -984,41 +984,64 @@ function SessionPage() {
         const outOfOrder = seq <= maxSeqRef.current;
         if (seq > maxSeqRef.current) maxSeqRef.current = seq;
 
-        const outputs = outOfOrder
-          ? [...wsOutputsRef.current.entries()].sort(([a], [b]) => a - b).map(([, v]) => v)
-          : [...wsOutputsRef.current.values()];
-        const update = deriveStreamState(outputs, 'streaming');
+        const orderedEntries = outOfOrder
+          ? [...wsOutputsRef.current.entries()].sort(([a], [b]) => a - b)
+          : [...wsOutputsRef.current.entries()];
+        const segments = deriveLiveSegments(orderedEntries);
 
+        // Rebuild the live transcript chronologically — one bubble per committed
+        // turn, sub-agent bubbles at their seq position, streaming tail last —
+        // mirroring the persisted layout. This keeps an earlier turn's text
+        // visible while the next turn streams (it used to vanish: the single
+        // live bubble's body was replaced per turn) and streams a
+        // post-sub-agent turn *below* the sub-agent bubble instead of above it.
         const aiId = `live-ai-${sessionId}`;
         setLiveMessages((prev) => {
-          let next = prev.map((m) => {
-            if (m.id !== aiId) return m;
-            const updatedToolCalls = update.toolCalls.length > 0
-              ? update.toolCalls.map((tc) => ({ ...tc }))
-              : m.toolCalls;
-            return { ...m, body: update.text, status: 'streaming' as const, toolCalls: updatedToolCalls };
-          });
-          // Upsert subagent bubbles
-          for (const sub of update.subagentUpdates) {
-            const subId = `live-sub-${sub.sourceAgent}`;
-            const exists = next.some((m) => m.id === subId);
-            const nowIso = new Date().toISOString();
-            if (exists) {
-              next = next.map((m) =>
-                m.id === subId ? { ...m, body: sub.text, status: 'streaming' as const } : m,
-              );
-            } else {
-              next = [...next, {
-                id: subId,
+          const isLiveTranscript = (id: string) =>
+            id === aiId || id.startsWith('live-sub-') || id.startsWith('live-turn-');
+          // User bubbles (optimistic or from run_started) stay in front.
+          const head = prev.filter((m) => !isLiveTranscript(String(m.id)));
+          const prevById = new Map(prev.map((m) => [String(m.id), m]));
+          const nowIso = new Date().toISOString();
+          const committed = segments.map((seg): Message => {
+            if (seg.kind === 'turn') {
+              const id = `live-turn-${seg.seq}`;
+              return {
+                id,
                 sessionId: sessionPrefix,
-                sender: { kind: 'agent' as const, name: sub.sourceAgent },
-                createdAt: nowIso,
-                body: sub.text,
-                status: 'streaming' as const,
-              }];
+                sender: { kind: 'agent' as const, name: 'agent-k' },
+                createdAt: prevById.get(id)?.createdAt ?? nowIso,
+                body: seg.text,
+                status: 'done' as const,
+                toolCalls: seg.toolCalls.length > 0 ? seg.toolCalls.map((tc) => ({ ...tc })) : undefined,
+              };
             }
-          }
-          return next;
+            const id = `live-sub-${seg.sourceAgent}`;
+            return {
+              id,
+              sessionId: sessionPrefix,
+              sender: { kind: 'agent' as const, name: seg.sourceAgent },
+              createdAt: prevById.get(id)?.createdAt ?? nowIso,
+              body: seg.text,
+              status: 'streaming' as const,
+            };
+          });
+          // The streaming tail is where the next turn's deltas paint (the
+          // reveal loop targets aiId); this commit consumed the partial, so its
+          // body resets to empty.
+          const tail = prevById.get(aiId);
+          return [
+            ...head,
+            ...committed,
+            {
+              id: aiId,
+              sessionId: sessionPrefix,
+              sender: { kind: 'agent' as const, name: 'agent-k' },
+              createdAt: tail?.createdAt ?? nowIso,
+              body: '',
+              status: 'streaming' as const,
+            },
+          ];
         });
       }
 

--- a/backend/src/agent_stream.rs
+++ b/backend/src/agent_stream.rs
@@ -18,8 +18,9 @@ use ailoy::message::{
 /// One actionable item derived from the raw delta stream.
 #[derive(Debug)]
 pub enum AgentStreamItem {
-    /// Newly streamed assistant text for live rendering. Empty fragments are
-    /// never emitted, and tool results never appear here — they surface only as
+    /// Newly streamed top-level assistant text for live rendering. Empty
+    /// fragments are never emitted, and tool results and sub-agent (depth ≥ 1)
+    /// output never appear here — they surface only as
     /// [`AgentStreamItem::Completed`], matching the pre-streaming-API semantics.
     Delta(String),
     /// A message finalized at a boundary (equivalent to the old
@@ -51,11 +52,16 @@ impl MessageAssembler {
     pub fn push(&mut self, delta: MessageDeltaOutput) -> Result<Vec<AgentStreamItem>, String> {
         let mut items = Vec::new();
 
-        // 1. Live assistant text. A continuation delta carries no role, so fall
-        //    back to the in-progress message's; exclude Tool rather than require
-        //    Assistant so text streamed before the role marker isn't dropped.
+        // 1. Live assistant text — top-level only. A sub-agent's answer is
+        //    re-emitted on this same stream as a role=Assistant one-shot at
+        //    depth ≥ 1; streaming it here would splice the sub-agent's internal
+        //    text into the top-level answer (and a stop would persist that mix).
+        //    A continuation delta carries no role/depth, so fall back to the
+        //    in-progress message's; exclude Tool rather than require Assistant
+        //    so text streamed before the role marker isn't dropped.
         let effective_role = delta.delta.role.as_ref().or(self.acc.delta.role.as_ref());
-        if !matches!(effective_role, Some(Role::Tool)) {
+        let is_top_level = matches!(delta.depth.or(self.acc.depth), None | Some(0));
+        if is_top_level && !matches!(effective_role, Some(Role::Tool)) {
             let mut fragment = String::new();
             for part in &delta.delta.contents {
                 if let PartDelta::Text { text } = part {
@@ -222,6 +228,30 @@ mod tests {
         assert!(
             err.contains("role"),
             "error should mention the role mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn subagent_output_never_streams_as_live_delta() {
+        // A sub-agent's answer is re-emitted on the stream as a one-shot
+        // role=Assistant delta at depth >= 1. It must not surface as live
+        // top-level text (that would splice the sub-agent's internal answer
+        // into the main bubble, and a stop would persist the mix) — only as a
+        // Completed message, which the client routes to the sub-agent UI.
+        let mut a = MessageAssembler::new();
+        let mut d = delta(Some(Role::Assistant), "subagent internal answer", true);
+        d.depth = Some(1);
+        let items = a.push(d).unwrap();
+        assert!(
+            text_of(&items).is_empty(),
+            "sub-agent text must not stream as the top-level answer"
+        );
+        let done = completed(items);
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].depth, Some(1));
+        assert_eq!(
+            done[0].message.contents[0].as_text().unwrap(),
+            "subagent internal answer"
         );
     }
 

--- a/backend/src/agent_stream.rs
+++ b/backend/src/agent_stream.rs
@@ -1,0 +1,242 @@
+//! Reassembles ailoy's raw streaming output into discrete, actionable items.
+//!
+//! `Agent::run_stream` yields a uniform stream of [`MessageDeltaOutput`]s.
+//! ailoy's stream contract guarantees every message ends with a delta carrying a
+//! `finish_reason` (the LangModel layer synthesizes a terminal Stop delta when a
+//! provider ends the stream without one), so a message boundary is exactly
+//! "`finish_reason` present". [`MessageAssembler`] folds deltas to that boundary
+//! while also passing the assistant's text through for live rendering —
+//! recreating the shape of ailoy's old `AgentEvent` (Delta | Message) for
+//! consumers that want both views. A non-conforming stream (role change with no
+//! intervening `finish_reason`) fails loudly via `accumulate` rather than being
+//! silently healed.
+
+use ailoy::message::{
+    Delta as _, FinishReason, MessageDeltaOutput, MessageOutput, PartDelta, Role,
+};
+
+/// One actionable item derived from the raw delta stream.
+#[derive(Debug)]
+pub enum AgentStreamItem {
+    /// Newly streamed assistant text for live rendering. Empty fragments are
+    /// never emitted, and tool results never appear here — they surface only as
+    /// [`AgentStreamItem::Completed`], matching the pre-streaming-API semantics.
+    Delta(String),
+    /// A message finalized at a boundary (equivalent to the old
+    /// `AgentEvent::Message`): a completed assistant turn or a tool result. Boxed
+    /// so this variant doesn't bloat the small `Delta` case.
+    Completed(Box<MessageOutput>),
+}
+
+/// Accumulates streamed [`MessageDeltaOutput`]s and emits [`AgentStreamItem`]s at
+/// message boundaries. Feed each delta to [`push`](Self::push); call
+/// [`finish`](Self::finish) once the stream ends to flush any trailing message.
+#[derive(Default)]
+pub struct MessageAssembler {
+    /// The message currently being streamed, accumulated across deltas.
+    acc: MessageDeltaOutput,
+}
+
+impl MessageAssembler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one streamed delta. Returns the items to act on, in order: an
+    /// optional `Delta` (assistant text from this delta), then an optional
+    /// `Completed` (when this delta carries the message's `finish_reason`).
+    /// `Err` carries a finalization/accumulation failure message; a role change
+    /// with no intervening `finish_reason` (contract violation) lands here via
+    /// `accumulate`'s role-mismatch rejection.
+    pub fn push(&mut self, delta: MessageDeltaOutput) -> Result<Vec<AgentStreamItem>, String> {
+        let mut items = Vec::new();
+
+        // 1. Live assistant text. A continuation delta carries no role, so fall
+        //    back to the in-progress message's; exclude Tool rather than require
+        //    Assistant so text streamed before the role marker isn't dropped.
+        let effective_role = delta.delta.role.as_ref().or(self.acc.delta.role.as_ref());
+        if !matches!(effective_role, Some(Role::Tool)) {
+            let mut fragment = String::new();
+            for part in &delta.delta.contents {
+                if let PartDelta::Text { text } = part {
+                    fragment.push_str(text);
+                }
+            }
+            if !fragment.is_empty() {
+                items.push(AgentStreamItem::Delta(fragment));
+            }
+        }
+
+        // 2. Fold this delta into the running message.
+        let acc = std::mem::take(&mut self.acc);
+        self.acc = acc.accumulate(delta).map_err(|e| e.to_string())?;
+
+        // 3. A delta carrying finish_reason finalizes the message — per ailoy's
+        //    stream contract, this is the message boundary.
+        if self.acc.finish_reason.is_some() {
+            let done = std::mem::take(&mut self.acc);
+            items.push(AgentStreamItem::Completed(Box::new(
+                done.finish().map_err(|e| e.to_string())?,
+            )));
+        }
+
+        Ok(items)
+    }
+
+    /// Flush a message still accumulating when the stream ends. Defensive:
+    /// ailoy's contract (every message ends with a finish_reason delta) makes
+    /// this a no-op for conforming streams — `Some` here means an upstream
+    /// producer broke the contract, so the caller should log it. The message is
+    /// still returned (finalized as Stop) rather than dropped, because losing a
+    /// completed answer is strictly worse than surfacing a contract bug quietly.
+    /// Returns `None` if nothing pending.
+    pub fn finish(&mut self) -> Result<Option<MessageOutput>, String> {
+        if self.acc.delta.role.is_none() {
+            return Ok(None);
+        }
+        let mut done = std::mem::take(&mut self.acc);
+        done.finish_reason.get_or_insert(FinishReason::Stop {});
+        Ok(Some(done.finish().map_err(|e| e.to_string())?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ailoy::message::MessageDelta;
+
+    use super::*;
+
+    /// Build a streamed delta with an optional role, text, and finish_reason.
+    fn delta(role: Option<Role>, text: &str, finish: bool) -> MessageDeltaOutput {
+        let mut md = MessageDelta::new();
+        if let Some(r) = role {
+            md = md.with_role(r);
+        }
+        if !text.is_empty() {
+            md = md.with_contents([PartDelta::Text { text: text.into() }]);
+        }
+        let mut out = MessageDeltaOutput::new();
+        out.delta = md;
+        out.depth = Some(0);
+        if finish {
+            out.finish_reason = Some(FinishReason::Stop {});
+        }
+        out
+    }
+
+    fn text_of(items: &[AgentStreamItem]) -> Vec<String> {
+        items
+            .iter()
+            .filter_map(|i| match i {
+                AgentStreamItem::Delta(t) => Some(t.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn completed(items: Vec<AgentStreamItem>) -> Vec<MessageOutput> {
+        items
+            .into_iter()
+            .filter_map(|i| match i {
+                AgentStreamItem::Completed(o) => Some(*o),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn streams_text_then_completes_on_finish_reason() {
+        let mut a = MessageAssembler::new();
+
+        let first = a.push(delta(Some(Role::Assistant), "Hel", false)).unwrap();
+        assert_eq!(text_of(&first), vec!["Hel"]);
+        assert!(completed(first).is_empty());
+
+        let second = a.push(delta(None, "lo", true)).unwrap();
+        assert_eq!(text_of(&second), vec!["lo"]);
+        let done = completed(second);
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].message.role, Role::Assistant);
+        assert_eq!(done[0].message.contents[0].as_text().unwrap(), "Hello");
+        assert!(matches!(done[0].finish_reason, FinishReason::Stop {}));
+
+        // Nothing pending after a clean finish.
+        assert!(a.finish().unwrap().is_none());
+    }
+
+    #[test]
+    fn flushes_trailing_message_when_stream_ends_without_finish_reason() {
+        // Defensive path: ailoy's contract means a conforming stream never ends
+        // mid-message, but if one does (upstream bug), the trailing message must
+        // be recovered — losing a completed answer is worse than the anomaly.
+        let mut a = MessageAssembler::new();
+
+        let items = a
+            .push(delta(Some(Role::Assistant), "answer", false))
+            .unwrap();
+        assert_eq!(text_of(&items), vec!["answer"]);
+        assert!(completed(items).is_empty());
+
+        let trailing = a.finish().unwrap().expect("trailing message must flush");
+        assert_eq!(trailing.message.role, Role::Assistant);
+        assert_eq!(trailing.message.contents[0].as_text().unwrap(), "answer");
+        assert!(matches!(trailing.finish_reason, FinishReason::Stop {}));
+    }
+
+    #[test]
+    fn tool_result_surfaces_only_as_completed_never_as_delta() {
+        let mut a = MessageAssembler::new();
+        // Finish an assistant turn first.
+        a.push(delta(Some(Role::Assistant), "calling", true))
+            .unwrap();
+
+        // A tool result arrives as its own role=Tool one-shot delta.
+        let items = a
+            .push(delta(Some(Role::Tool), "tool output", true))
+            .unwrap();
+        assert!(
+            text_of(&items).is_empty(),
+            "tool result must not stream as assistant text"
+        );
+        let done = completed(items);
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].message.role, Role::Tool);
+    }
+
+    #[test]
+    fn role_change_without_finish_reason_errors_loudly() {
+        // ailoy's contract guarantees a finish_reason delta closes every message
+        // before the role can change; a violation must surface as an error (via
+        // accumulate's role-mismatch rejection), not be silently healed into a
+        // split — silent healing would mask a broken producer.
+        let mut a = MessageAssembler::new();
+        let first = a
+            .push(delta(Some(Role::Assistant), "thinking", false))
+            .unwrap();
+        assert_eq!(text_of(&first), vec!["thinking"]);
+        assert!(completed(first).is_empty());
+
+        let err = a
+            .push(delta(Some(Role::Tool), "result", true))
+            .expect_err("role change without finish_reason must be rejected");
+        assert!(
+            err.contains("role"),
+            "error should mention the role mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_fragments_are_not_emitted() {
+        let mut a = MessageAssembler::new();
+        // A role-only opener (e.g. message_start) carries no text.
+        let items = a.push(delta(Some(Role::Assistant), "", false)).unwrap();
+        assert!(text_of(&items).is_empty());
+        assert!(completed(items).is_empty());
+    }
+
+    #[test]
+    fn finish_on_empty_assembler_yields_nothing() {
+        let mut a = MessageAssembler::new();
+        assert!(a.finish().unwrap().is_none());
+    }
+}

--- a/backend/src/events.rs
+++ b/backend/src/events.rs
@@ -1,6 +1,7 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RunUserMessage {
     pub sender_user_id: String,
     pub content: String,
@@ -27,13 +28,18 @@ pub enum WsEvent {
         seq: u64,
         output: ailoy::message::MessageOutput,
     },
-    /// Live token fragment for the in-progress assistant turn. Ephemeral: not
-    /// persisted and carries no seq — the client accumulates deltas for live
-    /// rendering and is reconciled by the completed `AgentMessage` that follows.
+    /// Incremental text delta for the in-progress assistant turn. Ephemeral: not
+    /// persisted, no seq. `delta` is the newly produced text; `cum_len` is the
+    /// turn's total length (in UTF-16 code units, matching JS `String.length`)
+    /// after appending it. The client uses `cum_len` to dedup/order across the
+    /// replay↔live boundary: skip if already applied, slice off any overlap. The
+    /// resume path (subscribe replay / load) sends the whole turn as one delta.
+    /// Reconciled by the completed `AgentMessage` that follows.
     AgentDelta {
         session_id: String,
         run_id: String,
-        delta: ailoy::message::MessageDeltaOutput,
+        delta: String,
+        cum_len: u64,
     },
     AgentError {
         session_id: String,

--- a/backend/src/events.rs
+++ b/backend/src/events.rs
@@ -27,6 +27,14 @@ pub enum WsEvent {
         seq: u64,
         output: ailoy::message::MessageOutput,
     },
+    /// Live token fragment for the in-progress assistant turn. Ephemeral: not
+    /// persisted and carries no seq — the client accumulates deltas for live
+    /// rendering and is reconciled by the completed `AgentMessage` that follows.
+    AgentDelta {
+        session_id: String,
+        run_id: String,
+        delta: ailoy::message::MessageDeltaOutput,
+    },
     AgentError {
         session_id: String,
         run_id: String,

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use agent_k::agents::{GUEST_ATTACHED_DIR, GUEST_SHARED_DIR};
 use ailoy::{
-    agent::Agent,
+    agent::{Agent, AgentEvent},
     message::{FinishReason, Message, MessageOutput, Part, Role},
     runenv::{Sandbox, SandboxConfig},
 };
@@ -881,8 +881,7 @@ pub async fn get_message_history(
             Some(summary) => (*summary).clone(),
             None => match state.store_for(session.project_id).await {
                 Ok(store) => {
-                    let summary =
-                        crate::handlers::knowledge::corpus_summary(&*store.read().await);
+                    let summary = crate::handlers::knowledge::corpus_summary(&*store.read().await);
                     state.set_corpus_summary(session.project_id, summary.clone());
                     summary
                 }
@@ -912,19 +911,31 @@ pub async fn get_message_history(
             // cached result when present; otherwise verify once and cache it.
             // The cache is dropped per project whenever the corpus changes, so a
             // hit always reflects the current corpus.
-            let citations = if matches!(r.sender_kind, DbSenderKind::Agent) && !corpus_docs.is_empty() {
-                match state.citation_checks(session.project_id, session.id, r.seq) {
-                    Some(cached) => (*cached).clone(),
-                    None => {
-                        let text: String = r.message.contents.iter().filter_map(|p| p.as_text()).collect();
-                        let checks = crate::handlers::knowledge::verify_citations(&text, &corpus_docs);
-                        state.set_citation_checks(session.project_id, session.id, r.seq, checks.clone());
-                        checks
+            let citations =
+                if matches!(r.sender_kind, DbSenderKind::Agent) && !corpus_docs.is_empty() {
+                    match state.citation_checks(session.project_id, session.id, r.seq) {
+                        Some(cached) => (*cached).clone(),
+                        None => {
+                            let text: String = r
+                                .message
+                                .contents
+                                .iter()
+                                .filter_map(|p| p.as_text())
+                                .collect();
+                            let checks =
+                                crate::handlers::knowledge::verify_citations(&text, &corpus_docs);
+                            state.set_citation_checks(
+                                session.project_id,
+                                session.id,
+                                r.seq,
+                                checks.clone(),
+                            );
+                            checks
+                        }
                     }
-                }
-            } else {
-                Vec::new()
-            };
+                } else {
+                    Vec::new()
+                };
             Ok(SessionMessageResponse {
                 seq: r.seq,
                 message: r.message,
@@ -1116,7 +1127,7 @@ pub async fn send_message(
         let mut agent = guard; // OwnedMutexGuard — held for the run's lifetime
         let prev_artifacts = collect_artifact_paths(&artifacts_dir).await;
         let msg = Message::new(Role::User).with_contents([Part::text(content_with_note)]);
-        let mut run = agent.run(msg);
+        let mut run = agent.run_stream(msg);
 
         let mut run_error: Option<String> = None;
         let mut stopped = false;
@@ -1150,7 +1161,18 @@ pub async fn send_message(
                 item = run.next() => item,
             };
             match item {
-                Some(Ok(output)) => {
+                // Live token fragment: forward for client-side live rendering.
+                // Ephemeral — not persisted, no seq, never breaks the stop loop
+                // (we let the in-flight turn complete into its `Message` first).
+                Some(Ok(AgentEvent::Delta(delta))) => {
+                    let _ = state2.ws_tx.send(WsEvent::AgentDelta {
+                        session_id: session_id.to_string(),
+                        run_id: run_id.to_string(),
+                        delta,
+                    });
+                }
+                // Completed turn: identical to what `run()` used to yield.
+                Some(Ok(AgentEvent::Message(output))) => {
                     if matches!(output.depth, None | Some(0)) {
                         if output.message.role == Role::Tool {
                             pending_tool_results = pending_tool_results.saturating_sub(1);
@@ -1242,7 +1264,11 @@ pub async fn send_message(
                 // add a paired one (via synthetic_msgs) if none was produced yet.
                 const INTERRUPT_NOTE: &str =
                     "[Interrupted: the user manually stopped response generation here]";
-                if let Some(last) = new_msgs.iter_mut().rev().find(|m| m.role == Role::Assistant) {
+                if let Some(last) = new_msgs
+                    .iter_mut()
+                    .rev()
+                    .find(|m| m.role == Role::Assistant)
+                {
                     last.contents.push(Part::text(INTERRUPT_NOTE));
                     if let Some(warm) = agent.state.history[prev_len..]
                         .iter_mut()
@@ -1252,14 +1278,12 @@ pub async fn send_message(
                         warm.contents.push(Part::text(INTERRUPT_NOTE));
                     }
                 } else {
-                    synthetic_msgs
-                        .push(Message::new(Role::Assistant).with_contents([Part::text(INTERRUPT_NOTE)]));
+                    synthetic_msgs.push(
+                        Message::new(Role::Assistant).with_contents([Part::text(INTERRUPT_NOTE)]),
+                    );
                 }
             }
-            agent
-                .state
-                .history
-                .extend(synthetic_msgs.iter().cloned());
+            agent.state.history.extend(synthetic_msgs.iter().cloned());
         }
 
         // Strip the attachment note before persisting — clean content is stored in DB and the
@@ -1288,18 +1312,14 @@ pub async fn send_message(
             }
         }
 
-        to_persist.extend(
-            synthetic_msgs
-                .into_iter()
-                .map(|message| NewSessionMessage {
-                    message,
-                    sender_kind: crate::repository::DbSenderKind::Agent,
-                    sender_name: Some(TOP_LEVEL_AGENT_NAME.to_string()),
-                    sender_user_id: None,
-                    attachments: vec![],
-                    artifacts: vec![],
-                }),
-        );
+        to_persist.extend(synthetic_msgs.into_iter().map(|message| NewSessionMessage {
+            message,
+            sender_kind: crate::repository::DbSenderKind::Agent,
+            sender_name: Some(TOP_LEVEL_AGENT_NAME.to_string()),
+            sender_user_id: None,
+            attachments: vec![],
+            artifacts: vec![],
+        }));
 
         // [A] Persist before releasing the agent lock. On failure: roll back in-memory history,
         // send AgentError (not AgentRunDone), and return — the DB remains consistent.

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -22,9 +22,9 @@ use crate::{
         DirentScope, copy_dir_recursive, enforce_scope_access, parse_dirent_path, scope_root,
     },
     model::{
-        CreateSessionRequest, MessageSender, RunAck, RunActiveResponse, SendMessageRequest,
-        SessionListResponse, SessionMessageListResponse, SessionMessageResponse, SessionResponse,
-        UpdateSessionRequest,
+        ActiveRunOutput, ActiveRunSnapshot, CreateSessionRequest, MessageSender, RunAck,
+        RunActiveResponse, SendMessageRequest, SessionListResponse, SessionMessageListResponse,
+        SessionMessageResponse, SessionResponse, UpdateSessionRequest,
     },
     repository::{
         DbSenderKind, NewSessionMessage, PrefixLookup, SessionAccess, SessionOrigin, ShareMode,
@@ -1150,21 +1150,32 @@ pub async fn send_message(
                 item = run.next() => item,
             };
             match item {
-                // Live token fragment: forward for client-side live rendering.
-                // Ephemeral — not persisted and carries no seq.
+                // Live text fragment. Broadcast it incrementally (cheap — small
+                // payload even with many subscribers) with the running total so
+                // the client can dedup at the replay↔live boundary. Keep the full
+                // text in `partial_text` for stop-persist and mid-turn resume.
+                // Ephemeral — not persisted, no seq.
                 Some(Ok(AgentEvent::Delta(delta))) => {
-                    // Accumulate text so a mid-turn stop can still persist the
-                    // partial answer (see `partial_text` above).
+                    let mut fragment = String::new();
                     for part in &delta.delta.contents {
                         if let PartDelta::Text { text } = part {
-                            partial_text.push_str(text);
+                            fragment.push_str(text);
                         }
                     }
-                    let _ = state2.ws_tx.send(WsEvent::AgentDelta {
-                        session_id: session_id.to_string(),
-                        run_id: run_id.to_string(),
-                        delta,
-                    });
+                    if !fragment.is_empty() {
+                        partial_text.push_str(&fragment);
+                        // UTF-16 units so cum_len matches the client's String.length.
+                        let cum_len = partial_text.encode_utf16().count() as u64;
+                        // Keep the resume snapshot exact so a (re)subscribe never
+                        // lands in a hole (cheap: in-process, not per-subscriber).
+                        state2.set_partial(&session_id, partial_text.clone()).await;
+                        let _ = state2.ws_tx.send(WsEvent::AgentDelta {
+                            session_id: session_id.to_string(),
+                            run_id: run_id.to_string(),
+                            delta: fragment,
+                            cum_len,
+                        });
+                    }
                 }
                 // Completed turn: identical to what `run()` used to yield.
                 Some(Ok(AgentEvent::Message(output))) => {
@@ -1173,8 +1184,10 @@ pub async fn send_message(
                             // This turn committed as a real Message; the partial
                             // buffer is now redundant — clear it so the next turn
                             // accumulates from empty (and a later stop doesn't
-                            // re-persist already-committed text).
+                            // re-persist already-committed text). Also clear the
+                            // replayable snapshot so a resume doesn't double it.
                             partial_text.clear();
+                            state2.set_partial(&session_id, String::new()).await;
                         }
                         depth0_outputs.push(output.clone());
                     }
@@ -1446,4 +1459,35 @@ pub async fn run_active(
         Some((active_run_id, _, _)) if active_run_id == run_id
     );
     Ok(Json(RunActiveResponse { active }))
+}
+
+/// Snapshot of the session's in-flight run (or `null` if none), so a client
+/// loading the page mid-stream can render the in-progress turn immediately
+/// rather than waiting for the WebSocket replay. The completed run is in the DB
+/// via the normal message history; this only covers the not-yet-persisted run.
+pub async fn get_active_run(
+    State(state): State<Arc<AppState>>,
+    Extension(auth_user): Extension<AuthUser>,
+    Path(session_ref): Path<String>,
+) -> ApiResult<Json<Option<ActiveRunSnapshot>>> {
+    let session_id = resolve_session_id(&state, &session_ref).await?;
+    state
+        .repository
+        .get_session_with_authz(session_id, auth_user.id)
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?
+        .ok_or_else(|| AppError::not_found("session not found or access denied"))?;
+
+    let snapshot = state.snapshot(&session_id).await.map(
+        |(run_id, user_message, outputs, partial)| ActiveRunSnapshot {
+            run_id: run_id.to_string(),
+            user_message,
+            outputs: outputs
+                .into_iter()
+                .map(|(seq, output)| ActiveRunOutput { seq, output })
+                .collect(),
+            partial,
+        },
+    );
+    Ok(Json(snapshot))
 }

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -1235,8 +1235,10 @@ pub async fn send_message(
                 tracing::error!(%session_id, "agent run failed: {err}");
                 // Truncate in-memory history to match DB state so the agent stays consistent.
                 agent.state.history.truncate(prev_len);
+                // End the run before releasing the lock so no newer run can slot
+                // in between drop and cleanup.
+                state2.end_run(&session_id, run_id);
                 drop(agent);
-                state2.end_run(&session_id);
                 let _ = state2.ws_tx.send(WsEvent::AgentError {
                     session_id: session_id.to_string(),
                     run_id: run_id.to_string(),
@@ -1363,8 +1365,8 @@ pub async fn send_message(
         {
             tracing::error!(%session_id, "failed to persist messages: {e}");
             agent.state.history.truncate(prev_len);
+            state2.end_run(&session_id, run_id);
             drop(agent);
-            state2.end_run(&session_id);
             let _ = state2.ws_tx.send(WsEvent::AgentError {
                 session_id: session_id.to_string(),
                 run_id: run_id.to_string(),
@@ -1372,7 +1374,11 @@ pub async fn send_message(
             });
             return;
         }
-        drop(agent); // Release OwnedMutexGuard only after successful persist
+        // End the run before releasing the lock: while the OwnedMutexGuard is
+        // held no other request can acquire it and start a replacement run, so
+        // this can never delete a newer run's record.
+        state2.end_run(&session_id, run_id);
+        drop(agent); // Release OwnedMutexGuard only after successful persist + cleanup
 
         // Intentionally NOT calling mark_session_read here: the sender should
         // only be considered to have read the agent's reply when they actually
@@ -1381,7 +1387,6 @@ pub async fn send_message(
         // messages, so unread_count is always 0 — breaking cross-session
         // unread badges for users who navigated away before the agent finished.
 
-        state2.end_run(&session_id);
         let _ = state2.ws_tx.send(WsEvent::AgentRunDone {
             session_id: session_id.to_string(),
             run_id: run_id.to_string(),
@@ -1399,7 +1404,10 @@ pub async fn send_message(
                 err = %join_err,
                 "agent background task panicked; forcing end_run and AgentError"
             );
-            state_mon.end_run(&session_id);
+            // run_id-guarded: unwind released the agent lock before this task
+            // ran, so a newer run may already own the session's entry — only
+            // remove ours.
+            state_mon.end_run(&session_id, run_id);
             let _ = state_mon.ws_tx.send(WsEvent::AgentError {
                 session_id: session_id.to_string(),
                 run_id: run_id.to_string(),

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -11,7 +11,7 @@ use axum::{
     extract::{Extension, Path, State},
     http::StatusCode,
 };
-use futures_util::StreamExt;
+use futures_util::{FutureExt, StreamExt};
 use uuid::Uuid;
 
 use crate::{
@@ -1137,17 +1137,30 @@ pub async fn send_message(
         // answer. Cleared whenever a depth-0 assistant Message commits.
         let mut partial_text = String::new();
         loop {
-            let item = tokio::select! {
-                biased;
-                _ = cancel.cancelled() => {
-                    // Stop promptly: drop the stream (aborting the in-flight model
-                    // request) instead of draining the rest of the turn. Whatever
-                    // text streamed so far is in `partial_text` and gets persisted
-                    // below, so the partial answer survives without finishing.
-                    stopped = true;
-                    break;
+            let item = if stopped {
+                // Drain mode (entered on cancel). Take only what ailoy has already
+                // produced, never awaiting new output, so a turn that finished at
+                // the exact cancel instant still commits its terminal Message
+                // (→ completed_naturally) instead of being mistagged [Interrupted].
+                // Nothing ready → drop the stream below, aborting the in-flight
+                // request, so stop stays prompt.
+                match run.next().now_or_never() {
+                    Some(item) => item, // Some(x) ready, or None if the stream ended
+                    None => break,      // would block → nothing buffered, stop now
                 }
-                item = run.next() => item,
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        // Switch to drain mode rather than breaking immediately, so
+                        // an already-produced terminal Message isn't discarded.
+                        // Whatever text streamed so far is in `partial_text` and is
+                        // persisted below if the turn truly didn't finish.
+                        stopped = true;
+                        continue;
+                    }
+                    item = run.next() => item,
+                }
             };
             match item {
                 // Live text fragment. Broadcast it incrementally (cheap — small
@@ -1199,9 +1212,9 @@ pub async fn send_message(
                             output,
                         });
                     }
-                    if stopped {
-                        break;
-                    }
+                    // No early break in drain mode: keep taking already-ready items
+                    // until the stream ends (`None`) or nothing is buffered
+                    // (`now_or_never` → break above), so a finish-line turn commits.
                 }
                 Some(Err(e)) => {
                     run_error = Some(e.to_string());

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, sync::Arc};
 use agent_k::agents::{GUEST_ATTACHED_DIR, GUEST_SHARED_DIR};
 use ailoy::{
     agent::{Agent, AgentEvent},
-    message::{FinishReason, Message, MessageOutput, Part, Role},
+    message::{FinishReason, Message, MessageOutput, Part, PartDelta, Role},
     runenv::{Sandbox, SandboxConfig},
 };
 use axum::{
@@ -35,7 +35,6 @@ use crate::{
 
 const TOP_LEVEL_AGENT_NAME: &str = "agent-k";
 const SANDBOX_IMAGE: &str = "brekkylab/agent-k:latest";
-const STOP_RUN_GRACE_SECS: u64 = 10;
 
 pub(crate) fn sandbox_name_for(id: &Uuid) -> String {
     let s = id.simple().to_string();
@@ -1132,39 +1131,35 @@ pub async fn send_message(
         let mut run_error: Option<String> = None;
         let mut stopped = false;
         let mut depth0_outputs: Vec<MessageOutput> = Vec::new();
-        let mut pending_tool_results: usize = 0;
+        // Accumulates streamed assistant text for the in-flight turn. ailoy drops
+        // its own accumulator when the stream is dropped, so if a stop cuts a turn
+        // short before it commits a Message, this is the only copy of the partial
+        // answer. Cleared whenever a depth-0 assistant Message commits.
+        let mut partial_text = String::new();
         loop {
             let item = tokio::select! {
                 biased;
                 _ = cancel.cancelled() => {
+                    // Stop promptly: drop the stream (aborting the in-flight model
+                    // request) instead of draining the rest of the turn. Whatever
+                    // text streamed so far is in `partial_text` and gets persisted
+                    // below, so the partial answer survives without finishing.
                     stopped = true;
-                    if pending_tool_results == 0 {
-                        match tokio::time::timeout(
-                            std::time::Duration::from_secs(STOP_RUN_GRACE_SECS),
-                            run.next(),
-                        )
-                        .await
-                        {
-                            Ok(item) => item,
-                            Err(_) => {
-                                tracing::warn!(
-                                    %session_id,
-                                    "stop: in-flight model call exceeded {STOP_RUN_GRACE_SECS}s grace period; discarding"
-                                );
-                                break;
-                            }
-                        }
-                    } else {
-                        break;
-                    }
+                    break;
                 }
                 item = run.next() => item,
             };
             match item {
                 // Live token fragment: forward for client-side live rendering.
-                // Ephemeral — not persisted, no seq, never breaks the stop loop
-                // (we let the in-flight turn complete into its `Message` first).
+                // Ephemeral — not persisted and carries no seq.
                 Some(Ok(AgentEvent::Delta(delta))) => {
+                    // Accumulate text so a mid-turn stop can still persist the
+                    // partial answer (see `partial_text` above).
+                    for part in &delta.delta.contents {
+                        if let PartDelta::Text { text } = part {
+                            partial_text.push_str(text);
+                        }
+                    }
                     let _ = state2.ws_tx.send(WsEvent::AgentDelta {
                         session_id: session_id.to_string(),
                         run_id: run_id.to_string(),
@@ -1174,11 +1169,12 @@ pub async fn send_message(
                 // Completed turn: identical to what `run()` used to yield.
                 Some(Ok(AgentEvent::Message(output))) => {
                     if matches!(output.depth, None | Some(0)) {
-                        if output.message.role == Role::Tool {
-                            pending_tool_results = pending_tool_results.saturating_sub(1);
-                        } else if matches!(output.finish_reason, FinishReason::ToolCall {}) {
-                            pending_tool_results =
-                                output.message.tool_calls.as_ref().map_or(0, |tc| tc.len());
+                        if output.message.role == Role::Assistant {
+                            // This turn committed as a real Message; the partial
+                            // buffer is now redundant — clear it so the next turn
+                            // accumulates from empty (and a later stop doesn't
+                            // re-persist already-committed text).
+                            partial_text.clear();
                         }
                         depth0_outputs.push(output.clone());
                     }
@@ -1260,11 +1256,22 @@ pub async fn send_message(
                 // completion so the client doesn't see a spurious "Run stopped" toast.
                 stopped = false;
             } else {
-                // Mark the turn as cut short: append to the last assistant message, or
-                // add a paired one (via synthetic_msgs) if none was produced yet.
+                // Mark the turn as cut short.
                 const INTERRUPT_NOTE: &str =
                     "[Interrupted: the user manually stopped response generation here]";
-                if let Some(last) = new_msgs
+                if !partial_text.is_empty() {
+                    // The interrupted turn streamed text but never committed a
+                    // Message (ailoy dropped its accumulator). Persist what we
+                    // accumulated as a fresh assistant message so the partial
+                    // answer survives a refresh. Routed through synthetic_msgs so
+                    // it is both persisted and pushed into history (keeping the
+                    // agent's in-memory state consistent with the DB).
+                    partial_text.push_str("\n\n");
+                    partial_text.push_str(INTERRUPT_NOTE);
+                    synthetic_msgs.push(
+                        Message::new(Role::Assistant).with_contents([Part::text(partial_text)]),
+                    );
+                } else if let Some(last) = new_msgs
                     .iter_mut()
                     .rev()
                     .find(|m| m.role == Role::Assistant)

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -3,9 +3,7 @@ use std::{collections::HashSet, sync::Arc};
 use agent_k::agents::{GUEST_ATTACHED_DIR, GUEST_SHARED_DIR};
 use ailoy::{
     agent::Agent,
-    message::{
-        Delta, FinishReason, Message, MessageDeltaOutput, MessageOutput, Part, PartDelta, Role,
-    },
+    message::{FinishReason, Message, MessageOutput, Part, Role},
     runenv::{Sandbox, SandboxConfig},
 };
 use axum::{
@@ -17,6 +15,7 @@ use futures_util::{FutureExt, StreamExt};
 use uuid::Uuid;
 
 use crate::{
+    agent_stream::{AgentStreamItem, MessageAssembler},
     auth::AuthUser,
     error::{ApiResult, AppError},
     events::{RunUserMessage, WsEvent},
@@ -1172,12 +1171,10 @@ pub async fn send_message(
         // short before it commits a Message, this is the only copy of the partial
         // answer. Cleared whenever a depth-0 assistant Message commits.
         let mut partial_text = String::new();
-        // `run_stream` now yields only `MessageDeltaOutput`s; we rebuild each
-        // completed `MessageOutput` ourselves by accumulating deltas until a
-        // boundary (a delta carrying `finish_reason`, or a role change), mirroring
-        // ailoy's `into_messages`. This is the running accumulator for the
-        // message currently being streamed.
-        let mut acc = MessageDeltaOutput::new();
+        // `run_stream` yields only `MessageDeltaOutput`s; the assembler reassembles
+        // them into live assistant deltas + completed messages (boundary detection
+        // and the trailing-flush quirk live in `agent_stream`, unit-tested there).
+        let mut assembler = MessageAssembler::new();
         loop {
             let item = if stopped {
                 // Drain mode (entered on cancel). Take only what ailoy has already
@@ -1206,107 +1203,50 @@ pub async fn send_message(
             };
             match item {
                 Some(Ok(delta)) => {
-                    // 1. Live text fragment. Only the assistant's own tokens stream
-                    // as the answer; tool results arrive on this same stream as
-                    // their own role=Tool one-shot delta and must not be shown as
-                    // the assistant's text. Everything else on this stream is
-                    // assistant text, so exclude Tool rather than require Assistant
-                    // — a provider may stream leading text before the role marker,
-                    // leaving both the delta and the accumulator role-less.
-                    let effective_role = delta.delta.role.as_ref().or(acc.delta.role.as_ref());
-                    let is_assistant_text = !matches!(effective_role, Some(Role::Tool));
-                    if is_assistant_text {
-                        let mut fragment = String::new();
-                        for part in &delta.delta.contents {
-                            if let PartDelta::Text { text } = part {
-                                fragment.push_str(text);
-                            }
-                        }
-                        if !fragment.is_empty() {
-                            // Broadcast incrementally (cheap — small payload even with
-                            // many subscribers) with the running total so the client can
-                            // dedup at the replay↔live boundary. Keep the full text in
-                            // `partial_text` for stop-persist and mid-turn resume.
-                            // Ephemeral — not persisted, no seq.
-                            partial_text.push_str(&fragment);
-                            // UTF-16 units so cum_len matches the client's String.length.
-                            let cum_len = partial_text.encode_utf16().count() as u64;
-                            // Keep the resume snapshot exact so a (re)subscribe never
-                            // lands in a hole (cheap: in-process, not per-subscriber).
-                            state2.set_partial(&session_id, partial_text.clone()).await;
-                            let _ = state2.ws_tx.send(WsEvent::AgentDelta {
-                                session_id: session_id.to_string(),
-                                run_id: run_id.to_string(),
-                                delta: fragment,
-                                cum_len,
-                            });
-                        }
-                    }
-
-                    // 2. A role change with no intervening finish_reason is also a
-                    // message boundary (e.g. an assistant turn flowing into a tool
-                    // result). accumulate() rejects a role mismatch, so flush the
-                    // in-progress message first (finalizing it as Stop).
-                    if let (Some(cur), Some(incoming)) = (&acc.delta.role, &delta.delta.role)
-                        && cur != incoming
-                    {
-                        let mut done = std::mem::replace(&mut acc, MessageDeltaOutput::new());
-                        if done.finish_reason.is_none() {
-                            done.finish_reason = Some(FinishReason::Stop {});
-                        }
-                        match done.finish() {
-                            Ok(output) => {
-                                commit_stream_output(
-                                    &state2,
-                                    &session_id,
-                                    run_id,
-                                    &mut depth0_outputs,
-                                    &mut partial_text,
-                                    output,
-                                )
-                                .await;
-                            }
-                            Err(e) => {
-                                run_error = Some(e.to_string());
-                                break;
-                            }
-                        }
-                    }
-
-                    // 3. Fold this delta into the running message.
-                    match acc.accumulate(delta) {
-                        Ok(a) => acc = a,
+                    // Reassemble the raw delta into live assistant deltas and/or a
+                    // completed message. No early break in drain mode: keep taking
+                    // already-ready items until the stream ends (`None`) or nothing
+                    // is buffered (`now_or_never` → break above), so a finish-line
+                    // turn commits.
+                    let produced = match assembler.push(delta) {
+                        Ok(items) => items,
                         Err(e) => {
-                            run_error = Some(e.to_string());
-                            // Restore a valid `acc` for the post-loop trailing
-                            // flush; it's skipped anyway once `run_error` is set.
-                            acc = MessageDeltaOutput::new();
+                            run_error = Some(e);
                             break;
                         }
-                    }
-
-                    // 4. A delta carrying finish_reason finalizes the message. Commit
-                    // it as a completed MessageOutput (the old `AgentEvent::Message`).
-                    // No early break in drain mode: keep taking already-ready items
-                    // until the stream ends (`None`) or nothing is buffered
-                    // (`now_or_never` → break above), so a finish-line turn commits.
-                    if acc.finish_reason.is_some() {
-                        let done = std::mem::replace(&mut acc, MessageDeltaOutput::new());
-                        match done.finish() {
-                            Ok(output) => {
+                    };
+                    for out in produced {
+                        match out {
+                            // Live assistant text. Broadcast incrementally (cheap —
+                            // small payload even with many subscribers) with the
+                            // running total so the client can dedup at the replay↔live
+                            // boundary. Keep the full text in `partial_text` for
+                            // stop-persist and mid-turn resume. Ephemeral — no seq.
+                            AgentStreamItem::Delta(fragment) => {
+                                partial_text.push_str(&fragment);
+                                // UTF-16 units so cum_len matches the client's String.length.
+                                let cum_len = partial_text.encode_utf16().count() as u64;
+                                // Keep the resume snapshot exact so a (re)subscribe never
+                                // lands in a hole (cheap: in-process, not per-subscriber).
+                                state2.set_partial(&session_id, partial_text.clone()).await;
+                                let _ = state2.ws_tx.send(WsEvent::AgentDelta {
+                                    session_id: session_id.to_string(),
+                                    run_id: run_id.to_string(),
+                                    delta: fragment,
+                                    cum_len,
+                                });
+                            }
+                            // Completed turn (the old `AgentEvent::Message`).
+                            AgentStreamItem::Completed(output) => {
                                 commit_stream_output(
                                     &state2,
                                     &session_id,
                                     run_id,
                                     &mut depth0_outputs,
                                     &mut partial_text,
-                                    output,
+                                    *output,
                                 )
                                 .await;
-                            }
-                            Err(e) => {
-                                run_error = Some(e.to_string());
-                                break;
                             }
                         }
                     }
@@ -1320,19 +1260,19 @@ pub async fn send_message(
         }
         drop(run);
 
-        // Provider quirk: some models (e.g. Gemini) end the stream cleanly with no
-        // terminal finish_reason delta, so the final assistant message never hit
-        // the finish_reason boundary in the loop and is still sitting in `acc`. On
-        // a natural completion (not an error, not a user stop) finalize it as Stop
-        // and commit it — mirroring ailoy's own internal fallback and
-        // `into_messages`' trailing flush — so it lands in `depth0_outputs`.
-        // Without this, `attribute_messages` below zips a sender list one short of
-        // `agent`'s history and silently drops the final answer from persistence.
-        // A stopped/errored turn is left to the partial-text path below on purpose.
-        if run_error.is_none() && !stopped && acc.delta.role.is_some() {
-            acc.finish_reason.get_or_insert(FinishReason::Stop {});
-            match acc.finish() {
-                Ok(output) => {
+        // Defensive trailing flush on natural completion. ailoy's stream contract
+        // (every message ends with a finish_reason delta) makes this a no-op for
+        // conforming streams — Some here means an upstream producer broke the
+        // contract. Still commit the message (losing a completed answer is worse)
+        // but warn so the violation is visible. A stopped/errored turn is left to
+        // the partial-text path below on purpose.
+        if run_error.is_none() && !stopped {
+            match assembler.finish() {
+                Ok(Some(output)) => {
+                    tracing::warn!(
+                        %session_id,
+                        "stream ended mid-message (contract violation upstream); committing trailing message"
+                    );
                     commit_stream_output(
                         &state2,
                         &session_id,
@@ -1343,6 +1283,7 @@ pub async fn send_message(
                     )
                     .await;
                 }
+                Ok(None) => {}
                 Err(e) => {
                     tracing::warn!(%session_id, "failed to finalize trailing stream delta: {e}");
                 }

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -1564,16 +1564,20 @@ pub async fn get_active_run(
         .map_err(|e| AppError::internal(e.to_string()))?
         .ok_or_else(|| AppError::not_found("session not found or access denied"))?;
 
-    let snapshot = state.snapshot(&session_id).await.map(
-        |(run_id, user_message, outputs, partial)| ActiveRunSnapshot {
-            run_id: run_id.to_string(),
-            user_message,
-            outputs: outputs
-                .into_iter()
-                .map(|(seq, output)| ActiveRunOutput { seq, output })
-                .collect(),
-            partial,
-        },
-    );
+    let snapshot =
+        state
+            .snapshot(&session_id)
+            .await
+            .map(
+                |(run_id, user_message, outputs, partial)| ActiveRunSnapshot {
+                    run_id: run_id.to_string(),
+                    user_message,
+                    outputs: outputs
+                        .into_iter()
+                        .map(|(seq, output)| ActiveRunOutput { seq, output })
+                        .collect(),
+                    partial,
+                },
+            );
     Ok(Json(snapshot))
 }

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -2,8 +2,10 @@ use std::{collections::HashSet, sync::Arc};
 
 use agent_k::agents::{GUEST_ATTACHED_DIR, GUEST_SHARED_DIR};
 use ailoy::{
-    agent::{Agent, AgentEvent},
-    message::{FinishReason, Message, MessageOutput, Part, PartDelta, Role},
+    agent::Agent,
+    message::{
+        Delta, FinishReason, Message, MessageDeltaOutput, MessageOutput, Part, PartDelta, Role,
+    },
     runenv::{Sandbox, SandboxConfig},
 };
 use axum::{
@@ -337,6 +339,40 @@ fn classify_senders_from_outputs(
     }
 
     senders
+}
+
+/// Commit one completed [`MessageOutput`] reconstructed from the delta stream:
+/// record depth-0 outputs (clearing the partial buffer once a depth-0 assistant
+/// message commits), then broadcast it as an `AgentMessage` so spectators see
+/// the finalized turn. This is the streaming-era equivalent of the old
+/// `AgentEvent::Message` arm, now that `run_stream` yields only deltas.
+async fn commit_stream_output(
+    state: &AppState,
+    session_id: &Uuid,
+    run_id: Uuid,
+    depth0_outputs: &mut Vec<MessageOutput>,
+    partial_text: &mut String,
+    output: MessageOutput,
+) {
+    if matches!(output.depth, None | Some(0)) {
+        if output.message.role == Role::Assistant {
+            // This turn committed as a real Message; the partial buffer is now
+            // redundant — clear it so the next turn accumulates from empty (and a
+            // later stop doesn't re-persist already-committed text). Also clear
+            // the replayable snapshot so a resume doesn't double it.
+            partial_text.clear();
+            state.set_partial(session_id, String::new()).await;
+        }
+        depth0_outputs.push(output.clone());
+    }
+    if let Some(seq) = state.push_output(session_id, output.clone()).await {
+        let _ = state.ws_tx.send(WsEvent::AgentMessage {
+            session_id: session_id.to_string(),
+            run_id: run_id.to_string(),
+            seq,
+            output,
+        });
+    }
 }
 
 async fn resolve_agent_for(
@@ -1136,6 +1172,12 @@ pub async fn send_message(
         // short before it commits a Message, this is the only copy of the partial
         // answer. Cleared whenever a depth-0 assistant Message commits.
         let mut partial_text = String::new();
+        // `run_stream` now yields only `MessageDeltaOutput`s; we rebuild each
+        // completed `MessageOutput` ourselves by accumulating deltas until a
+        // boundary (a delta carrying `finish_reason`, or a role change), mirroring
+        // ailoy's `into_messages`. This is the running accumulator for the
+        // message currently being streamed.
+        let mut acc = MessageDeltaOutput::new();
         loop {
             let item = if stopped {
                 // Drain mode (entered on cancel). Take only what ailoy has already
@@ -1163,58 +1205,111 @@ pub async fn send_message(
                 }
             };
             match item {
-                // Live text fragment. Broadcast it incrementally (cheap — small
-                // payload even with many subscribers) with the running total so
-                // the client can dedup at the replay↔live boundary. Keep the full
-                // text in `partial_text` for stop-persist and mid-turn resume.
-                // Ephemeral — not persisted, no seq.
-                Some(Ok(AgentEvent::Delta(delta))) => {
-                    let mut fragment = String::new();
-                    for part in &delta.delta.contents {
-                        if let PartDelta::Text { text } = part {
-                            fragment.push_str(text);
+                Some(Ok(delta)) => {
+                    // 1. Live text fragment. Only the assistant's own tokens stream
+                    // as the answer; tool results arrive on this same stream as
+                    // their own role=Tool one-shot delta and must not be shown as
+                    // the assistant's text. Everything else on this stream is
+                    // assistant text, so exclude Tool rather than require Assistant
+                    // — a provider may stream leading text before the role marker,
+                    // leaving both the delta and the accumulator role-less.
+                    let effective_role = delta.delta.role.as_ref().or(acc.delta.role.as_ref());
+                    let is_assistant_text = !matches!(effective_role, Some(Role::Tool));
+                    if is_assistant_text {
+                        let mut fragment = String::new();
+                        for part in &delta.delta.contents {
+                            if let PartDelta::Text { text } = part {
+                                fragment.push_str(text);
+                            }
+                        }
+                        if !fragment.is_empty() {
+                            // Broadcast incrementally (cheap — small payload even with
+                            // many subscribers) with the running total so the client can
+                            // dedup at the replay↔live boundary. Keep the full text in
+                            // `partial_text` for stop-persist and mid-turn resume.
+                            // Ephemeral — not persisted, no seq.
+                            partial_text.push_str(&fragment);
+                            // UTF-16 units so cum_len matches the client's String.length.
+                            let cum_len = partial_text.encode_utf16().count() as u64;
+                            // Keep the resume snapshot exact so a (re)subscribe never
+                            // lands in a hole (cheap: in-process, not per-subscriber).
+                            state2.set_partial(&session_id, partial_text.clone()).await;
+                            let _ = state2.ws_tx.send(WsEvent::AgentDelta {
+                                session_id: session_id.to_string(),
+                                run_id: run_id.to_string(),
+                                delta: fragment,
+                                cum_len,
+                            });
                         }
                     }
-                    if !fragment.is_empty() {
-                        partial_text.push_str(&fragment);
-                        // UTF-16 units so cum_len matches the client's String.length.
-                        let cum_len = partial_text.encode_utf16().count() as u64;
-                        // Keep the resume snapshot exact so a (re)subscribe never
-                        // lands in a hole (cheap: in-process, not per-subscriber).
-                        state2.set_partial(&session_id, partial_text.clone()).await;
-                        let _ = state2.ws_tx.send(WsEvent::AgentDelta {
-                            session_id: session_id.to_string(),
-                            run_id: run_id.to_string(),
-                            delta: fragment,
-                            cum_len,
-                        });
-                    }
-                }
-                // Completed turn: identical to what `run()` used to yield.
-                Some(Ok(AgentEvent::Message(output))) => {
-                    if matches!(output.depth, None | Some(0)) {
-                        if output.message.role == Role::Assistant {
-                            // This turn committed as a real Message; the partial
-                            // buffer is now redundant — clear it so the next turn
-                            // accumulates from empty (and a later stop doesn't
-                            // re-persist already-committed text). Also clear the
-                            // replayable snapshot so a resume doesn't double it.
-                            partial_text.clear();
-                            state2.set_partial(&session_id, String::new()).await;
+
+                    // 2. A role change with no intervening finish_reason is also a
+                    // message boundary (e.g. an assistant turn flowing into a tool
+                    // result). accumulate() rejects a role mismatch, so flush the
+                    // in-progress message first (finalizing it as Stop).
+                    if let (Some(cur), Some(incoming)) = (&acc.delta.role, &delta.delta.role)
+                        && cur != incoming
+                    {
+                        let mut done = std::mem::replace(&mut acc, MessageDeltaOutput::new());
+                        if done.finish_reason.is_none() {
+                            done.finish_reason = Some(FinishReason::Stop {});
                         }
-                        depth0_outputs.push(output.clone());
+                        match done.finish() {
+                            Ok(output) => {
+                                commit_stream_output(
+                                    &state2,
+                                    &session_id,
+                                    run_id,
+                                    &mut depth0_outputs,
+                                    &mut partial_text,
+                                    output,
+                                )
+                                .await;
+                            }
+                            Err(e) => {
+                                run_error = Some(e.to_string());
+                                break;
+                            }
+                        }
                     }
-                    if let Some(seq) = state2.push_output(&session_id, output.clone()).await {
-                        let _ = state2.ws_tx.send(WsEvent::AgentMessage {
-                            session_id: session_id.to_string(),
-                            run_id: run_id.to_string(),
-                            seq,
-                            output,
-                        });
+
+                    // 3. Fold this delta into the running message.
+                    match acc.accumulate(delta) {
+                        Ok(a) => acc = a,
+                        Err(e) => {
+                            run_error = Some(e.to_string());
+                            // Restore a valid `acc` for the post-loop trailing
+                            // flush; it's skipped anyway once `run_error` is set.
+                            acc = MessageDeltaOutput::new();
+                            break;
+                        }
                     }
+
+                    // 4. A delta carrying finish_reason finalizes the message. Commit
+                    // it as a completed MessageOutput (the old `AgentEvent::Message`).
                     // No early break in drain mode: keep taking already-ready items
                     // until the stream ends (`None`) or nothing is buffered
                     // (`now_or_never` → break above), so a finish-line turn commits.
+                    if acc.finish_reason.is_some() {
+                        let done = std::mem::replace(&mut acc, MessageDeltaOutput::new());
+                        match done.finish() {
+                            Ok(output) => {
+                                commit_stream_output(
+                                    &state2,
+                                    &session_id,
+                                    run_id,
+                                    &mut depth0_outputs,
+                                    &mut partial_text,
+                                    output,
+                                )
+                                .await;
+                            }
+                            Err(e) => {
+                                run_error = Some(e.to_string());
+                                break;
+                            }
+                        }
+                    }
                 }
                 Some(Err(e)) => {
                     run_error = Some(e.to_string());
@@ -1224,6 +1319,35 @@ pub async fn send_message(
             }
         }
         drop(run);
+
+        // Provider quirk: some models (e.g. Gemini) end the stream cleanly with no
+        // terminal finish_reason delta, so the final assistant message never hit
+        // the finish_reason boundary in the loop and is still sitting in `acc`. On
+        // a natural completion (not an error, not a user stop) finalize it as Stop
+        // and commit it — mirroring ailoy's own internal fallback and
+        // `into_messages`' trailing flush — so it lands in `depth0_outputs`.
+        // Without this, `attribute_messages` below zips a sender list one short of
+        // `agent`'s history and silently drops the final answer from persistence.
+        // A stopped/errored turn is left to the partial-text path below on purpose.
+        if run_error.is_none() && !stopped && acc.delta.role.is_some() {
+            acc.finish_reason.get_or_insert(FinishReason::Stop {});
+            match acc.finish() {
+                Ok(output) => {
+                    commit_stream_output(
+                        &state2,
+                        &session_id,
+                        run_id,
+                        &mut depth0_outputs,
+                        &mut partial_text,
+                        output,
+                    )
+                    .await;
+                }
+                Err(e) => {
+                    tracing::warn!(%session_id, "failed to finalize trailing stream delta: {e}");
+                }
+            }
+        }
 
         if let Some(err) = run_error {
             if stopped {

--- a/backend/src/handlers/ws.rs
+++ b/backend/src/handlers/ws.rs
@@ -176,7 +176,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, user_id: Uuid) {
                     inbound_sessions.lock().await.insert(session_id);
 
                     // Replay any in-progress run so the spectator catches up.
-                    if let Some((run_id, user_message, outputs)) =
+                    if let Some((run_id, user_message, outputs, partial)) =
                         inbound_state.snapshot(&session_id).await
                     {
                         let started = WsEvent::AgentRunStarted {
@@ -196,6 +196,26 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, user_id: Uuid) {
                                 run_id: run_id.to_string(),
                                 seq,
                                 output,
+                            };
+                            if let Ok(json) = serde_json::to_string(&event) {
+                                if inbound_tx.send(Message::Text(json.into())).await.is_err() {
+                                    break 'inbound;
+                                }
+                            }
+                        }
+
+                        // Resume the in-flight turn: replay the partial-text
+                        // snapshot after the committed messages so the client
+                        // picks up mid-turn instead of waiting for the next live
+                        // delta. Snapshot semantics make this idempotent with the
+                        // live deltas that follow.
+                        if !partial.is_empty() {
+                            let cum_len = partial.encode_utf16().count() as u64;
+                            let event = WsEvent::AgentDelta {
+                                session_id: session_id.to_string(),
+                                run_id: run_id.to_string(),
+                                delta: partial,
+                                cum_len,
                             };
                             if let Ok(json) = serde_json::to_string(&event) {
                                 if inbound_tx.send(Message::Text(json.into())).await.is_err() {

--- a/backend/src/handlers/ws.rs
+++ b/backend/src/handlers/ws.rs
@@ -126,7 +126,15 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, user_id: Uuid) {
                     }
                 }
                 Err(broadcast::error::RecvError::Lagged(n)) => {
-                    tracing::warn!(missed = n, "ws broadcast lagged; spectator may miss events");
+                    // This connection fell behind the shared broadcast ring and
+                    // missed `n` events. Dropped deltas leave a hole the client
+                    // recovers from by refetching the active-run partial, so this
+                    // is a degraded-live-reveal signal, not data loss.
+                    tracing::warn!(
+                        missed = n,
+                        user_id = %broadcast_user_id,
+                        "ws broadcast lagged; client will resync from active-run snapshot"
+                    );
                     continue;
                 }
                 Err(broadcast::error::RecvError::Closed) => break,

--- a/backend/src/handlers/ws.rs
+++ b/backend/src/handlers/ws.rs
@@ -98,6 +98,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, user_id: Uuid) {
                         }
                         WsEvent::AgentRunStarted { session_id, .. }
                         | WsEvent::AgentMessage { session_id, .. }
+                        | WsEvent::AgentDelta { session_id, .. }
                         | WsEvent::AgentError { session_id, .. }
                         | WsEvent::AgentRunDone { session_id, .. } => {
                             match Uuid::parse_str(session_id) {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_stream;
 pub mod auth;
 pub mod cron;
 pub mod error;

--- a/backend/src/model/session.rs
+++ b/backend/src/model/session.rs
@@ -1,9 +1,10 @@
-use ailoy::message::Message;
+use ailoy::message::{Message, MessageOutput};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::events::RunUserMessage;
 use crate::repository::DbSession;
 pub use crate::repository::{SessionOrigin, ShareMode};
 
@@ -91,6 +92,25 @@ pub struct RunAck {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct RunActiveResponse {
     pub active: bool,
+}
+
+/// Snapshot of the in-flight run for a session, used to seed the client on load
+/// so a refresh mid-stream resumes immediately instead of waiting for the WS
+/// replay. Mirrors what the WebSocket replays (started + messages + partial).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ActiveRunOutput {
+    pub seq: u64,
+    pub output: MessageOutput,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ActiveRunSnapshot {
+    pub run_id: String,
+    pub user_message: RunUserMessage,
+    /// Completed depth-0 messages of the in-flight run (not yet persisted to DB).
+    pub outputs: Vec<ActiveRunOutput>,
+    /// Accumulated text of the current streaming turn (empty if none in flight).
+    pub partial: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]

--- a/backend/src/router.rs
+++ b/backend/src/router.rs
@@ -123,6 +123,10 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
             "/sessions/{session_id}/runs/{run_id}/active",
             get(handlers::run_active),
         )
+        .api_route(
+            "/sessions/{session_id}/active-run",
+            get(handlers::get_active_run),
+        )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth_required,

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -103,7 +103,9 @@ impl AppState {
                     .ok()
             })
             .unwrap_or(50 * 1024 * 1024);
-        let (ws_tx, _) = broadcast::channel(128);
+        // One event per streamed token: a fast model enqueues hundreds per turn,
+        // so a small ring lets a slow subscriber lag and drop deltas.
+        let (ws_tx, _) = broadcast::channel(1024);
         Self {
             agents: DashMap::new(),
             active_agent_runs: DashMap::new(),

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -464,13 +464,32 @@ impl AppState {
         self.active_agent_runs.contains_key(session_id)
     }
 
-    /// Removes the active run record for `session_id`.
+    /// Removes the active run record for `session_id`, but only if it still
+    /// belongs to `run_id`.
+    ///
+    /// The `run_id` guard matters because a run releases its agent lock before
+    /// this is called (and a panicking run releases it during unwind, well
+    /// before the monitor task runs cleanup). In that window a newer run can
+    /// acquire the lock and replace this session's entry via [`Self::start_run`].
+    /// A blind `remove(session_id)` would then delete the *newer* run's record,
+    /// orphaning it (no live stream, unstoppable). `remove_if` runs the
+    /// predicate under the shard lock, so the check-and-remove is atomic.
     ///
     /// # Invariant
     /// Must be called exactly once per `start_run`, on both success and error paths.
     /// Failing to call this leaks the in-memory run buffer indefinitely.
-    pub fn end_run(&self, session_id: &Uuid) {
-        self.active_agent_runs.remove(session_id);
+    pub fn end_run(&self, session_id: &Uuid, run_id: Uuid) {
+        // `try_read` is sufficient: only the run's own task ever write-locks the
+        // entry (push_output/set_partial), and it is no longer streaming by the
+        // time it ends its run — so no writer contends here. A newer run holding
+        // its own write lock only fails the predicate, which is the correct
+        // outcome (don't remove someone else's entry).
+        self.active_agent_runs.remove_if(session_id, |_, run_arc| {
+            run_arc
+                .try_read()
+                .map(|run| run.run_id == run_id)
+                .unwrap_or(false)
+        });
     }
 }
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -34,6 +34,10 @@ pub struct ActiveAgentRun {
     pub cancel: CancellationToken,
     pub(crate) next_seq: u64,
     pub(crate) outputs: Vec<(u64, MessageOutput)>,
+    /// Accumulated text of the in-flight (not-yet-committed) assistant turn,
+    /// snapshotted from the stream so a client that (re)subscribes mid-turn can
+    /// resume the partial answer. Cleared when the turn commits as an output.
+    pub(crate) partial: String,
 }
 
 pub struct AppState {
@@ -77,7 +81,8 @@ pub struct AppState {
     /// Cached citation-verification results, keyed by `(project, session, seq)`.
     /// Lets the message-fetch path reuse a check instead of recomputing it each
     /// poll; dropped per project when the corpus changes so it never goes stale.
-    citation_checks: DashMap<(Uuid, Uuid, i64), Arc<Vec<crate::handlers::knowledge::CitationCheck>>>,
+    citation_checks:
+        DashMap<(Uuid, Uuid, i64), Arc<Vec<crate::handlers::knowledge::CitationCheck>>>,
     pub jwt: JwtConfig,
     pub data_root: PathBuf,
     pub max_upload_bytes: usize,
@@ -133,7 +138,10 @@ impl AppState {
 
     /// Whether a knowledge resync is currently in flight for `project_id`.
     pub fn is_indexing(&self, project_id: Uuid) -> bool {
-        self.knowledge_indexing.get(&project_id).map(|n| *n > 0).unwrap_or(false)
+        self.knowledge_indexing
+            .get(&project_id)
+            .map(|n| *n > 0)
+            .unwrap_or(false)
     }
 
     /// Per-project resync lock; the caller holds it across the whole resync.
@@ -161,7 +169,9 @@ impl AppState {
     /// The last knowledge-resync error for `project_id`, if the most recent
     /// resync failed and none has succeeded since.
     pub fn resync_error(&self, project_id: Uuid) -> Option<String> {
-        self.knowledge_resync_error.get(&project_id).map(|e| e.clone())
+        self.knowledge_resync_error
+            .get(&project_id)
+            .map(|e| e.clone())
     }
 
     /// Replace the set of scope-relative paths that failed to index.
@@ -169,7 +179,8 @@ impl AppState {
         if paths.is_empty() {
             self.knowledge_failed_files.remove(&project_id);
         } else {
-            self.knowledge_failed_files.insert(project_id, Arc::new(paths));
+            self.knowledge_failed_files
+                .insert(project_id, Arc::new(paths));
         }
     }
 
@@ -183,7 +194,13 @@ impl AppState {
     /// Cached content id for a knowledge file, valid only if `(mtime, size)`
     /// still match what was cached — otherwise `None` and the caller must
     /// re-hash. Lets the per-file status poll avoid re-reading unchanged files.
-    pub fn cached_file_id(&self, project_id: Uuid, path: &std::path::Path, mtime: SystemTime, size: u64) -> Option<Uuid> {
+    pub fn cached_file_id(
+        &self,
+        project_id: Uuid,
+        path: &std::path::Path,
+        mtime: SystemTime,
+        size: u64,
+    ) -> Option<Uuid> {
         self.knowledge_file_ids
             .get(&(project_id, path.to_path_buf()))
             .and_then(|e| {
@@ -193,7 +210,14 @@ impl AppState {
     }
 
     /// Record a knowledge file's content id alongside its `(mtime, size)`.
-    pub fn cache_file_id(&self, project_id: Uuid, path: &std::path::Path, mtime: SystemTime, size: u64, id: Uuid) {
+    pub fn cache_file_id(
+        &self,
+        project_id: Uuid,
+        path: &std::path::Path,
+        mtime: SystemTime,
+        size: u64,
+        id: Uuid,
+    ) {
         self.knowledge_file_ids
             .insert((project_id, path.to_path_buf()), (mtime, size, id));
     }
@@ -224,7 +248,9 @@ impl AppState {
         session_id: Uuid,
         seq: i64,
     ) -> Option<Arc<Vec<crate::handlers::knowledge::CitationCheck>>> {
-        self.citation_checks.get(&(project_id, session_id, seq)).map(|e| e.clone())
+        self.citation_checks
+            .get(&(project_id, session_id, seq))
+            .map(|e| e.clone())
     }
 
     /// Cache the citation checks for one message.
@@ -318,7 +344,10 @@ impl AppState {
         Ok(self
             .document_stores
             .entry(project_id)
-            .or_insert(StoreEntry { store: shared, last_access: Instant::now() })
+            .or_insert(StoreEntry {
+                store: shared,
+                last_access: Instant::now(),
+            })
             .store
             .clone())
     }
@@ -366,6 +395,7 @@ impl AppState {
             cancel: cancel.clone(),
             next_seq: 0,
             outputs: vec![],
+            partial: String::new(),
         }));
         if self.active_agent_runs.insert(session_id, fresh).is_some() {
             // Caller holds the agent lock, so no real run is executing.
@@ -401,15 +431,31 @@ impl AppState {
         Some(seq)
     }
 
+    /// Update the in-flight turn's accumulated text (for mid-turn resume). Pass
+    /// an empty string to clear it once the turn commits as an output.
+    pub async fn set_partial(&self, session_id: &Uuid, text: String) {
+        let Some(entry) = self.active_agent_runs.get(session_id) else {
+            return;
+        };
+        let run_arc = entry.value().clone();
+        drop(entry);
+        run_arc.write().await.partial = text;
+    }
+
     pub async fn snapshot(
         &self,
         session_id: &Uuid,
-    ) -> Option<(Uuid, RunUserMessage, Vec<(u64, MessageOutput)>)> {
+    ) -> Option<(Uuid, RunUserMessage, Vec<(u64, MessageOutput)>, String)> {
         let entry = self.active_agent_runs.get(session_id)?;
         let run_arc = entry.value().clone();
         drop(entry);
         let run = run_arc.read().await;
-        Some((run.run_id, run.user_message.clone(), run.outputs.clone()))
+        Some((
+            run.run_id,
+            run.user_message.clone(),
+            run.outputs.clone(),
+            run.partial.clone(),
+        ))
     }
 
     pub fn has_active_run(&self, session_id: &Uuid) -> bool {

--- a/backend/tests/session_sandbox_test.rs
+++ b/backend/tests/session_sandbox_test.rs
@@ -427,7 +427,7 @@ async fn stop_run_authz_and_lifecycle() {
         StatusCode::FORBIDDEN,
         "only the sender may stop their run"
     );
-    state.end_run(&session.id);
+    state.end_run(&session.id, other_run_id);
 
     let own_user_msg = RunUserMessage {
         sender_user_id: user_id.to_string(),


### PR DESCRIPTION
## Summary
Agent responses now stream to the client token-by-token instead of
appearing only when each turn completes. Adopts ailoy's(https://github.com/brekkylab/ailoy/pull/434) `run_stream` agentic loop end-to-end: backend forwards token deltas over the existing WebSocket, the client renders them with a smooth typewriter effect, and an in-progress turn survives a page refresh.

## Changes
**Backend**
- Switch the session run loop (and the `run` CLI) from `Agent::run` to `Agent::run_stream`, forwarding `AgentEvent::Delta` as a new ephemeral `WsEvent::AgentDelta` (not persisted, no seq). The `Message` arm keeps the existing persist / broadcast / history logic unchanged.
- Stop now aborts promptly: cancel drops the stream (cancelling the in-flight model request) instead of draining the turn to completion (a regression the old non-streaming grace-wait caused once every token became a sub-grace delta).
- Preserve the partial answer on stop: accumulate streamed text and persist it with the interrupt note via `synthetic_msgs`, so a mid-turn stop survives a refresh and the agent's history stays consistent.
- Send deltas incrementally: `AgentDelta` carries an incremental `delta` + `cum_len` (UTF-16 running total) rather than resending the full text each tick, keeping the wire cheap with many subscribers.
- Resume in-flight streaming: keep the turn's accumulated text in `ActiveAgentRun.partial`; add `GET /sessions/{id}/active-run` returning the in-flight snapshot, and have the WS subscribe-replay send the partial so a reconnecting client catches up.
- Bump ailoy to `2086bfd` so streaming reports token usage.

**Frontend**
- Consume `agent_delta`: apply each incremental fragment and reveal it with a `requestAnimationFrame` typewriter loop (backlog-proportional, ~33fps throttle) so bursty network chunks read as steady typing.
- Resume on mount: seed from the `active-run` HTTP snapshot (idempotent with the WS replay), dedup across the replay↔live boundary via `cum_len` (skip already-applied, trim slice overlap). The resumed backlog is painted instantly; only subsequent tokens animate.
- Reconciled by the completed `agent_message`.
- Don't trap the reader at the bottom while streaming: every token used to force the view back down whenever it was within 700px of the tail, so scrolling up to re-read was yanked straight back (only a hard scroll escaped). Replace the distance heuristic with direction-based follow detection — the auto-scroll only moves scrollTop down and growing content fires no scroll event, so any decrease in scrollTop is a genuine user scroll-up. Stop following on the slightest upward move and re-engage only once back at the very bottom; scroll instantly (not smoothly) while streaming so the per-token animation no longer fights the user.

## Behavior changes
- **Stop** now halts immediately rather than finishing the current turn.
- A stopped turn persists the partial text (+ `[Interrupted: …]`).
- Refreshing mid-stream resumes the in-progress turn instead of losing it.
- Scrolling up during a live stream now holds position instead of being forced back to the bottom; auto-follow resumes once you return to the bottom.

## Testing
- `cargo build` + `tsc`/`lint` clean; existing unit tests pass.
- Manual: long answer streams smoothly; stop halts at once and the partial answer + interrupt note survive a page refresh; refreshing mid-stream resumes the in-progress turn and keeps animating; scrolling up mid-stream stays put and resumes auto-follow at the bottom.
