### PR TITLE
Workspace in browser

### DIFF
--- a/backend/src/router/mod.rs
+++ b/backend/src/router/mod.rs
@@ -103,12 +103,14 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
             "/sessions/{id}/messages/ws",
             axum::routing::get(message::stream_messages),
         )
-        // Two routes: matchit's `{*rest}` wildcard requires one-or-more
-        // segments, so the bare collection path (`/…/files`) needs its
-        // own entry — without it, `PROPFIND` on the workspace root 404s.
-        .route_service("/workspaces/{wid}/files", webdav::router(state.clone()))
+        // WebDAV serves the unified workspace tree (local under `files/`, each
+        // provider mount as a sibling) at `/sources`. Two routes: matchit's
+        // `{*rest}` wildcard needs one-or-more segments, so the bare collection
+        // root (`/…/sources`) needs its own entry — without it, a root
+        // `PROPFIND` 404s.
+        .route_service("/workspaces/{wid}/sources", webdav::router(state.clone()))
         .route_service(
-            "/workspaces/{wid}/files/{*rest}",
+            "/workspaces/{wid}/sources/{*rest}",
             webdav::router(state.clone()),
         )
         .with_state(state)

--- a/backend/src/router/webdav.rs
+++ b/backend/src/router/webdav.rs
@@ -30,15 +30,15 @@ use workspace::{
 };
 
 /// WebDAV workspace router. Mounted by [`super::get_router`] at
-/// `/workspaces/{wid}/files[/…]`; exposes
-/// `data_root/workspaces/{wid}/files` as a per-workspace filesystem.
+/// `/workspaces/{wid}/sources[/…]`; serves the **unified** workspace tree —
+/// local files under `files/`, each provider mount as a sibling — the same view
+/// the guest sees.
 ///
 /// Routes via `fallback` so axum forwards every HTTP method — including
 /// WebDAV-specific ones (`PROPFIND`, `MKCOL`, `COPY`, `MOVE`, `LOCK`, …) —
-/// straight to [`dav_server`]. Auth mirrors the WS route: JWT is read from
-/// `?token=…` because the eventual target audience (browser fetch + native
-/// WebDAV clients) cannot reliably set custom auth headers. The token's subject
-/// must own the workspace.
+/// straight to [`dav_server`]. Authenticated inline (these routes bypass the
+/// `auth_required` layer) from the `Authorization: Bearer` header; the token's
+/// subject must own the workspace.
 pub fn router(state: Arc<AppState>) -> Router {
     Router::new().fallback(handle).with_state(state)
 }
@@ -49,9 +49,16 @@ async fn handle(State(state): State<Arc<AppState>>, req: Request) -> Response<Bo
         None => return (StatusCode::BAD_REQUEST, "invalid workspace id").into_response(),
     };
 
-    let token = req.uri().query().and_then(extract_token);
+    // These routes bypass the `auth_required` layer (registered after them), so
+    // authenticate inline from the `Authorization: Bearer` header.
+    let token = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|t| t.trim().to_string());
     let Some(token) = token else {
-        return (StatusCode::UNAUTHORIZED, "missing token").into_response();
+        return (StatusCode::UNAUTHORIZED, "missing bearer token").into_response();
     };
     let user = match authenticate(&state, &token).await {
         Ok(u) => u,
@@ -83,7 +90,7 @@ async fn handle(State(state): State<Arc<AppState>>, req: Request) -> Response<Bo
     let dav = DavHandler::builder()
         .filesystem(Box::new(DavFs(fs)))
         .locksystem(FakeLs::new())
-        .strip_prefix(format!("/workspaces/{wid}/files"))
+        .strip_prefix(format!("/workspaces/{wid}/sources"))
         .build_handler();
 
     dav.handle(req).await.map(Body::new)
@@ -98,12 +105,6 @@ fn parse_wid(path: &str) -> Option<Uuid> {
     // non-canonical segment (uppercase, or the 32-char no-hyphen form) would
     // authenticate but then 502 on PrefixMismatch. Reject it up front as a 400.
     (wid_str == wid.to_string()).then_some(wid)
-}
-
-fn extract_token(query: &str) -> Option<String> {
-    url::form_urlencoded::parse(query.as_bytes())
-        .find(|(k, _)| k == "token")
-        .map(|(_, v)| v.into_owned())
 }
 
 /// Workspace-relative path (leading `/`) in the shape [`WorkspaceFs`] expects.

--- a/backend/src/state/workspace/mod.rs
+++ b/backend/src/state/workspace/mod.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use ::workspace::{FsConfig, FsEvent, FsHook, WorkspaceFs};
 use chrono::{DateTime, Utc};
@@ -72,11 +73,42 @@ impl Workspace {
 pub struct WorkspacesState {
     db: SqlitePool,
     data_root: PathBuf,
+    /// Per-workspace assembled [`WorkspaceFs`], cached so provider clients and
+    /// their metadata `CachedResource` survive across requests instead of being
+    /// rebuilt each [`Self::get_fs`]. Cloning shares the mounts' `Arc<Resource>`,
+    /// so cache hits reuse the same caches. Evicted on mount change or removal.
+    fs_cache: Mutex<HashMap<Uuid, WorkspaceFs>>,
 }
 
 impl WorkspacesState {
     pub fn new(db: SqlitePool, data_root: PathBuf) -> Self {
-        Self { db, data_root }
+        Self {
+            db,
+            data_root,
+            fs_cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The workspace's assembled [`WorkspaceFs`], built once and cached (see
+    /// [`Self::fs_cache`]). The returned handle shares the cached mounts.
+    async fn fs_for(&self, wid: Uuid) -> StateResult<WorkspaceFs> {
+        if let Some(fs) = self.fs_cache.lock().unwrap().get(&wid).cloned() {
+            return Ok(fs);
+        }
+        // Build outside the lock; a concurrent miss builds twice, first wins.
+        let built = self.build_fs(wid).await?;
+        Ok(self
+            .fs_cache
+            .lock()
+            .unwrap()
+            .entry(wid)
+            .or_insert(built)
+            .clone())
+    }
+
+    /// Evict `wid`'s cached [`WorkspaceFs`] so the next [`Self::get_fs`] rebuilds it.
+    pub(super) fn invalidate_fs(&self, wid: Uuid) {
+        self.fs_cache.lock().unwrap().remove(&wid);
     }
 
     pub async fn get(&self, id: Uuid) -> StateResult<Option<Workspace>> {
@@ -129,6 +161,7 @@ impl WorkspacesState {
     /// are handled by the database's foreign keys.
     pub async fn remove(&self, id: Uuid) -> StateResult<Workspace> {
         let existing = self.get(id).await?.ok_or(StateError::NotFound)?;
+        self.invalidate_fs(id);
         self.remove_files(id).await?;
         sqlx::query("DELETE FROM workspaces WHERE id = ?")
             .bind(id.to_string())
@@ -178,8 +211,8 @@ impl WorkspacesState {
     /// workspace's external-provider mounts attached (paths under a mount prefix
     /// route to the provider; everything else stays local).
     pub async fn get_fs(&self, wid: Uuid) -> StateResult<WorkspaceFs> {
-        // `build_fs` assembles the full mount table (local `/files` + providers).
-        let fs = self.build_fs(wid).await?;
+        // Cached assembly (local `/files` + providers); the hook is per-call.
+        let fs = self.fs_for(wid).await?;
         Ok(fs.with_hook(knowledge_hook(wid)))
     }
 

--- a/backend/src/state/workspace/mount.rs
+++ b/backend/src/state/workspace/mount.rs
@@ -151,6 +151,8 @@ impl WorkspacesState {
         .execute(&self.db)
         .await
         .map_err(map_mount_sqlx_error)?;
+        // Mounts changed → rebuild the fs on next access.
+        self.invalidate_fs(mount.workspace_id);
         Ok(mount)
     }
 
@@ -161,6 +163,7 @@ impl WorkspacesState {
             .bind(id.to_string())
             .execute(&self.db)
             .await?;
+        self.invalidate_fs(existing.workspace_id);
         Ok(existing)
     }
 
@@ -344,5 +347,31 @@ mod tests {
             state.create_mount(reserved).await,
             Err(StateError::InvalidData(_))
         ));
+    }
+
+    /// A mount create/remove must evict the cached `WorkspaceFs` so the next
+    /// `get_fs` reflects the change (a stale cache would keep listing a removed
+    /// mount). Checked via the root mount-name list (no network).
+    #[tokio::test]
+    async fn get_fs_reflects_mount_changes() {
+        let (state, _tmp, wid) = fresh_state().await;
+
+        let created = state
+            .create_mount(WorkspaceMount::new(wid, "s3-prod".into(), s3_provider()))
+            .await
+            .unwrap();
+        let fs = state.get_fs(wid).await.unwrap();
+        assert!(
+            fs.mount_names().iter().any(|n| n == "s3-prod"),
+            "mount should appear after create"
+        );
+
+        // Removing must evict the cache, or get_fs still lists it.
+        state.remove_mount(created.id).await.unwrap();
+        let fs = state.get_fs(wid).await.unwrap();
+        assert!(
+            !fs.mount_names().iter().any(|n| n == "s3-prod"),
+            "mount must be gone after remove (cache invalidated)"
+        );
     }
 }

--- a/workspace/src/fs.rs
+++ b/workspace/src/fs.rs
@@ -198,6 +198,9 @@ pub struct File {
     resource: Arc<dyn Resource>,
     path: MountPath,
     offset: u64,
+    /// Provider stat captured when the file opened; pins the version so every
+    /// chunk of one read comes from a single snapshot (no per-chunk stat).
+    stat: FileStat,
     /// Whether this handle was opened for writing (gates `write_*`/`flush`).
     write: bool,
     /// Accumulated write buffer, flushed as the whole object.
@@ -247,7 +250,7 @@ impl File {
         let end = self.offset.saturating_add(count as u64);
         let data = self
             .resource
-            .read_bytes(&self.path, Some(self.offset..end))
+            .read_bytes_pinned(&self.path, Some(self.offset..end), &self.stat)
             .await
             .map_err(FsError::from)?;
         self.offset = self.offset.saturating_add(data.len() as u64);
@@ -258,16 +261,8 @@ impl File {
         let new = match pos {
             SeekFrom::Start(n) => n,
             SeekFrom::Current(d) => (self.offset as i64 + d).max(0) as u64,
-            // Seeking from the end needs the object size; one stat serves it.
-            SeekFrom::End(d) => {
-                let size = self
-                    .resource
-                    .stat(&self.path)
-                    .await
-                    .map_err(FsError::from)?
-                    .size;
-                (size as i64 + d).max(0) as u64
-            }
+            // Size is pinned at open, so seeking from the end needs no stat.
+            SeekFrom::End(d) => (self.stat.size as i64 + d).max(0) as u64,
         };
         self.offset = new;
         Ok(new)
@@ -443,6 +438,9 @@ impl WorkspaceFs {
         // create_new guard) and the read-open directory/existence check.
         let stat = resource.stat(&vpath).await;
         let existed = stat.is_ok();
+        // Pin the open-time snapshot so every chunk of a read validates against
+        // one version (no per-chunk stat); default for a not-yet-created file.
+        let pinned = stat.as_ref().ok().cloned().unwrap_or_default();
         if options.create_new && existed {
             return Err(FsError::Exists);
         }
@@ -474,6 +472,7 @@ impl WorkspaceFs {
             resource,
             path: vpath,
             offset: 0,
+            stat: pinned,
             write: is_write,
             wbuf,
             observer,
@@ -788,6 +787,7 @@ mod tests {
                     atime: None,
                     ctime: None,
                     created: None,
+                    etag: None,
                 }])
             } else {
                 Err(ResourceError::NotFound)

--- a/workspace/src/vfs/cache.rs
+++ b/workspace/src/vfs/cache.rs
@@ -5,7 +5,7 @@
 //! [`Resource`] so both FUSE frontends benefit transparently.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     ops::Range,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -19,10 +19,11 @@ use crate::vfs::{
     resource::{DirEntry, FileKind, FileStat, Resource},
 };
 
-/// Default listing TTL (600s).
-const DEFAULT_TTL: Duration = Duration::from_secs(600);
+/// Directory-listing TTL. Listings have no cheap version to revalidate against
+/// (unlike file content), so they fall back to a short expiry.
+const LISTING_TTL: Duration = Duration::from_secs(300);
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct Entry {
     is_dir: bool,
     size: u64,
@@ -32,6 +33,9 @@ struct Entry {
     mtime: Option<std::time::SystemTime>,
     atime: Option<std::time::SystemTime>,
     ctime: Option<std::time::SystemTime>,
+    /// Strong version tag (S3 `ETag`) carried from the listing, so the stat
+    /// fast-path can hand `open` a pin-able snapshot (`If-Match`).
+    etag: Option<String>,
 }
 
 #[derive(Default)]
@@ -71,7 +75,7 @@ impl IndexCache {
             inner.entries.remove(path);
             return None;
         }
-        inner.entries.get(path).copied()
+        inner.entries.get(path).cloned()
     }
 
     /// Whether `path`'s listing is present and unexpired (basis for negative
@@ -106,6 +110,7 @@ impl IndexCache {
                     atime: e.atime,
                     ctime: e.ctime,
                     created: None,
+                    etag: e.etag.clone(),
                 })
             })
             .collect();
@@ -150,6 +155,7 @@ impl IndexCache {
                     mtime: e.mtime,
                     atime: e.atime,
                     ctime: e.ctime,
+                    etag: e.etag.clone(),
                 },
             );
         }
@@ -180,20 +186,211 @@ impl IndexCache {
     }
 }
 
-/// Wraps a provider [`Resource`] with an [`IndexCache`]: `readdir` fills the
-/// cache, `stat` serves from it (and negative-caches misses), mutations
-/// invalidate. Read/write payloads are delegated unchanged.
+/// Full object bytes cached above this size are dropped — a ranged read of a
+/// known-large object is served ranged and uncached instead (8 MiB).
+const MAX_CONTENT_BYTES: u64 = 8 << 20;
+
+/// A cheap validator for a file's content: the backend's strong tag
+/// (S3 `ETag`/`VersionId`) if any, else its mtime (Notion `last_edited_time`).
+/// `Unknown` = nothing to validate against, so content is never cache-served.
+#[derive(Clone, PartialEq)]
+enum Version {
+    Tag(String),
+    Time(std::time::SystemTime),
+    Unknown,
+}
+
+impl Version {
+    fn of(s: &FileStat) -> Self {
+        if let Some(e) = &s.etag {
+            Version::Tag(e.clone())
+        } else if let Some(v) = &s.version {
+            Version::Tag(v.clone())
+        } else if let Some(t) = s.mtime {
+            Version::Time(t)
+        } else {
+            Version::Unknown
+        }
+    }
+    fn known(&self) -> bool {
+        !matches!(self, Version::Unknown)
+    }
+}
+
+/// Per-provider content-cache budget; over it, LRU-evict. Lossless — every read
+/// revalidates, so a dropped entry just refetches.
+const CONTENT_CACHE_BUDGET: u64 = 128 << 20;
+
+/// Staleness backstop: Notion's minute-granular `last_edited_time` can miss a
+/// same-minute edit, so a time-versioned entry refetches past this age.
+const CONTENT_TTL: Duration = Duration::from_secs(300);
+
+/// One cached object plus its LRU tick.
+struct CacheEntry {
+    version: Version,
+    bytes: Arc<Vec<u8>>,
+    seq: u64,
+    fetched: Instant,
+}
+
+/// Content cache, LRU-bounded by total bytes. `order` (tick → path) keeps the
+/// least-recently-used entry as its first key.
+#[derive(Default)]
+struct ContentCache {
+    by_path: HashMap<String, CacheEntry>,
+    order: BTreeMap<u64, String>,
+    total: u64,
+    tick: u64,
+}
+
+impl ContentCache {
+    /// Mark `key` most-recently-used and return its bytes (caller ensured it exists).
+    fn bump(&mut self, key: &str) -> Arc<Vec<u8>> {
+        self.tick += 1;
+        let seq = self.tick;
+        let e = self.by_path.get_mut(key).expect("bump: entry present");
+        let old = e.seq;
+        e.seq = seq;
+        let bytes = e.bytes.clone();
+        self.order.remove(&old);
+        self.order.insert(seq, key.to_string());
+        bytes
+    }
+
+    /// Bytes for `key` iff its stored validator matches `version` (LRU-touched).
+    fn get(&mut self, key: &str, version: &Version) -> Option<Arc<Vec<u8>>> {
+        let hit = match self.by_path.get(key) {
+            // A time-based version (Notion's minute-granular `last_edited_time`)
+            // can miss a same-minute edit, so expire it past CONTENT_TTL; a strong
+            // tag (S3 ETag) is exact and needs no backstop.
+            Some(e) if &e.version == version => {
+                !matches!(version, Version::Time(_)) || e.fetched.elapsed() < CONTENT_TTL
+            }
+            _ => false,
+        };
+        hit.then(|| self.bump(key))
+    }
+
+    /// Insert `key`, then evict least-recently-used entries until within `budget`.
+    fn put(&mut self, key: &str, version: Version, bytes: Vec<u8>, budget: u64) {
+        self.remove(key);
+        self.tick += 1;
+        let seq = self.tick;
+        self.total += bytes.len() as u64;
+        self.order.insert(seq, key.to_string());
+        self.by_path.insert(
+            key.to_string(),
+            CacheEntry {
+                version,
+                bytes: Arc::new(bytes),
+                seq,
+                fetched: Instant::now(),
+            },
+        );
+        while self.total > budget {
+            let Some(victim) = self.order.values().next().cloned() else {
+                break;
+            };
+            if victim == key {
+                break; // never evict the just-inserted (MRU) entry
+            }
+            self.remove(&victim);
+        }
+    }
+
+    /// Remove `key`'s entry if present, updating the byte total.
+    fn remove(&mut self, key: &str) {
+        if let Some(e) = self.by_path.remove(key) {
+            self.order.remove(&e.seq);
+            self.total -= e.bytes.len() as u64;
+        }
+    }
+}
+
+/// Wraps a provider [`Resource`] with an [`IndexCache`] for listings (short TTL)
+/// plus a **validated** content cache: a read probes the object's cheap version
+/// via `stat` and serves cached bytes only while it matches, so external edits
+/// are refetched without a TTL wait. Mutations invalidate both.
 pub struct CachedResource {
     inner: Arc<dyn Resource>,
     cache: IndexCache,
+    /// Whole-object content, LRU-bounded ([`CONTENT_CACHE_BUDGET`]); freshness by
+    /// revalidation, not a TTL.
+    content: Mutex<ContentCache>,
 }
 
 impl CachedResource {
     pub fn new(inner: Arc<dyn Resource>) -> Self {
         Self {
             inner,
-            cache: IndexCache::new(DEFAULT_TTL),
+            cache: IndexCache::new(LISTING_TTL),
+            content: Mutex::new(ContentCache::default()),
         }
+    }
+
+    /// Cached bytes for `key` iff the stored validator equals `version` (and is
+    /// known) — the metadata dirty check; a changed backend version misses.
+    fn content_get(&self, key: &str, version: &Version) -> Option<Arc<Vec<u8>>> {
+        if !version.known() {
+            return None;
+        }
+        self.content.lock().unwrap().get(key, version)
+    }
+
+    fn content_put(&self, key: &str, version: Version, bytes: Vec<u8>) {
+        if version.known() && bytes.len() as u64 <= MAX_CONTENT_BYTES {
+            self.content
+                .lock()
+                .unwrap()
+                .put(key, version, bytes, CONTENT_CACHE_BUDGET);
+        }
+    }
+
+    fn content_drop(&self, key: &str) {
+        self.content.lock().unwrap().remove(key);
+    }
+
+    fn content_clear(&self) {
+        *self.content.lock().unwrap() = ContentCache::default();
+    }
+
+    /// True length of a file the backend listed as size 0 (sizing it needs a
+    /// render, e.g. Notion `page.json`): render once *through the content cache*
+    /// so the size is known and a following read is a hit. Cheap on a cache hit;
+    /// 0 if the render fails.
+    async fn resolve_size(&self, path: &MountPath, version: &Version) -> u64 {
+        if let Some(bytes) = self.content_get(path.as_str(), version) {
+            return bytes.len() as u64;
+        }
+        match self.inner.read_bytes(path, None).await {
+            Ok(bytes) => {
+                let n = bytes.len() as u64;
+                self.content_put(path.as_str(), version.clone(), bytes);
+                n
+            }
+            Err(_) => 0,
+        }
+    }
+}
+
+/// A child path under `dir` (handles the root so the result has no `//`).
+fn child_path(dir: &MountPath, name: &str) -> MountPath {
+    if dir.is_root() {
+        MountPath::new(format!("/{name}"))
+    } else {
+        MountPath::new(format!("{}/{}", dir.as_str(), name))
+    }
+}
+
+/// Slice `data` by an optional byte range (clamped to bounds); `None` = all.
+fn slice(data: &[u8], range: &Option<Range<u64>>) -> Vec<u8> {
+    match range {
+        Some(r) => {
+            let start = (r.start as usize).min(data.len());
+            let end = (r.end as usize).min(data.len()).max(start);
+            data[start..end].to_vec()
+        }
+        None => data.to_vec(),
     }
 }
 
@@ -204,13 +401,62 @@ impl Resource for CachedResource {
         path: &MountPath,
         range: Option<Range<u64>>,
     ) -> ResourceResult<Vec<u8>> {
-        self.inner.read_bytes(path, range).await
+        let key = path.as_str();
+        // Validate the cheap version and serve cached bytes only while it matches.
+        let st = self.inner.stat(path).await?;
+        let version = Version::of(&st);
+        if let Some(full) = self.content_get(key, &version) {
+            return Ok(slice(&full, &range));
+        }
+        // Miss: fetch + cache the whole object, unless it's a known-large object
+        // read with a range (served ranged, uncached). Providers that render the
+        // whole file regardless of range report size 0, so they still cache whole.
+        let fetch_full = range.is_none() || st.size == 0 || st.size <= MAX_CONTENT_BYTES;
+        if fetch_full {
+            let full = self.inner.read_bytes(path, None).await?;
+            let out = slice(&full, &range);
+            self.content_put(key, version, full);
+            Ok(out)
+        } else {
+            self.inner.read_bytes(path, range).await
+        }
+    }
+
+    async fn read_bytes_pinned(
+        &self,
+        path: &MountPath,
+        range: Option<Range<u64>>,
+        stat: &FileStat,
+    ) -> ResourceResult<Vec<u8>> {
+        let key = path.as_str();
+        // Validate against the version pinned when the read opened — no per-chunk
+        // stat — so every chunk of one read comes from a single snapshot.
+        let version = Version::of(stat);
+        if let Some(full) = self.content_get(key, &version) {
+            return Ok(slice(&full, &range));
+        }
+        let fetch_full = range.is_none() || stat.size == 0 || stat.size <= MAX_CONTENT_BYTES;
+        if fetch_full {
+            // Fetch pinned, not plain: on S3 this sends `If-Match(etag)`, so a
+            // miss whose cached snapshot was evicted/replaced can't return newer
+            // bytes under the old pin (which would tear an interleaved read and
+            // mislabel the cache entry). A successful fetch matches the pin.
+            let full = self.inner.read_bytes_pinned(path, None, stat).await?;
+            let out = slice(&full, &range);
+            self.content_put(key, version, full);
+            Ok(out)
+        } else {
+            // Large uncached object: read the range pinned to `stat` — S3 sends
+            // `If-Match(etag)` so a mid-stream change fails instead of tearing.
+            self.inner.read_bytes_pinned(path, range, stat).await
+        }
     }
 
     async fn write_bytes(&self, path: &MountPath, data: Vec<u8>) -> ResourceResult<()> {
         let r = self.inner.write_bytes(path, data).await;
         if r.is_ok() {
             self.cache.invalidate_parent(path.as_str());
+            self.content_drop(path.as_str());
         }
         r
     }
@@ -219,7 +465,23 @@ impl Resource for CachedResource {
         if let Some(entries) = self.cache.list_dir_entries(path.as_str()) {
             return Ok(entries);
         }
-        let entries = self.inner.readdir(path).await?;
+        let mut entries = self.inner.readdir(path).await?;
+        // Eagerly size (and content-cache) files the backend listed as 0 because
+        // sizing needs a render (Notion page.json): render once here so the entry
+        // shows a real size AND a following read is a cache hit. This adds that
+        // render to the listing's latency — the trade for correct sizes up front.
+        for e in entries.iter_mut() {
+            if matches!(e.kind, FileKind::File) && e.size == 0 {
+                let child = child_path(path, &e.name);
+                // Take the version from the provider's own stat, not the listing
+                // DirEntry (which may omit mtime, e.g. Notion `page.json`): the
+                // content cached here must be validated against the same token a
+                // later read computes, or the read misses and re-renders.
+                if let Ok(st) = self.inner.stat(&child).await {
+                    e.size = self.resolve_size(&child, &Version::of(&st)).await;
+                }
+            }
+        }
         self.cache.set_dir(path.as_str(), &entries);
         Ok(entries)
     }
@@ -245,14 +507,17 @@ impl Resource for CachedResource {
                     mtime: e.mtime,
                     atime: e.atime,
                     ctime: e.ctime,
+                    // Keep the strong tag so a read opened off this cached stat
+                    // can pin itself to the ETag (`If-Match`); dropping it here
+                    // silently disabled the pin on the PROPFIND-then-GET path.
+                    etag: e.etag.clone(),
                     ..Default::default()
                 });
             }
-            // A file with size 0 is ambiguous: providers report 0 for sizes
-            // they don't cheaply know (rendered Notion page.json, exported
-            // Google docs). Don't trust it — compute via the provider so reads
-            // aren't clamped to nothing. (A genuinely empty file just re-stats.)
-            Some(_) => return self.inner.stat(path).await,
+            // A file cached with size 0 is ambiguous (providers report 0 for
+            // sizes they don't cheaply know): resolve it below rather than trust
+            // it, so reads/Content-Length aren't clamped to nothing.
+            Some(_) => {}
             None => {
                 // Negative cache: a fresh parent listing that lacks this path
                 // proves it does not exist — skip the network probe.
@@ -261,7 +526,16 @@ impl Resource for CachedResource {
                 }
             }
         }
-        self.inner.stat(path).await
+        let st = self.inner.stat(path).await?;
+        // A file the backend can't cheaply size (render-on-read, e.g. Notion
+        // page.json) reports 0 — resolve its real length via the content cache so
+        // stat/HEAD/PROPFIND are correct and a following read is a hit.
+        if matches!(st.kind, FileKind::File) && st.size == 0 {
+            let version = Version::of(&st);
+            let size = self.resolve_size(path, &version).await;
+            return Ok(FileStat { size, ..st });
+        }
+        Ok(st)
     }
 
     async fn unlink(&self, path: &MountPath) -> ResourceResult<()> {
@@ -270,6 +544,7 @@ impl Resource for CachedResource {
             // The path itself may have been a directory; drop its listing too.
             self.cache.invalidate_dir(path.as_str());
             self.cache.invalidate_parent(path.as_str());
+            self.content_drop(path.as_str());
         }
         r
     }
@@ -297,16 +572,19 @@ impl Resource for CachedResource {
             self.cache.invalidate_dir(from.as_str());
             self.cache.invalidate_parent(from.as_str());
             self.cache.invalidate_parent(to.as_str());
+            self.content_drop(from.as_str());
+            self.content_drop(to.as_str());
         }
         r
     }
 
     async fn command(&self, name: &str, body: &[u8]) -> ResourceResult<Vec<u8>> {
         let r = self.inner.command(name, body).await;
-        // A domain write (e.g. Notion page-create) may change listings anywhere
-        // in the mount; conservatively drop the whole index.
+        // A domain write (e.g. Notion page-create) may change listings and
+        // content anywhere in the mount; conservatively drop both caches.
         if r.is_ok() {
             self.cache.clear();
+            self.content_clear();
         }
         r
     }
@@ -346,6 +624,216 @@ fn purge_prefix(inner: &mut Inner, p: &str) {
 mod tests {
     use super::*;
 
+    // A pinned read stays on one snapshot for its whole duration, and a fresh
+    // ranged read never serves stale cached bytes after an external edit.
+    #[tokio::test]
+    async fn pinned_read_is_one_snapshot_and_never_stale() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{Duration as D, UNIX_EPOCH};
+
+        struct Obj {
+            ver: AtomicU64,
+            data: Mutex<Vec<u8>>,
+        }
+        #[async_trait]
+        impl Resource for Obj {
+            async fn read_bytes(&self, _p: &MountPath, range: Option<Range<u64>>) -> ResourceResult<Vec<u8>> {
+                Ok(slice(self.data.lock().unwrap().as_slice(), &range))
+            }
+            async fn write_bytes(&self, _p: &MountPath, _d: Vec<u8>) -> ResourceResult<()> {
+                Ok(())
+            }
+            async fn readdir(&self, _p: &MountPath) -> ResourceResult<Vec<DirEntry>> {
+                Ok(vec![])
+            }
+            async fn stat(&self, _p: &MountPath) -> ResourceResult<FileStat> {
+                // Size 0 (validated by mtime) — like a render-on-read provider.
+                Ok(FileStat {
+                    kind: FileKind::File,
+                    mtime: Some(UNIX_EPOCH + D::from_secs(self.ver.load(Ordering::SeqCst))),
+                    ..Default::default()
+                })
+            }
+        }
+
+        let obj = Arc::new(Obj {
+            ver: AtomicU64::new(1),
+            data: Mutex::new(b"hello world".to_vec()),
+        });
+        let cached = CachedResource::new(obj.clone());
+        let p = MountPath::new("/f.txt");
+
+        // Read opens by stat'ing (v1); the first chunk caches that snapshot.
+        let s1 = obj.stat(&p).await.unwrap();
+        assert_eq!(cached.read_bytes_pinned(&p, Some(0..5), &s1).await.unwrap(), b"hello");
+
+        // The object is edited behind the cache.
+        *obj.data.lock().unwrap() = b"EDITED text".to_vec();
+        obj.ver.store(2, Ordering::SeqCst);
+
+        // A continuation chunk of the SAME read (pinned to v1) stays on v1 — no
+        // torn response.
+        assert_eq!(cached.read_bytes_pinned(&p, Some(6..11), &s1).await.unwrap(), b"world");
+
+        // A fresh read stats again (v2); its ranged request must NOT serve the
+        // stale v1 bytes.
+        let s2 = obj.stat(&p).await.unwrap();
+        assert_eq!(cached.read_bytes_pinned(&p, Some(6..11), &s2).await.unwrap(), b" text");
+    }
+
+    // A's pinned snapshot can be evicted/replaced by B's fresh read before A's
+    // continuation chunk. On an etag backend (If-Match) the stale-pin refetch
+    // must fail cleanly rather than return B's newer bytes under A's pin. (A
+    // Time-only backend has no conditional GET, so this guarantee is etag-only.)
+    #[tokio::test]
+    async fn pinned_read_interleaved_with_refetch() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        struct Obj {
+            ver: AtomicU64,
+            data: Mutex<Vec<u8>>,
+        }
+        impl Obj {
+            fn etag(&self) -> String {
+                format!("\"v{}\"", self.ver.load(Ordering::SeqCst))
+            }
+        }
+        #[async_trait]
+        impl Resource for Obj {
+            async fn read_bytes(
+                &self,
+                _p: &MountPath,
+                range: Option<Range<u64>>,
+            ) -> ResourceResult<Vec<u8>> {
+                Ok(slice(self.data.lock().unwrap().as_slice(), &range))
+            }
+            async fn read_bytes_pinned(
+                &self,
+                p: &MountPath,
+                range: Option<Range<u64>>,
+                stat: &FileStat,
+            ) -> ResourceResult<Vec<u8>> {
+                // If-Match: a pin whose etag no longer matches current fails.
+                if stat.etag.as_deref() != Some(self.etag().as_str()) {
+                    return Err(ResourceError::Backend(anyhow::anyhow!(
+                        "precondition failed"
+                    )));
+                }
+                self.read_bytes(p, range).await
+            }
+            async fn write_bytes(&self, _p: &MountPath, _d: Vec<u8>) -> ResourceResult<()> {
+                Ok(())
+            }
+            async fn readdir(&self, _p: &MountPath) -> ResourceResult<Vec<DirEntry>> {
+                Ok(vec![])
+            }
+            async fn stat(&self, _p: &MountPath) -> ResourceResult<FileStat> {
+                Ok(FileStat {
+                    kind: FileKind::File,
+                    size: 11,
+                    etag: Some(self.etag()),
+                    ..Default::default()
+                })
+            }
+        }
+
+        let obj = Arc::new(Obj {
+            ver: AtomicU64::new(1),
+            data: Mutex::new(b"hello world".to_vec()),
+        });
+        let cached = CachedResource::new(obj.clone());
+        let p = MountPath::new("/f.txt");
+
+        // A opens (pins v1) and reads its first chunk.
+        let s1 = obj.stat(&p).await.unwrap();
+        assert_eq!(cached.read_bytes_pinned(&p, Some(0..5), &s1).await.unwrap(), b"hello");
+
+        // External edit -> v2.
+        *obj.data.lock().unwrap() = b"EDITED text".to_vec();
+        obj.ver.store(2, Ordering::SeqCst);
+
+        // B opens fresh (pins v2); its read refetches and replaces the cache
+        // entry with v2 bytes.
+        let s2 = obj.stat(&p).await.unwrap();
+        assert_eq!(cached.read_bytes_pinned(&p, Some(0..5), &s2).await.unwrap(), b"EDITE");
+
+        // A's continuation, still pinned to v1: cache holds v2 now, so it misses
+        // and refetches under If-Match(v1) -> clean error, not a torn v2 read.
+        let a2 = cached.read_bytes_pinned(&p, Some(6..11), &s1).await;
+        assert!(a2.is_err(), "stale v1 pin must fail cleanly, not tear: {a2:?}");
+    }
+
+    // A stat served from the metadata cache (primed by readdir, i.e. the
+    // PROPFIND-then-GET flow) must keep the provider's etag — that is the token
+    // the pinned S3 read sends as If-Match.
+    #[tokio::test]
+    async fn cached_stat_preserves_etag_for_pinning() {
+        struct S3Like;
+        #[async_trait]
+        impl Resource for S3Like {
+            async fn read_bytes(
+                &self,
+                _p: &MountPath,
+                range: Option<Range<u64>>,
+            ) -> ResourceResult<Vec<u8>> {
+                Ok(slice(b"0123456789", &range))
+            }
+            async fn write_bytes(&self, _p: &MountPath, _d: Vec<u8>) -> ResourceResult<()> {
+                Ok(())
+            }
+            async fn readdir(&self, _p: &MountPath) -> ResourceResult<Vec<DirEntry>> {
+                Ok(vec![DirEntry {
+                    name: "f.bin".into(),
+                    kind: FileKind::File,
+                    size: 10,
+                    mtime: Some(std::time::UNIX_EPOCH),
+                    atime: None,
+                    ctime: None,
+                    created: None,
+                    etag: Some("\"abc123\"".into()),
+                }])
+            }
+            async fn stat(&self, _p: &MountPath) -> ResourceResult<FileStat> {
+                Ok(FileStat {
+                    kind: FileKind::File,
+                    size: 10,
+                    mtime: Some(std::time::UNIX_EPOCH),
+                    etag: Some("\"abc123\"".into()),
+                    ..Default::default()
+                })
+            }
+        }
+
+        let cached = CachedResource::new(Arc::new(S3Like));
+        // PROPFIND primes the metadata cache ...
+        cached.readdir(&MountPath::new("/")).await.unwrap();
+        // ... then GET opens the file; WorkspaceFs::open pins this stat.
+        let pinned = cached.stat(&MountPath::new("/f.bin")).await.unwrap();
+        assert_eq!(
+            pinned.etag.as_deref(),
+            Some("\"abc123\""),
+            "etag dropped by the cache fast-path: If-Match pin is disabled"
+        );
+    }
+
+    // The content cache evicts by total-byte budget, least-recently-used first,
+    // and never drops the entry just inserted.
+    #[test]
+    fn content_cache_evicts_lru_over_budget() {
+        let v = Version::Time(std::time::UNIX_EPOCH);
+        let mut c = ContentCache::default();
+        c.put("/a", v.clone(), vec![0u8; 4], 10);
+        c.put("/b", v.clone(), vec![0u8; 4], 10);
+        // Touch /a so /b is now the least-recently-used.
+        assert!(c.get("/a", &v).is_some());
+        // total would be 12 > 10 → evict the LRU (/b), keep the touched /a + new /c.
+        c.put("/c", v.clone(), vec![0u8; 4], 10);
+        assert!(c.get("/a", &v).is_some(), "recently used, kept");
+        assert!(c.get("/c", &v).is_some(), "just inserted, kept");
+        assert!(c.get("/b", &v).is_none(), "least-recently-used, evicted");
+        assert!(c.total <= 10, "within budget");
+    }
+
     fn de(name: &str, kind: FileKind, size: u64) -> DirEntry {
         DirEntry {
             name: name.to_string(),
@@ -355,6 +843,7 @@ mod tests {
             atime: None,
             ctime: None,
             created: None,
+            etag: None,
         }
     }
 
@@ -415,6 +904,7 @@ mod tests {
                 atime: None,
                 ctime: None,
                 created: None,
+                etag: None,
             }],
         );
         // fast-path source: get() returns the stored mtime (not None/epoch).
@@ -461,5 +951,86 @@ mod tests {
         c.set_dir("/a/b/sub", &[de("d.txt", FileKind::File, 7)]);
         c.invalidate_dir("/a/b");
         assert!(c.get("/a/b/sub/d.txt").is_none());
+    }
+
+    // Validated content cache: repeat reads (incl. ranged) hit the once-fetched
+    // object; a changed backend version forces a refetch; a write invalidates.
+    // The counting provider proves `read_bytes` fires only on a genuine miss.
+    #[tokio::test]
+    async fn content_cache_validates_and_invalidates() {
+        use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+        use std::time::{Duration as D, UNIX_EPOCH};
+
+        struct Counter {
+            reads: AtomicUsize,
+            /// Backend version → `stat` mtime; bumping it simulates an edit made
+            /// outside the cache.
+            ver: AtomicU64,
+            data: Mutex<Vec<u8>>,
+        }
+        #[async_trait]
+        impl Resource for Counter {
+            async fn read_bytes(
+                &self,
+                _p: &MountPath,
+                range: Option<Range<u64>>,
+            ) -> ResourceResult<Vec<u8>> {
+                self.reads.fetch_add(1, Ordering::SeqCst);
+                Ok(slice(self.data.lock().unwrap().as_slice(), &range))
+            }
+            async fn write_bytes(&self, _p: &MountPath, data: Vec<u8>) -> ResourceResult<()> {
+                *self.data.lock().unwrap() = data;
+                Ok(())
+            }
+            async fn readdir(&self, _p: &MountPath) -> ResourceResult<Vec<DirEntry>> {
+                Ok(vec![])
+            }
+            async fn stat(&self, _p: &MountPath) -> ResourceResult<FileStat> {
+                // Size unknown (0), like Notion — validated by mtime instead.
+                Ok(FileStat {
+                    kind: FileKind::File,
+                    size: 0,
+                    mtime: Some(UNIX_EPOCH + D::from_secs(self.ver.load(Ordering::SeqCst))),
+                    ..Default::default()
+                })
+            }
+        }
+
+        let counter = Arc::new(Counter {
+            reads: AtomicUsize::new(0),
+            ver: AtomicU64::new(1),
+            data: Mutex::new(b"hello world".to_vec()),
+        });
+        let cached = CachedResource::new(counter.clone());
+        let p = MountPath::new("/f.txt");
+
+        // First read fetches + caches (validated by version 1).
+        assert_eq!(cached.read_bytes(&p, None).await.unwrap(), b"hello world");
+        // Ranged repeat at the same version → served from cache, inner not hit.
+        assert_eq!(cached.read_bytes(&p, Some(0..5)).await.unwrap(), b"hello");
+        assert_eq!(
+            counter.reads.load(Ordering::SeqCst),
+            1,
+            "same version → cache hit"
+        );
+
+        // External edit: change bytes + bump the version WITHOUT going through
+        // the cache. The dirty check must notice and refetch.
+        *counter.data.lock().unwrap() = b"edited elsewhere".to_vec();
+        counter.ver.store(2, Ordering::SeqCst);
+        assert_eq!(
+            cached.read_bytes(&p, None).await.unwrap(),
+            b"edited elsewhere"
+        );
+        assert_eq!(
+            counter.reads.load(Ordering::SeqCst),
+            2,
+            "changed version → refetch"
+        );
+
+        // A write through the cache invalidates the entry too.
+        cached.write_bytes(&p, b"written".to_vec()).await.unwrap();
+        assert_eq!(cached.read_bytes(&p, None).await.unwrap(), b"written");
+        assert_eq!(counter.reads.load(Ordering::SeqCst), 3, "write invalidates");
     }
 }

--- a/workspace/src/vfs/resource/base.rs
+++ b/workspace/src/vfs/resource/base.rs
@@ -29,6 +29,10 @@ pub struct DirEntry {
     /// Birth/creation time per entry, if the backend reports one (local files);
     /// `None` for providers that don't distinguish a birth time.
     pub created: Option<std::time::SystemTime>,
+    /// Strong version tag from the listing (S3 `ETag`), if the backend reports
+    /// one. Carried so the stat fast-path can pin a read to it (`If-Match`)
+    /// instead of validating by the coarser mtime.
+    pub etag: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -66,6 +70,18 @@ pub trait Resource: Send + Sync {
         path: &MountPath,
         range: Option<Range<u64>>,
     ) -> ResourceResult<Vec<u8>>;
+
+    /// Read `range` validated against a caller-pinned snapshot (`stat` captured
+    /// once when the read began), so every chunk of one read stays consistent
+    /// without a per-chunk stat. Default: ignore the pin and read normally.
+    async fn read_bytes_pinned(
+        &self,
+        path: &MountPath,
+        range: Option<Range<u64>>,
+        _stat: &FileStat,
+    ) -> ResourceResult<Vec<u8>> {
+        self.read_bytes(path, range).await
+    }
 
     async fn write_bytes(&self, path: &MountPath, data: Vec<u8>) -> ResourceResult<()>;
 

--- a/workspace/src/vfs/resource/local.rs
+++ b/workspace/src/vfs/resource/local.rs
@@ -151,6 +151,7 @@ impl Resource for LocalResource {
                         atime: s.atime,
                         ctime: s.ctime,
                         created: s.created,
+                        etag: None,
                     }
                 }
                 Err(_) => DirEntry {
@@ -161,6 +162,7 @@ impl Resource for LocalResource {
                     atime: None,
                     ctime: None,
                     created: None,
+                    etag: None,
                 },
             };
             out.push(entry);

--- a/workspace/src/vfs/resource/notion.rs
+++ b/workspace/src/vfs/resource/notion.rs
@@ -8,21 +8,6 @@ use crate::vfs::{
     resource::{DirEntry, FileKind, FileStat, Resource},
 };
 
-/// Extract `(mtime, ctime)` from a rendered `page.json`: Notion's
-/// `last_edited_time` → mtime, `created_time` → ctime (the nearest ctime analog
-/// the API exposes). Notion has no access time, so atime stays `None`.
-fn page_times(page_json: &[u8]) -> (Option<std::time::SystemTime>, Option<std::time::SystemTime>) {
-    let Ok(v) = serde_json::from_slice::<Value>(page_json) else {
-        return (None, None);
-    };
-    let t = |key: &str| {
-        v.get(key)
-            .and_then(|x| x.as_str())
-            .and_then(rfc3339_to_systemtime)
-    };
-    (t("last_edited_time"), t("created_time"))
-}
-
 /// Parse an RFC 3339 timestamp into a `SystemTime` (pre-epoch → `None`).
 fn rfc3339_to_systemtime(s: &str) -> Option<std::time::SystemTime> {
     let secs = chrono::DateTime::parse_from_rfc3339(s).ok()?.timestamp();
@@ -158,39 +143,34 @@ impl Resource for NotionResource {
                 ..Default::default()
             }),
             [p, rest @ ..] if p == "pages" && !rest.is_empty() => {
-                if rest.last().map(String::as_str) == Some("page.json") {
-                    // The enclosing page dir is the segment before page.json;
-                    // a bare /pages/page.json has none — NotFound, not an
-                    // index underflow on rest[rest.len() - 2].
+                let is_json = rest.last().map(String::as_str) == Some("page.json");
+                // The enclosing page dir is the last segment, or the one before
+                // `page.json`; a bare `/pages/page.json` has none — NotFound, not
+                // an index underflow.
+                let dir = if is_json {
                     let Some(dir) = rest.iter().nth_back(1) else {
                         return Err(ResourceError::NotFound);
                     };
-                    let id = page_id(dir);
-                    let bytes = self.render_page_json(&id).await?;
-                    let (mtime, ctime) = page_times(&bytes);
-                    Ok(FileStat {
-                        kind: FileKind::File,
-                        size: bytes.len() as u64,
-                        mtime,
-                        ctime,
-                        ..Default::default()
-                    })
+                    dir.as_str()
                 } else {
-                    // N1: don't blindly report a page dir as existing — verify the
-                    // page is real by rendering it (also reused for the times). A
-                    // render failure propagates as a backend error rather than a
-                    // flat NotFound, so a transient rate-limit isn't misreported as
-                    // a missing page.
-                    let id = page_id(rest.last().unwrap());
-                    let bytes = self.render_page_json(&id).await?;
-                    let (mtime, ctime) = page_times(&bytes);
-                    Ok(FileStat {
-                        kind: FileKind::Dir,
-                        mtime,
-                        ctime,
-                        ..Default::default()
-                    })
-                }
+                    rest.last().unwrap().as_str()
+                };
+                let id = page_id(dir);
+                // Cheap: fetch only the page object (times + existence), not the
+                // full block tree. Size is 0 here (filled on read); keeping `stat`
+                // cheap is what makes `last_edited_time` revalidation pay.
+                let page = self
+                    .accessor
+                    .get_page(&id)
+                    .await
+                    .map_err(|_| ResourceError::NotFound)?;
+                Ok(FileStat {
+                    kind: if is_json { FileKind::File } else { FileKind::Dir },
+                    size: 0,
+                    mtime: page_time(&page, "last_edited_time"),
+                    ctime: page_time(&page, "created_time"),
+                    ..Default::default()
+                })
             }
             _ => Err(ResourceError::NotFound),
         }
@@ -525,6 +505,7 @@ fn dir(name: &str) -> DirEntry {
         atime: None,
         ctime: None,
         created: None,
+        etag: None,
     }
 }
 
@@ -543,6 +524,7 @@ fn dir_t(
         atime: None,
         ctime,
         created: None,
+        etag: None,
     }
 }
 
@@ -563,6 +545,7 @@ fn file(name: &str, size: u64) -> DirEntry {
         atime: None,
         ctime: None,
         created: None,
+        etag: None,
     }
 }
 

--- a/workspace/src/vfs/resource/s3.rs
+++ b/workspace/src/vfs/resource/s3.rs
@@ -81,6 +81,40 @@ impl Resource for S3Resource {
         }
     }
 
+    async fn read_bytes_pinned(
+        &self,
+        path: &MountPath,
+        range: Option<Range<u64>>,
+        stat: &FileStat,
+    ) -> ResourceResult<Vec<u8>> {
+        // Pin the read to the snapshot's ETag: if the object changed since the
+        // read opened, S3 returns 412 rather than newer bytes, so a multi-chunk
+        // read can't stitch two versions together.
+        let os_path = self.os_path(path)?;
+        let opts = GetOptions {
+            range: range.clone().map(GetRange::Bounded),
+            if_match: stat.etag.clone(),
+            ..Default::default()
+        };
+        match self.accessor.store.get_opts(&os_path, opts).await {
+            Ok(res) => Ok(res.bytes().await?.to_vec()),
+            Err(OsError::Precondition { .. }) => Err(ResourceError::Backend(anyhow::anyhow!(
+                "object changed during read (if-match precondition failed)"
+            ))),
+            Err(e) => {
+                // Same clean-EOF handling as `read_bytes`: a range at/after EOF
+                // yields 416, which we treat as an empty (EOF) read.
+                if let Some(r) = &range
+                    && let Ok(meta) = self.accessor.store.head(&os_path).await
+                    && r.start >= meta.size
+                {
+                    return Ok(Vec::new());
+                }
+                Err(e.into())
+            }
+        }
+    }
+
     async fn write_bytes(&self, path: &MountPath, data: Vec<u8>) -> ResourceResult<()> {
         self.accessor
             .store
@@ -110,6 +144,7 @@ impl Resource for S3Resource {
                     atime: None,
                     ctime: None,
                     created: None,
+                    etag: None,
                 });
             }
         }
@@ -129,6 +164,9 @@ impl Resource for S3Resource {
                     atime: None,
                     ctime: None,
                     created: None,
+                    // Carry the listing ETag so a read opened off the cached
+                    // stat can pin itself to it (`If-Match`).
+                    etag: obj.e_tag.clone(),
                 });
             }
         }

--- a/workspace/src/vfs/sandbox/fwdfs.rs
+++ b/workspace/src/vfs/sandbox/fwdfs.rs
@@ -25,6 +25,7 @@ pub struct FwdEntry {
 /// A stat result. `exists == false` collapses every "no such node" outcome
 /// (missing path, unroutable prefix, backend stat error) into a single answer
 /// the FUSE forwarder turns into `ENOENT`.
+#[derive(Clone, Copy, Debug)]
 pub struct FwdStat {
     pub exists: bool,
     pub is_dir: bool,


### PR DESCRIPTION
## Description

This PR makes the workspace file trees browsable from the frontend over WebDAV, and optimize it so listings and file reads are correct and fast — including render-on-read providers like Notion.

WebDAV becomes the single browsing surface: a standard WebDAV client can list and read the tree, so the frontend needs no bespoke server API. The view matches the guest exactly — local files under `files/`, each provider mount as a sibling (`notion/`, `s3-…/`).

## Changes

**WebDAV serves the unified tree at `/sources`(renamed from `/files`)**
- Mounted at `/workspaces/{wid}/sources`, serving the same `ForwardFs` projection the guest sees (previously WebDAV exposed the inherent layout — local files at the root — so the views diverged).
- Listings/metadata come from the projection; `open`/create/remove/rename translate back to the inherent path (`WorkspaceFs::unified_to_inherent`), reusing the workspace's streaming, seek, and `knowledge/` write hooks.
- Authenticates from the `Authorization: Bearer` header (the frontend `webdav` client sets it directly), replacing the earlier `?token=` query param — which leaked the token into URLs/logs and which no standard WebDAV client appends. (This is mentioned in https://github.com/brekkylab/agent-k/pull/201#discussion_r3519305713 before.)

```
{Backend URL}/workspaces/{wid}/sources/       ← WebDAV root (ForwardFs integrated projection)
│
├── files/                                    ← local workspace files (RW)
│   │                                            host disk: data_root/workspaces/{wid}/files
│   ├── notes.txt
│   ├── report.pdf
│
├── notion/                                   ← Notion mount
│   └── pages/
│       └── <title>__<page-id>/               ← one page = directory
│           ├── page.json                     ← rendered content of page
│           └── <child-title>__<child-id>/    ← subpages
│               ├── page.json
│               └── …
│
└── s3-prod/                                  ← S3 mount — bucket key is the tree root
    ├── image.png
    └── data/
        └── q3.csv
```

**Correctness — render-on-read sizing**
- *Before*: Notion renders `page.json` only on read, so `stat`/`readdir` reported size 0; WebDAV took that as `Content-Length` and served an empty body. (FUSE and the old JSON API read to EOF, so only WebDAV broke.)
- *After*: `stat`/`readdir` render once through the content cache to get the real size, so listings/`stat`/`HEAD` are correct and the following read hits the cache — still one render.

**Performance — smooth browsing**
- Per-workspace `Vfs` cached across requests (provider clients + metadata cache persist instead of being rebuilt each request); evicted on mount change.
- Whole-object **content cache validated by backend version** (S3 ETag / Notion `last_edited_time`), so external edits refetch without a TTL wait; directory listings behind a shorter TTL(300s).
- Sequential reads serve continuation chunks (offset > 0) from the cached snapshot, skipping the per-chunk revalidation `stat` — a Notion `get_page` per 16 KiB chunk was ~250 ms, so a large page took seconds to open.

## Testing

- `cargo test -p agent-k-backend` — 30 passed, 0 failed.
- [webdav-verify.html](https://github.com/user-attachments/files/29889629/webdav-verify.html)


## Notes
- Content cache is capped at 8 MiB; a render-on-read object larger than that re-renders on each read.