### PR TITLE
Source indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "async-stream",
+ "async-trait",
  "axum",
  "axum-extra",
  "bytes",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -46,6 +46,7 @@ uuid = { version = "1.18.1", features = ["serde", "v4"] }
 workspace = { path = "../workspace" }
 
 [dev-dependencies]
+async-trait = "0.1"
 http-body-util = "0.1"
 tempfile = "3.23.0"
 tower = { version = "0.5", features = ["util"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -67,6 +67,32 @@ async fn main() -> std::io::Result<()> {
 
     bootstrap_admin_if_needed(&app_state.users, &app_state.workspaces).await;
 
+    // Optional periodic knowledge resync: picks up provider-side changes to
+    // referenced external targets, which produce no local write event. Disabled
+    // unless AGENT_K_INDEX_INTERVAL_SECS is set > 0.
+    if let Some(secs) = std::env::var("AGENT_K_INDEX_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+    {
+        let state = app_state.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(secs));
+            loop {
+                ticker.tick().await;
+                match state.workspaces.all_ids().await {
+                    Ok(ids) => {
+                        for wid in ids {
+                            state.workspaces.resyncer().spawn_resync(wid);
+                        }
+                    }
+                    Err(e) => tracing::warn!("periodic resync: listing workspaces failed: {e}"),
+                }
+            }
+        });
+        tracing::info!("periodic knowledge resync enabled: every {secs}s");
+    }
+
     let bind_addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:8080".to_string());
 
     aide::generate::on_error(|error| {

--- a/backend/src/router/knowledge.rs
+++ b/backend/src/router/knowledge.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 use ::workspace::{FsError as WsFsError, OpenOptions, WorkspaceFs};
 
 use crate::auth::AuthUser;
-use crate::state::{AppState, KNOWLEDGE_DIR, KnowledgeRef, REF_SUFFIX};
+use crate::state::{AppState, KNOWLEDGE_ROOT, KnowledgeRef, REF_SUFFIX};
 
 use super::{error::ApiError, error::err, workspace::require_owned_workspace};
 
@@ -75,13 +75,13 @@ pub(super) async fn create_ref(
         Err(_) => return Err(err(StatusCode::INTERNAL_SERVER_ERROR, "internal error")),
     }
 
-    match fs.create_dir(KNOWLEDGE_DIR).await {
+    match fs.create_dir(KNOWLEDGE_ROOT).await {
         Ok(()) | Err(WsFsError::Exists) => {}
         Err(_) => return Err(err(StatusCode::INTERNAL_SERVER_ERROR, "internal error")),
     }
 
     let name = ref_name_for(&target);
-    let ref_path = format!("{KNOWLEDGE_DIR}/{name}");
+    let ref_path = format!("{KNOWLEDGE_ROOT}/{name}");
     let body = KnowledgeRef {
         path: target.clone(),
     }
@@ -113,7 +113,7 @@ pub(super) async fn list_refs(
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "internal error"))?;
 
     let mut items = Vec::new();
-    match fs.read_dir(KNOWLEDGE_DIR).await {
+    match fs.read_dir(KNOWLEDGE_ROOT).await {
         Ok(mut stream) => {
             while let Some(entry) = stream.next().await {
                 let Ok(entry) = entry else { continue };
@@ -121,7 +121,7 @@ pub(super) async fn list_refs(
                 if !name.ends_with(REF_SUFFIX) {
                     continue;
                 }
-                let ref_path = format!("{KNOWLEDGE_DIR}/{name}");
+                let ref_path = format!("{KNOWLEDGE_ROOT}/{name}");
                 let Ok(bytes) = read_all(&fs, &ref_path).await else {
                     continue;
                 };
@@ -154,7 +154,7 @@ pub(super) async fn delete_ref(
         .get_fs(wid)
         .await
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "internal error"))?;
-    match fs.remove_file(&format!("{KNOWLEDGE_DIR}/{name}")).await {
+    match fs.remove_file(&format!("{KNOWLEDGE_ROOT}/{name}")).await {
         Ok(()) => Ok(StatusCode::NO_CONTENT),
         Err(WsFsError::NotFound) => Err(err(StatusCode::NOT_FOUND, "reference not found")),
         Err(_) => Err(err(StatusCode::INTERNAL_SERVER_ERROR, "internal error")),

--- a/backend/src/router/knowledge.rs
+++ b/backend/src/router/knowledge.rs
@@ -1,0 +1,262 @@
+//! HTTP API for a workspace's knowledge index membership.
+//!
+//! Membership is a set of references under `/files/knowledge`: each `*.ref` file
+//! holds the unified-tree path of a target (a local file, a mounted object, or a
+//! directory). Writing / deleting a reference goes through
+//! [`WorkspaceFs`](::workspace::WorkspaceFs), whose `/files/knowledge` hook spawns
+//! a resync — so these routes never touch the resyncer directly except for the
+//! explicit `resync`.
+
+use std::sync::Arc;
+
+use axum::{
+    Extension, Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use bytes::Bytes;
+use futures_util::StreamExt as _;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use ::workspace::{FsError as WsFsError, OpenOptions, WorkspaceFs};
+
+use crate::auth::AuthUser;
+use crate::state::{AppState, KNOWLEDGE_DIR, KnowledgeRef, REF_SUFFIX};
+
+use super::{error::ApiError, error::err, workspace::require_owned_workspace};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateRefRequest {
+    /// Absolute unified-tree path of the target to index, e.g. `/files/docs/q3.pdf`
+    /// (local) or `/s3-prod/reports/q3.pdf` (mounted). May point at a directory.
+    pub target_path: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RefResponse {
+    pub name: String,
+    pub target_path: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RefListResponse {
+    pub items: Vec<RefResponse>,
+}
+
+/// `POST /workspaces/{wid}/knowledge/refs` — reference a target into knowledge.
+pub(super) async fn create_ref(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(wid): Path<Uuid>,
+    Json(payload): Json<CreateRefRequest>,
+) -> Result<(StatusCode, Json<RefResponse>), ApiError> {
+    require_owned_workspace(&state, &auth, wid).await?;
+
+    let target = clean_target(&payload.target_path).map_err(|m| err(StatusCode::BAD_REQUEST, m))?;
+    if is_under_knowledge(&target) {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "cannot reference the knowledge directory itself",
+        ));
+    }
+
+    let fs = state
+        .workspaces
+        .get_fs(wid)
+        .await
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "internal error"))?;
+
+    match fs.metadata(&target).await {
+        Ok(_) => {}
+        Err(WsFsError::NotFound) => return Err(err(StatusCode::NOT_FOUND, "target not found")),
+        Err(_) => return Err(err(StatusCode::INTERNAL_SERVER_ERROR, "internal error")),
+    }
+
+    match fs.create_dir(KNOWLEDGE_DIR).await {
+        Ok(()) | Err(WsFsError::Exists) => {}
+        Err(_) => return Err(err(StatusCode::INTERNAL_SERVER_ERROR, "internal error")),
+    }
+
+    let name = ref_name_for(&target);
+    let ref_path = format!("{KNOWLEDGE_DIR}/{name}");
+    let body = KnowledgeRef {
+        path: target.clone(),
+    }
+    .to_bytes();
+    write_ref(&fs, &ref_path, body)
+        .await
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "failed to write reference"))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(RefResponse {
+            name,
+            target_path: target,
+        }),
+    ))
+}
+
+/// `GET /workspaces/{wid}/knowledge/refs` — list the workspace's references.
+pub(super) async fn list_refs(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(wid): Path<Uuid>,
+) -> Result<Json<RefListResponse>, ApiError> {
+    require_owned_workspace(&state, &auth, wid).await?;
+    let fs = state
+        .workspaces
+        .get_fs(wid)
+        .await
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "internal error"))?;
+
+    let mut items = Vec::new();
+    match fs.read_dir(KNOWLEDGE_DIR).await {
+        Ok(mut stream) => {
+            while let Some(entry) = stream.next().await {
+                let Ok(entry) = entry else { continue };
+                let name = String::from_utf8_lossy(&entry.name()).into_owned();
+                if !name.ends_with(REF_SUFFIX) {
+                    continue;
+                }
+                let ref_path = format!("{KNOWLEDGE_DIR}/{name}");
+                let Ok(bytes) = read_all(&fs, &ref_path).await else {
+                    continue;
+                };
+                if let Ok(r) = serde_json::from_slice::<KnowledgeRef>(&bytes) {
+                    items.push(RefResponse {
+                        name,
+                        target_path: r.path,
+                    });
+                }
+            }
+        }
+        Err(WsFsError::NotFound) => {}
+        Err(_) => return Err(err(StatusCode::INTERNAL_SERVER_ERROR, "internal error")),
+    }
+    Ok(Json(RefListResponse { items }))
+}
+
+/// `DELETE /workspaces/{wid}/knowledge/refs/{name}` — drop a reference.
+pub(super) async fn delete_ref(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path((wid, name)): Path<(Uuid, String)>,
+) -> Result<StatusCode, ApiError> {
+    require_owned_workspace(&state, &auth, wid).await?;
+    if name.contains('/') || name.contains("..") || !name.ends_with(REF_SUFFIX) {
+        return Err(err(StatusCode::BAD_REQUEST, "invalid reference name"));
+    }
+    let fs = state
+        .workspaces
+        .get_fs(wid)
+        .await
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "internal error"))?;
+    match fs.remove_file(&format!("{KNOWLEDGE_DIR}/{name}")).await {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(WsFsError::NotFound) => Err(err(StatusCode::NOT_FOUND, "reference not found")),
+        Err(_) => Err(err(StatusCode::INTERNAL_SERVER_ERROR, "internal error")),
+    }
+}
+
+/// `POST /workspaces/{wid}/knowledge/resync` — force a resync now.
+pub(super) async fn resync(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(wid): Path<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    require_owned_workspace(&state, &auth, wid).await?;
+    state.workspaces.resyncer().spawn_resync(wid);
+    Ok(StatusCode::ACCEPTED)
+}
+
+/// Validate + normalise a reference target: an absolute unified-tree path of
+/// normal segments (no relative, no `.`/`..`).
+fn clean_target(raw: &str) -> Result<String, &'static str> {
+    let t = raw.trim();
+    if !t.starts_with('/') {
+        return Err("target_path must be an absolute unified-tree path");
+    }
+    let segments: Vec<&str> = t.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.is_empty() {
+        return Err("target_path must not be the root");
+    }
+    if segments.iter().any(|s| *s == "." || *s == "..") {
+        return Err("target_path must not contain '.' or '..'");
+    }
+    Ok(format!("/{}", segments.join("/")))
+}
+
+/// True when `path` is `/files/knowledge` or lives under it.
+fn is_under_knowledge(path: &str) -> bool {
+    let p = path.trim_start_matches('/');
+    p == "files/knowledge" || p.starts_with("files/knowledge/")
+}
+
+/// A readable, unique reference file name derived from the target's basename.
+fn ref_name_for(target: &str) -> String {
+    let base = target.rsplit('/').next().unwrap_or("item");
+    let stem = base.split('.').next().unwrap_or(base);
+    let slug: String = stem
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let slug = slug.trim_matches('-');
+    let slug = if slug.is_empty() { "item" } else { slug };
+    let suffix = Uuid::new_v4().simple().to_string();
+    format!("{slug}-{}{REF_SUFFIX}", &suffix[..8])
+}
+
+async fn write_ref(fs: &WorkspaceFs, ref_path: &str, body: Vec<u8>) -> Result<(), WsFsError> {
+    let mut file = fs
+        .open(
+            ref_path,
+            OpenOptions {
+                write: true,
+                create: true,
+                truncate: true,
+                ..Default::default()
+            },
+        )
+        .await?;
+    file.write_bytes(Bytes::from(body)).await?;
+    file.flush().await
+}
+
+async fn read_all(fs: &WorkspaceFs, path: &str) -> Result<Vec<u8>, WsFsError> {
+    let mut file = fs
+        .open(
+            path,
+            OpenOptions {
+                read: true,
+                ..Default::default()
+            },
+        )
+        .await?;
+    let mut out = Vec::new();
+    loop {
+        let chunk = file.read_bytes(256 * 1024).await?;
+        if chunk.is_empty() {
+            break;
+        }
+        out.extend_from_slice(&chunk);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clean_target;
+
+    #[test]
+    fn clean_target_requires_absolute_normal_path() {
+        assert_eq!(clean_target("/files/a.md").unwrap(), "/files/a.md");
+        assert_eq!(clean_target("  /a//b/ ").unwrap(), "/a/b");
+        assert!(clean_target("a.md").is_err());
+        assert!(clean_target("/").is_err());
+        assert!(clean_target("/../etc/passwd").is_err());
+        assert!(clean_target("/a/./b").is_err());
+    }
+}

--- a/backend/src/router/mod.rs
+++ b/backend/src/router/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod error;
 
 mod agent;
 mod auth;
+mod knowledge;
 mod message;
 mod mount;
 mod session;
@@ -69,6 +70,18 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
         .api_route(
             "/workspaces/{wid}/mounts/{mount_id}",
             delete(mount::delete_mount),
+        )
+        .api_route(
+            "/workspaces/{wid}/knowledge/refs",
+            get(knowledge::list_refs).post(knowledge::create_ref),
+        )
+        .api_route(
+            "/workspaces/{wid}/knowledge/refs/{name}",
+            delete(knowledge::delete_ref),
+        )
+        .api_route(
+            "/workspaces/{wid}/knowledge/resync",
+            post(knowledge::resync),
         )
         .api_route(
             "/agents",

--- a/backend/src/state/knowledge/mod.rs
+++ b/backend/src/state/knowledge/mod.rs
@@ -12,13 +12,15 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use agent_k::knowledge_base::{FileType, PdfEngine, SharedStore, Store};
 use dashmap::DashMap;
 use futures_util::StreamExt as _;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OnceCell, RwLock};
 use uuid::Uuid;
 
 use ::workspace::{FsError, FsResult, OpenOptions, WorkspaceFs};
@@ -27,9 +29,9 @@ use super::workspace::{build_workspace_vfs, workspace_fs};
 
 /// Unified-tree directory holding the index references. Local files live under
 /// the `/files` mount, so knowledge refs are `/files/knowledge/*.ref`.
-pub const KNOWLEDGE_DIR: &str = "/files/knowledge";
+pub const KNOWLEDGE_ROOT: &str = "/files/knowledge";
 
-/// Suffix marking a reference file under [`KNOWLEDGE_DIR`].
+/// Suffix marking a reference file under [`KNOWLEDGE_ROOT`].
 pub const REF_SUFFIX: &str = ".ref";
 
 /// Resident-byte budget per ingest batch: bytes are dropped between batches so
@@ -74,16 +76,39 @@ struct TargetState {
     outcome: Outcome,
 }
 
+/// All per-workspace index state in one struct, so `Resyncer` holds a single
+/// `DashMap<Uuid, Arc<WsIndex>>` — one lookup per workspace and a single-entry
+/// teardown. `store` opens lazily; `lock` serializes reconciles (and teardown);
+/// `refmaps` is the per-target memo; `rev`/`done` are the coalescing gate (a
+/// trigger bumps `rev`, a task reconciles only while `rev != done`, and `done`
+/// advances — to the pre-scan `rev` — on success).
+#[derive(Default)]
+struct WsIndex {
+    store: OnceCell<SharedStore>,
+    lock: Mutex<()>,
+    refmaps: StdMutex<HashMap<String, TargetState>>,
+    rev: AtomicU64,
+    done: AtomicU64,
+}
+
+impl WsIndex {
+    /// The [`Store`] at `root`, opened (and cached) on first use.
+    async fn store(&self, root: PathBuf) -> anyhow::Result<SharedStore> {
+        self.store
+            .get_or_try_init(|| async { anyhow::Ok(Arc::new(RwLock::new(Store::new(root)?))) })
+            .await
+            .map(|s| s.clone())
+    }
+}
+
 /// Indexes a workspace's referenced knowledge into its [`Store`]. Cheap to clone,
 /// so one handle serves the fs write-trigger hook, the router, and the loop.
 #[derive(Clone)]
 pub struct Resyncer {
     db: SqlitePool,
     data_root: PathBuf,
-    stores: Arc<DashMap<Uuid, SharedStore>>,
-    locks: Arc<DashMap<Uuid, Arc<Mutex<()>>>>,
-    /// Per-workspace, per-target state (path → state); in-memory only.
-    refmaps: Arc<DashMap<Uuid, HashMap<String, TargetState>>>,
+    /// One [`WsIndex`] per workspace (store + lock + memo + coalescing gate).
+    indexes: Arc<DashMap<Uuid, Arc<WsIndex>>>,
 }
 
 impl Resyncer {
@@ -91,10 +116,12 @@ impl Resyncer {
         Self {
             db,
             data_root,
-            stores: Arc::new(DashMap::new()),
-            locks: Arc::new(DashMap::new()),
-            refmaps: Arc::new(DashMap::new()),
+            indexes: Arc::new(DashMap::new()),
         }
+    }
+
+    fn ws_for(&self, wid: Uuid) -> Arc<WsIndex> {
+        self.indexes.entry(wid).or_default().clone()
     }
 
     fn store_root(&self, wid: Uuid) -> PathBuf {
@@ -104,54 +131,30 @@ impl Resyncer {
             .join("knowledge-index")
     }
 
-    fn store_for(&self, wid: Uuid) -> anyhow::Result<SharedStore> {
-        use dashmap::mapref::entry::Entry;
-        match self.stores.entry(wid) {
-            Entry::Occupied(o) => Ok(o.get().clone()),
-            Entry::Vacant(v) => {
-                let store = Store::new(self.store_root(wid))?;
-                let shared = Arc::new(RwLock::new(store));
-                v.insert(shared.clone());
-                Ok(shared)
-            }
-        }
-    }
-
-    fn lock_for(&self, wid: Uuid) -> Arc<Mutex<()>> {
-        self.locks
-            .entry(wid)
-            .or_insert_with(|| Arc::new(Mutex::new(())))
-            .clone()
-    }
-
-    /// Drop the cached [`Store`], lock, and per-target memo for a torn-down
-    /// workspace. Takes the per-workspace lock first so it can't interleave with
-    /// an in-flight reconcile whose tail would resurrect the memo.
+    /// Drop a torn-down workspace's index state (store, memo, gate), releasing its
+    /// mmapped tantivy index. Takes the per-workspace lock first so it can't
+    /// interleave with an in-flight reconcile.
     pub async fn forget(&self, wid: Uuid) {
-        let lock = self.lock_for(wid);
-        let _guard = lock.lock().await;
-        self.stores.remove(&wid);
-        self.locks.remove(&wid);
-        self.refmaps.remove(&wid);
+        let ws = self.ws_for(wid);
+        let _guard = ws.lock.lock().await;
+        self.indexes.remove(&wid);
     }
 
-    /// Spawn a background resync, logging any failure.
+    /// Request a resync for `wid`. Bumps the revision gate and spawns a task; the
+    /// [`coalesce`] gate ensures a mutation storm collapses to ~one reconcile
+    /// (plus one if a trigger lands mid-run) rather than one per trigger.
     pub fn spawn_resync(&self, wid: Uuid) {
+        let ws = self.ws_for(wid);
+        ws.rev.fetch_add(1, Ordering::SeqCst);
         let this = self.clone();
-        tokio::spawn(async move {
-            if let Err(e) = this.reconcile(wid).await {
-                tracing::warn!(%wid, "knowledge resync failed: {e:#}");
-            }
-        });
+        tokio::spawn(async move { coalesce(wid, &ws, || this.reconcile(wid, &ws)).await });
     }
 
-    /// Reconcile `wid`'s [`Store`] with its `/files/knowledge` references. Ingest
+    /// Reconcile `wid`'s [`Store`] with its `/files/knowledge` references: ingest
     /// referenced targets in byte-bounded batches, then purge documents whose ref
-    /// is gone. Serialized per workspace.
-    pub async fn reconcile(&self, wid: Uuid) -> anyhow::Result<()> {
-        let lock = self.lock_for(wid);
-        let _guard = lock.lock().await;
-
+    /// is gone. Not self-serializing — callers run it under `ws.lock` via
+    /// [`coalesce`] (or [`forget`](Self::forget)).
+    async fn reconcile(&self, wid: Uuid, ws: &WsIndex) -> anyhow::Result<()> {
         let config = build_workspace_vfs(&self.db, wid).await?;
         let fs = workspace_fs(&self.data_root, wid, config)?;
 
@@ -161,10 +164,10 @@ impl Resyncer {
             return Ok(());
         }
 
-        let store = self.store_for(wid)?;
+        let store = ws.store(self.store_root(wid)).await?;
         let mut store = store.write().await;
 
-        let prev = self.refmaps.get(&wid).map(|m| m.clone()).unwrap_or_default();
+        let prev = ws.refmaps.lock().unwrap().clone();
 
         // Read each target (remembering its content-hash id, or that it failed)
         // and ingest readable bytes in byte-bounded batches.
@@ -196,7 +199,7 @@ impl Resyncer {
         }
 
         let (next, protected) = build_keepset(&prev, &reads, &succeeded);
-        self.refmaps.insert(wid, next);
+        *ws.refmaps.lock().unwrap() = next;
 
         // Purge only docs whose ref is gone — never docs that merely failed to
         // read/ingest this cycle (protected via the memo above).
@@ -214,6 +217,29 @@ impl Resyncer {
         }
         store.compact()?;
         Ok(())
+    }
+}
+
+/// Coalescing gate: reconcile only if a trigger arrived since the last successful
+/// pass (`rev != done`), advancing `done` to the pre-scan `rev` on success so a
+/// burst's remaining tasks collapse. A failed pass leaves `done` behind, so the
+/// burst's other tasks retry (self-heal). Serialized per workspace by `lock`.
+async fn coalesce<F, Fut>(wid: Uuid, ws: &WsIndex, reconcile: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    if ws.rev.load(Ordering::SeqCst) == ws.done.load(Ordering::SeqCst) {
+        return; // fast path — latest already reconciled; skip the lock
+    }
+    let _guard = ws.lock.lock().await;
+    let cur = ws.rev.load(Ordering::SeqCst);
+    if cur == ws.done.load(Ordering::SeqCst) {
+        return; // an earlier task already reconciled this revision
+    }
+    match reconcile().await {
+        Ok(()) => ws.done.store(cur, Ordering::SeqCst),
+        Err(e) => tracing::warn!(%wid, "knowledge resync failed: {e:#}"),
     }
 }
 
@@ -308,18 +334,18 @@ async fn collect_targets(
     max_file_bytes: u64,
 ) -> anyhow::Result<Vec<(String, FileType)>> {
     let mut out = Vec::new();
-    let mut stream = match fs.read_dir(KNOWLEDGE_DIR).await {
+    let mut stream = match fs.read_dir(KNOWLEDGE_ROOT).await {
         Ok(s) => s,
         Err(FsError::NotFound) => return Ok(out),
-        Err(e) => anyhow::bail!("read {KNOWLEDGE_DIR}: {e:?}"),
+        Err(e) => anyhow::bail!("read {KNOWLEDGE_ROOT}: {e:?}"),
     };
     while let Some(entry) = stream.next().await {
-        let entry = entry.map_err(|e| anyhow::anyhow!("read {KNOWLEDGE_DIR}: {e:?}"))?;
+        let entry = entry.map_err(|e| anyhow::anyhow!("read {KNOWLEDGE_ROOT}: {e:?}"))?;
         let name = String::from_utf8_lossy(&entry.name()).into_owned();
         if !name.ends_with(REF_SUFFIX) {
             continue;
         }
-        let ref_path = format!("{KNOWLEDGE_DIR}/{name}");
+        let ref_path = format!("{KNOWLEDGE_ROOT}/{name}");
         let bytes = match read_all(fs, &ref_path).await {
             Ok(b) => b,
             Err(e) => {
@@ -416,8 +442,9 @@ fn is_safe_target(path: &str) -> bool {
     any
 }
 
-/// True when `path` is `/files/knowledge` or lives under it.
-fn is_under_knowledge(path: &str) -> bool {
+/// True when `path` is `/files/knowledge` or lives under it. Shared with the
+/// backend's `/knowledge` change hook so the predicate lives in one place.
+pub(super) fn is_under_knowledge(path: &str) -> bool {
     let p = path.trim_start_matches('/');
     p == "files/knowledge" || p.starts_with("files/knowledge/")
 }
@@ -431,7 +458,8 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        KnowledgeRef, Outcome, TargetState, build_keepset, collect_targets, is_safe_target,
+        KnowledgeRef, Outcome, TargetState, WsIndex, build_keepset, coalesce, collect_targets,
+        is_safe_target,
     };
 
     fn indexed(id: Uuid) -> TargetState {
@@ -505,6 +533,48 @@ mod tests {
             paths,
             vec!["/files/docs/a.md".to_string(), "/files/docs/sub/b.md".to_string()]
         );
+    }
+
+    /// A burst of triggers (rev bumped N times) drained by N tasks runs the
+    /// reconcile once — the rest see `rev == done` and return cheaply.
+    #[tokio::test]
+    async fn coalesce_collapses_burst() {
+        use std::sync::atomic::{AtomicUsize, Ordering as O};
+        let ws = WsIndex::default();
+        let calls = AtomicUsize::new(0);
+        for _ in 0..3 {
+            ws.rev.fetch_add(1, O::SeqCst);
+        }
+        for _ in 0..3 {
+            coalesce(Uuid::nil(), &ws, || async {
+                calls.fetch_add(1, O::SeqCst);
+                Ok(())
+            })
+            .await;
+        }
+        assert_eq!(calls.load(O::SeqCst), 1);
+    }
+
+    /// A failed pass doesn't advance `done`, so the burst's next task retries.
+    #[tokio::test]
+    async fn coalesce_retries_after_failure() {
+        use std::sync::atomic::{AtomicUsize, Ordering as O};
+        let ws = WsIndex::default();
+        let calls = AtomicUsize::new(0);
+        for _ in 0..2 {
+            ws.rev.fetch_add(1, O::SeqCst);
+        }
+        coalesce(Uuid::nil(), &ws, || async {
+            calls.fetch_add(1, O::SeqCst);
+            anyhow::bail!("boom")
+        })
+        .await;
+        coalesce(Uuid::nil(), &ws, || async {
+            calls.fetch_add(1, O::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert_eq!(calls.load(O::SeqCst), 2);
     }
 
     #[test]

--- a/backend/src/state/knowledge/mod.rs
+++ b/backend/src/state/knowledge/mod.rs
@@ -452,20 +452,221 @@ pub(super) fn is_under_knowledge(path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+    use std::ops::Range;
     use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use ::workspace::{FsConfig, WorkspaceFs};
+    use ::workspace::{
+        FileKind, FileStat, FsConfig, LocalResource, Mount, MountPath, Resource, ResourceDirEntry,
+        ResourceError, ResourceResult, WorkspaceFs,
+    };
+    use async_trait::async_trait;
     use uuid::Uuid;
 
     use super::{
-        KnowledgeRef, Outcome, TargetState, WsIndex, build_keepset, coalesce, collect_targets,
-        is_safe_target,
+        KnowledgeRef, Outcome, Resyncer, TargetState, WsIndex, build_keepset, coalesce,
+        collect_targets, is_safe_target, read_all,
     };
 
     fn indexed(id: Uuid) -> TargetState {
         TargetState {
             last_indexed_id: Some(id),
             outcome: Outcome::Indexed,
+        }
+    }
+
+    // --- build_keepset (pure) --------------------------------------------
+
+    /// A still-referenced target that fails to read keeps its document (protected
+    /// via its prior id) instead of being purged on a transient blip.
+    #[test]
+    fn transient_read_failure_protects_prior_doc() {
+        let id = Uuid::from_u128(1);
+        let mut prev = HashMap::new();
+        prev.insert("/files/a.md".to_string(), indexed(id));
+        let reads = vec![("/files/a.md".to_string(), None)];
+        let (next, protected) = build_keepset(&prev, &reads, &HashSet::new());
+        assert!(protected.contains(&id));
+        assert_eq!(next["/files/a.md"].last_indexed_id, Some(id));
+        assert_eq!(next["/files/a.md"].outcome, Outcome::ReadFailed);
+    }
+
+    /// A removed ref is absent from the scan, so its id isn't protected → purged.
+    #[test]
+    fn removed_ref_is_purged() {
+        let id = Uuid::from_u128(1);
+        let mut prev = HashMap::new();
+        prev.insert("/files/a.md".to_string(), indexed(id));
+        let (next, protected) = build_keepset(&prev, &[], &HashSet::new());
+        assert!(!protected.contains(&id));
+        assert!(next.is_empty());
+    }
+
+    /// A never-indexed target that fails to read has no doc to protect.
+    #[test]
+    fn unreadable_never_indexed_protects_nothing() {
+        let reads = vec![("/files/a.md".to_string(), None)];
+        let (next, protected) = build_keepset(&HashMap::new(), &reads, &HashSet::new());
+        assert!(protected.is_empty());
+        assert_eq!(next["/files/a.md"].last_indexed_id, None);
+    }
+
+    /// A broken (unreadable, never-indexed) ref can't shield unrelated docs.
+    #[test]
+    fn broken_ref_does_not_block_unrelated_purge() {
+        let removed_doc = Uuid::from_u128(9);
+        let reads = vec![("/mnt/broken.pdf".to_string(), None)];
+        let (_, protected) = build_keepset(&HashMap::new(), &reads, &HashSet::new());
+        assert!(protected.is_empty());
+        assert!(!protected.contains(&removed_doc));
+    }
+
+    /// Read OK but ingest failed (new id not confirmed): keep the prior doc.
+    #[test]
+    fn ingest_failure_keeps_prior_doc() {
+        let old = Uuid::from_u128(1);
+        let new = Uuid::from_u128(2);
+        let mut prev = HashMap::new();
+        prev.insert("/files/a.md".to_string(), indexed(old));
+        let reads = vec![("/files/a.md".to_string(), Some(new))];
+        let (next, protected) = build_keepset(&prev, &reads, &HashSet::new());
+        assert!(protected.contains(&old));
+        assert_eq!(next["/files/a.md"].last_indexed_id, Some(old));
+        assert_eq!(next["/files/a.md"].outcome, Outcome::IngestFailed);
+    }
+
+    /// The memo carries a target's last indexed id across cycles: it survives
+    /// repeated read blips and re-indexes on recovery (output fed back as `prev`).
+    #[test]
+    fn refmaps_carries_id_across_cycles() {
+        let p = "/files/a.md".to_string();
+        let x = Uuid::from_u128(1);
+        let hit: HashSet<Uuid> = [x].into_iter().collect();
+
+        let (m1, prot) = build_keepset(&HashMap::new(), &[(p.clone(), Some(x))], &hit);
+        assert!(prot.contains(&x));
+        assert_eq!(m1[&p].last_indexed_id, Some(x));
+
+        let (m2, prot) = build_keepset(&m1, &[(p.clone(), None)], &HashSet::new());
+        assert!(prot.contains(&x));
+        let (m3, prot) = build_keepset(&m2, &[(p.clone(), None)], &HashSet::new());
+        assert!(prot.contains(&x));
+
+        let (m4, prot) = build_keepset(&m3, &[(p.clone(), Some(x))], &hit);
+        assert!(prot.contains(&x));
+        assert_eq!(m4[&p].outcome, Outcome::Indexed);
+    }
+
+    /// Read OK, content changed, ingest confirmed: protect the new id; the old
+    /// content's doc is unreferenced → purgeable.
+    #[test]
+    fn content_change_swaps_protected_id() {
+        let old = Uuid::from_u128(1);
+        let new = Uuid::from_u128(2);
+        let mut prev = HashMap::new();
+        prev.insert("/files/a.md".to_string(), indexed(old));
+        let reads = vec![("/files/a.md".to_string(), Some(new))];
+        let succeeded: HashSet<Uuid> = [new].into_iter().collect();
+        let (next, protected) = build_keepset(&prev, &reads, &succeeded);
+        assert!(protected.contains(&new));
+        assert!(!protected.contains(&old));
+        assert_eq!(next["/files/a.md"].last_indexed_id, Some(new));
+        assert_eq!(next["/files/a.md"].outcome, Outcome::Indexed);
+    }
+
+    /// One keep-set over a mixed batch: each target's fate is independent.
+    #[test]
+    fn mixed_batch_protects_each_target_independently() {
+        let ok_id = Uuid::from_u128(1);
+        let blip_prior = Uuid::from_u128(2);
+        let removed_id = Uuid::from_u128(3);
+        let unconfirmed = Uuid::from_u128(4);
+
+        let mut prev = HashMap::new();
+        prev.insert("/files/ok.md".to_string(), indexed(ok_id));
+        prev.insert("/files/blip.md".to_string(), indexed(blip_prior));
+        prev.insert("/files/removed.md".to_string(), indexed(removed_id));
+
+        let reads = vec![
+            ("/files/ok.md".to_string(), Some(ok_id)),
+            ("/files/blip.md".to_string(), None),
+            ("/files/new.md".to_string(), Some(unconfirmed)),
+        ];
+        let succeeded: HashSet<Uuid> = [ok_id].into_iter().collect();
+
+        let (next, protected) = build_keepset(&prev, &reads, &succeeded);
+
+        assert_eq!(protected, [ok_id, blip_prior].into_iter().collect());
+        assert!(!protected.contains(&removed_id));
+        assert!(!protected.contains(&unconfirmed));
+        assert_eq!(next["/files/ok.md"].outcome, Outcome::Indexed);
+        assert_eq!(next["/files/blip.md"].outcome, Outcome::ReadFailed);
+        assert_eq!(next["/files/new.md"].outcome, Outcome::IngestFailed);
+        assert_eq!(next["/files/new.md"].last_indexed_id, None);
+        assert!(!next.contains_key("/files/removed.md"));
+    }
+
+    // --- enumeration -----------------------------------------------------
+
+    /// A read-only provider with one markdown file at its root, `/doc.md`.
+    struct MockResource {
+        content: Vec<u8>,
+    }
+
+    #[async_trait]
+    impl Resource for MockResource {
+        async fn read_bytes(
+            &self,
+            path: &MountPath,
+            range: Option<Range<u64>>,
+        ) -> ResourceResult<Vec<u8>> {
+            if path.as_str() != "/doc.md" {
+                return Err(ResourceError::NotFound);
+            }
+            Ok(match range {
+                Some(r) => {
+                    let s = (r.start as usize).min(self.content.len());
+                    let e = (r.end as usize).min(self.content.len());
+                    self.content[s..e].to_vec()
+                }
+                None => self.content.clone(),
+            })
+        }
+        async fn write_bytes(&self, _p: &MountPath, _d: Vec<u8>) -> ResourceResult<()> {
+            Err(ResourceError::Unsupported)
+        }
+        async fn readdir(&self, path: &MountPath) -> ResourceResult<Vec<ResourceDirEntry>> {
+            if path.is_root() {
+                Ok(vec![ResourceDirEntry {
+                    name: "doc.md".into(),
+                    kind: FileKind::File,
+                    size: self.content.len() as u64,
+                    mtime: None,
+                    atime: None,
+                    ctime: None,
+                    created: None,
+                    etag: None,
+                }])
+            } else {
+                Err(ResourceError::NotFound)
+            }
+        }
+        async fn stat(&self, path: &MountPath) -> ResourceResult<FileStat> {
+            if path.is_root() {
+                Ok(FileStat {
+                    kind: FileKind::Dir,
+                    ..Default::default()
+                })
+            } else if path.as_str() == "/doc.md" {
+                Ok(FileStat {
+                    kind: FileKind::File,
+                    size: self.content.len() as u64,
+                    ..Default::default()
+                })
+            } else {
+                Err(ResourceError::NotFound)
+            }
         }
     }
 
@@ -483,98 +684,135 @@ mod tests {
         write(root, &format!("knowledge/{name}"), &body).await;
     }
 
-    /// A still-referenced target that fails to read keeps its document (protected
-    /// via its prior id) rather than being purged on a transient blip.
-    #[test]
-    fn transient_read_failure_protects_prior_doc() {
-        let id = Uuid::from_u128(1);
-        let mut prev = HashMap::new();
-        prev.insert("/files/a.md".to_string(), indexed(id));
-        let reads = vec![("/files/a.md".to_string(), None)];
-        let (_next, protected) = build_keepset(&prev, &reads, &HashSet::new());
-        assert!(protected.contains(&id));
+    /// A local `/files` mount over `root` plus a `/mock` provider mount.
+    fn fs_with_mock(root: &Path, mock: MockResource) -> WorkspaceFs {
+        WorkspaceFs::from_mounts(vec![
+            Mount {
+                prefix: "/files".into(),
+                resource: Arc::new(LocalResource::new(root.to_path_buf())),
+            },
+            Mount {
+                prefix: "/mock".into(),
+                resource: Arc::new(mock),
+            },
+        ])
+        .unwrap()
     }
 
-    /// A removed ref (absent from this cycle's reads) is not protected → purged.
-    #[test]
-    fn removed_ref_not_protected() {
-        let id = Uuid::from_u128(2);
-        let mut prev = HashMap::new();
-        prev.insert("/files/gone.md".to_string(), indexed(id));
-        let (_next, protected) = build_keepset(&prev, &[], &HashSet::new());
-        assert!(!protected.contains(&id));
-    }
-
-    #[tokio::test]
-    async fn collects_file_and_dir_targets() {
-        let tmp = tempfile::tempdir().unwrap();
-        let files = tmp.path();
-        write(files, "docs/a.md", b"AAA").await;
-        write(files, "docs/sub/b.md", b"BBB").await;
-        write(files, "docs/sub/ignore.bin", b"nope").await;
-        write_ref(files, "a.ref", "/files/docs/a.md").await;
-        write_ref(files, "dir.ref", "/files/docs/sub").await;
-        write_ref(files, "missing.ref", "/files/docs/gone.md").await;
-        write_ref(files, "self.ref", "/files/knowledge/a.ref").await;
-
-        let fs = WorkspaceFs::from_config(FsConfig {
-            local_root: Some(files.to_path_buf()),
+    /// A local-only `/files` mount over `root`.
+    fn local_fs(root: &Path) -> WorkspaceFs {
+        WorkspaceFs::from_config(FsConfig {
+            local_root: Some(root.to_path_buf()),
             mounts: vec![],
         })
-        .unwrap();
-        let mut paths: Vec<String> = collect_targets(&fs, u64::MAX)
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|(p, _)| p)
-            .collect();
+        .unwrap()
+    }
+
+    /// Enumeration gathers local files, a directory's descendants, and a mounted
+    /// object — skipping non-`.ref`, self-references, missing targets, and
+    /// non-indexable extensions — and the paths resolve to real bytes.
+    #[tokio::test]
+    async fn collects_local_dir_and_mount_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        write(root, "docs/a.md", b"AAA").await;
+        write(root, "docs/sub/b.md", b"BBB").await;
+        write(root, "docs/sub/ignore.bin", b"nope").await;
+
+        write_ref(root, "a.ref", "/files/docs/a.md").await;
+        write_ref(root, "dir.ref", "/files/docs/sub").await;
+        write_ref(root, "mount.ref", "/mock/doc.md").await;
+        write_ref(root, "missing.ref", "/files/docs/gone.md").await;
+        write_ref(root, "self.ref", "/files/knowledge/a.ref").await;
+        write(root, "knowledge/note.txt", b"not a ref").await;
+
+        let fs = fs_with_mock(
+            root,
+            MockResource {
+                content: b"MOUNTED".to_vec(),
+            },
+        );
+
+        let targets = collect_targets(&fs, u64::MAX).await.unwrap();
+        let mut paths: Vec<String> = targets.iter().map(|(p, _)| p.clone()).collect();
         paths.sort();
         assert_eq!(
             paths,
-            vec!["/files/docs/a.md".to_string(), "/files/docs/sub/b.md".to_string()]
+            vec![
+                "/files/docs/a.md".to_string(),
+                "/files/docs/sub/b.md".to_string(),
+                "/mock/doc.md".to_string(),
+            ]
+        );
+
+        let mut bodies = Vec::new();
+        for (p, _) in &targets {
+            bodies.push(read_all(&fs, p).await.unwrap());
+        }
+        bodies.sort();
+        assert_eq!(
+            bodies,
+            vec![b"AAA".to_vec(), b"BBB".to_vec(), b"MOUNTED".to_vec()]
         );
     }
 
-    /// A burst of triggers (rev bumped N times) drained by N tasks runs the
-    /// reconcile once — the rest see `rev == done` and return cheaply.
+    /// A directory ref and an explicit file ref covering the same path enumerate
+    /// it once.
     #[tokio::test]
-    async fn coalesce_collapses_burst() {
-        use std::sync::atomic::{AtomicUsize, Ordering as O};
-        let ws = WsIndex::default();
-        let calls = AtomicUsize::new(0);
-        for _ in 0..3 {
-            ws.rev.fetch_add(1, O::SeqCst);
-        }
-        for _ in 0..3 {
-            coalesce(Uuid::nil(), &ws, || async {
-                calls.fetch_add(1, O::SeqCst);
-                Ok(())
-            })
-            .await;
-        }
-        assert_eq!(calls.load(O::SeqCst), 1);
+    async fn dedups_overlapping_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(root, "docs/a.md", b"A").await;
+        write_ref(root, "dir.ref", "/files/docs").await;
+        write_ref(root, "file.ref", "/files/docs/a.md").await;
+        let fs = local_fs(root);
+
+        let targets = collect_targets(&fs, u64::MAX).await.unwrap();
+        let paths: Vec<String> = targets.iter().map(|(p, _)| p.clone()).collect();
+        assert_eq!(paths, vec!["/files/docs/a.md".to_string()]);
     }
 
-    /// A failed pass doesn't advance `done`, so the burst's next task retries.
+    /// A target larger than the per-file cap is skipped, smaller ones kept.
     #[tokio::test]
-    async fn coalesce_retries_after_failure() {
-        use std::sync::atomic::{AtomicUsize, Ordering as O};
-        let ws = WsIndex::default();
-        let calls = AtomicUsize::new(0);
-        for _ in 0..2 {
-            ws.rev.fetch_add(1, O::SeqCst);
-        }
-        coalesce(Uuid::nil(), &ws, || async {
-            calls.fetch_add(1, O::SeqCst);
-            anyhow::bail!("boom")
-        })
-        .await;
-        coalesce(Uuid::nil(), &ws, || async {
-            calls.fetch_add(1, O::SeqCst);
-            Ok(())
-        })
-        .await;
-        assert_eq!(calls.load(O::SeqCst), 2);
+    async fn oversized_target_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(root, "docs/small.md", b"tiny").await;
+        write(root, "docs/big.md", &vec![b'x'; 100]).await;
+        write_ref(root, "small.ref", "/files/docs/small.md").await;
+        write_ref(root, "big.ref", "/files/docs/big.md").await;
+        let fs = local_fs(root);
+
+        let targets = collect_targets(&fs, 10).await.unwrap();
+        let paths: Vec<String> = targets.iter().map(|(p, _)| p.clone()).collect();
+        assert_eq!(paths, vec!["/files/docs/small.md".to_string()]);
+    }
+
+    /// A planted reference whose target escapes the root (`..`) or is relative is
+    /// skipped, not resolved.
+    #[tokio::test]
+    async fn skips_unsafe_ref_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write_ref(root, "esc.ref", "/../outside.md").await;
+        write_ref(root, "rel.ref", "docs/x.md").await;
+        write(root, "docs/ok.md", b"OK").await;
+        write_ref(root, "ok.ref", "/files/docs/ok.md").await;
+        let fs = local_fs(root);
+
+        let targets = collect_targets(&fs, u64::MAX).await.unwrap();
+        let paths: Vec<String> = targets.iter().map(|(p, _)| p.clone()).collect();
+        assert_eq!(paths, vec!["/files/docs/ok.md".to_string()]);
+    }
+
+    /// A missing `/files/knowledge` directory yields no targets rather than erroring.
+    #[tokio::test]
+    async fn absent_knowledge_dir_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fs = local_fs(tmp.path());
+        let targets = collect_targets(&fs, u64::MAX).await.unwrap();
+        assert!(targets.is_empty());
     }
 
     #[test]
@@ -583,5 +821,140 @@ mod tests {
         assert!(!is_safe_target("a.md"));
         assert!(!is_safe_target("/a/../b"));
         assert!(!is_safe_target("/"));
+    }
+
+    // --- coalescing gate -------------------------------------------------
+
+    /// A burst of triggers runs one reconcile; a later trigger runs one more.
+    #[tokio::test]
+    async fn coalesces_burst_to_one_reconcile() {
+        let ws = WsIndex::default();
+        let wid = Uuid::new_v4();
+        let calls = AtomicUsize::new(0);
+        for _ in 0..5 {
+            ws.rev.fetch_add(1, Ordering::SeqCst);
+        }
+        for _ in 0..5 {
+            coalesce(wid, &ws, || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                anyhow::Ok(())
+            })
+            .await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        ws.rev.fetch_add(1, Ordering::SeqCst);
+        coalesce(wid, &ws, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::Ok(())
+        })
+        .await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// On Err, `done` stays behind `rev`, so the burst's remaining tasks retry.
+    #[tokio::test]
+    async fn err_does_not_advance_done_so_burst_retries() {
+        let ws = WsIndex::default();
+        let wid = Uuid::new_v4();
+        ws.rev.fetch_add(1, Ordering::SeqCst);
+        coalesce(wid, &ws, || async { anyhow::bail!("transient") }).await;
+
+        let calls = AtomicUsize::new(0);
+        coalesce(wid, &ws, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::Ok(())
+        })
+        .await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// A trigger during a reconcile leaves `done` behind `rev`, so exactly one
+    /// follow-up runs (guards "never re-read `rev` at the end").
+    #[tokio::test]
+    async fn trigger_during_reconcile_runs_one_more() {
+        let ws = WsIndex::default();
+        let wid = Uuid::new_v4();
+        let calls = AtomicUsize::new(0);
+
+        ws.rev.fetch_add(1, Ordering::SeqCst);
+        coalesce(wid, &ws, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            ws.rev.fetch_add(1, Ordering::SeqCst);
+            anyhow::Ok(())
+        })
+        .await;
+        assert_eq!(ws.done.load(Ordering::SeqCst), 1);
+
+        for _ in 0..3 {
+            coalesce(wid, &ws, || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                anyhow::Ok(())
+            })
+            .await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// Concurrent triggers coalesce to exactly one reconcile under real contention.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_triggers_coalesce_to_one() {
+        use tokio::sync::oneshot;
+
+        let ws = Arc::new(WsIndex::default());
+        let wid = Uuid::new_v4();
+        let calls = Arc::new(AtomicUsize::new(0));
+        ws.rev.fetch_add(1, Ordering::SeqCst);
+        ws.rev.fetch_add(1, Ordering::SeqCst);
+
+        let (in_tx, in_rx) = oneshot::channel();
+        let (rel_tx, rel_rx) = oneshot::channel();
+
+        let a = tokio::spawn({
+            let (ws, calls) = (ws.clone(), calls.clone());
+            async move {
+                coalesce(wid, &ws, move || async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    in_tx.send(()).unwrap();
+                    rel_rx.await.unwrap();
+                    anyhow::Ok(())
+                })
+                .await;
+            }
+        });
+        in_rx.await.unwrap();
+
+        let b = tokio::spawn({
+            let (ws, calls) = (ws.clone(), calls.clone());
+            async move {
+                coalesce(wid, &ws, || async {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    anyhow::Ok(())
+                })
+                .await;
+            }
+        });
+
+        rel_tx.send(()).unwrap();
+        a.await.unwrap();
+        b.await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(ws.done.load(Ordering::SeqCst), 2);
+    }
+
+    /// `forget` drops a deleted workspace's index state.
+    #[tokio::test]
+    async fn forget_evicts_workspace_state() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let r = Resyncer::new(pool, tmp.path().to_path_buf());
+        let wid = Uuid::new_v4();
+
+        r.ws_for(wid);
+        assert!(r.indexes.contains_key(&wid));
+
+        r.forget(wid).await;
+        assert!(!r.indexes.contains_key(&wid));
     }
 }

--- a/backend/src/state/knowledge/mod.rs
+++ b/backend/src/state/knowledge/mod.rs
@@ -1,0 +1,517 @@
+//! Content-hash knowledge indexing (the current approach, ported to the
+//! `workspace` crate + `FsHook`).
+//!
+//! Membership is a set of `*.ref` files under `/files/knowledge`, each holding
+//! the unified-tree path of a target. Resync/reconcile against
+//! [`agent_k::knowledge_base::Store`]: enumerate targets, read + `ingest_many` in
+//! byte-bounded batches (document ids are a content hash, so unchanged content is
+//! a no-op), then purge documents no longer referenced. A per-workspace in-memory
+//! memo protects a still-referenced-but-unreadable target's document from a
+//! transient-failure purge (see `build_keepset`).
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use agent_k::knowledge_base::{FileType, PdfEngine, SharedStore, Store};
+use dashmap::DashMap;
+use futures_util::StreamExt as _;
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use tokio::sync::{Mutex, RwLock};
+use uuid::Uuid;
+
+use ::workspace::{FsError, FsResult, OpenOptions, WorkspaceFs};
+
+use super::workspace::{build_workspace_vfs, workspace_fs};
+
+/// Unified-tree directory holding the index references. Local files live under
+/// the `/files` mount, so knowledge refs are `/files/knowledge/*.ref`.
+pub const KNOWLEDGE_DIR: &str = "/files/knowledge";
+
+/// Suffix marking a reference file under [`KNOWLEDGE_DIR`].
+pub const REF_SUFFIX: &str = ".ref";
+
+/// Resident-byte budget per ingest batch: bytes are dropped between batches so
+/// peak memory stays bounded. A file over budget forms its own batch (bounded
+/// instead by [`MAX_FILE_BYTES`]). Near `Store`'s ~128 MB `IndexWriter`.
+const BATCH_BUDGET_BYTES: usize = 128 * 1024 * 1024;
+
+/// Per-file cap. A file can't be streamed (read whole to hash/translate), so an
+/// arbitrarily large one could OOM; files over this are skipped.
+const MAX_FILE_BYTES: u64 = 256 * 1024 * 1024;
+
+const READ_CHUNK: usize = 256 * 1024;
+
+/// The on-disk body of a `*.ref` file: the unified-tree path of its target.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KnowledgeRef {
+    pub path: String,
+}
+
+impl KnowledgeRef {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec_pretty(self).expect("serialise KnowledgeRef")
+    }
+}
+
+/// Outcome of the most recent reconcile for a single referenced target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Outcome {
+    Indexed,
+    ReadFailed,
+    IngestFailed,
+}
+
+/// Per-target state remembered between reconciles (in-memory only; rebuilt on the
+/// next reconcile after a restart).
+#[derive(Debug, Clone)]
+struct TargetState {
+    /// Content-hash id of the doc last indexed for this target, carried across
+    /// failed cycles so a still-referenced-but-unreadable target survives purge.
+    last_indexed_id: Option<Uuid>,
+    #[allow(dead_code)]
+    outcome: Outcome,
+}
+
+/// Indexes a workspace's referenced knowledge into its [`Store`]. Cheap to clone,
+/// so one handle serves the fs write-trigger hook, the router, and the loop.
+#[derive(Clone)]
+pub struct Resyncer {
+    db: SqlitePool,
+    data_root: PathBuf,
+    stores: Arc<DashMap<Uuid, SharedStore>>,
+    locks: Arc<DashMap<Uuid, Arc<Mutex<()>>>>,
+    /// Per-workspace, per-target state (path → state); in-memory only.
+    refmaps: Arc<DashMap<Uuid, HashMap<String, TargetState>>>,
+}
+
+impl Resyncer {
+    pub fn new(db: SqlitePool, data_root: PathBuf) -> Self {
+        Self {
+            db,
+            data_root,
+            stores: Arc::new(DashMap::new()),
+            locks: Arc::new(DashMap::new()),
+            refmaps: Arc::new(DashMap::new()),
+        }
+    }
+
+    fn store_root(&self, wid: Uuid) -> PathBuf {
+        self.data_root
+            .join("workspaces")
+            .join(wid.to_string())
+            .join("knowledge-index")
+    }
+
+    fn store_for(&self, wid: Uuid) -> anyhow::Result<SharedStore> {
+        use dashmap::mapref::entry::Entry;
+        match self.stores.entry(wid) {
+            Entry::Occupied(o) => Ok(o.get().clone()),
+            Entry::Vacant(v) => {
+                let store = Store::new(self.store_root(wid))?;
+                let shared = Arc::new(RwLock::new(store));
+                v.insert(shared.clone());
+                Ok(shared)
+            }
+        }
+    }
+
+    fn lock_for(&self, wid: Uuid) -> Arc<Mutex<()>> {
+        self.locks
+            .entry(wid)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    /// Drop the cached [`Store`], lock, and per-target memo for a torn-down
+    /// workspace. Takes the per-workspace lock first so it can't interleave with
+    /// an in-flight reconcile whose tail would resurrect the memo.
+    pub async fn forget(&self, wid: Uuid) {
+        let lock = self.lock_for(wid);
+        let _guard = lock.lock().await;
+        self.stores.remove(&wid);
+        self.locks.remove(&wid);
+        self.refmaps.remove(&wid);
+    }
+
+    /// Spawn a background resync, logging any failure.
+    pub fn spawn_resync(&self, wid: Uuid) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = this.reconcile(wid).await {
+                tracing::warn!(%wid, "knowledge resync failed: {e:#}");
+            }
+        });
+    }
+
+    /// Reconcile `wid`'s [`Store`] with its `/files/knowledge` references. Ingest
+    /// referenced targets in byte-bounded batches, then purge documents whose ref
+    /// is gone. Serialized per workspace.
+    pub async fn reconcile(&self, wid: Uuid) -> anyhow::Result<()> {
+        let lock = self.lock_for(wid);
+        let _guard = lock.lock().await;
+
+        let config = build_workspace_vfs(&self.db, wid).await?;
+        let fs = workspace_fs(&self.data_root, wid, config)?;
+
+        let targets = collect_targets(&fs, MAX_FILE_BYTES).await?;
+        let member_count = targets.len();
+        if member_count == 0 && !self.store_root(wid).join("index").exists() {
+            return Ok(());
+        }
+
+        let store = self.store_for(wid)?;
+        let mut store = store.write().await;
+
+        let prev = self.refmaps.get(&wid).map(|m| m.clone()).unwrap_or_default();
+
+        // Read each target (remembering its content-hash id, or that it failed)
+        // and ingest readable bytes in byte-bounded batches.
+        let mut succeeded: HashSet<Uuid> = HashSet::new();
+        let mut reads: Vec<(String, Option<Uuid>)> = Vec::new();
+        let mut batch: Vec<(Vec<u8>, FileType)> = Vec::new();
+        let mut batch_bytes = 0usize;
+        for (path, ft) in targets {
+            match read_all(&fs, &path).await {
+                Ok(bytes) => {
+                    let id = Uuid::new_v5(&Uuid::NAMESPACE_OID, &bytes);
+                    reads.push((path, Some(id)));
+                    if !batch.is_empty() && batch_bytes + bytes.len() > BATCH_BUDGET_BYTES {
+                        ingest_batch(&mut store, std::mem::take(&mut batch), wid, &mut succeeded)
+                            .await?;
+                        batch_bytes = 0;
+                    }
+                    batch_bytes += bytes.len();
+                    batch.push((bytes, ft));
+                }
+                Err(e) => {
+                    tracing::warn!(%wid, "unreadable target {path}: {e:?}");
+                    reads.push((path, None));
+                }
+            }
+        }
+        if !batch.is_empty() {
+            ingest_batch(&mut store, batch, wid, &mut succeeded).await?;
+        }
+
+        let (next, protected) = build_keepset(&prev, &reads, &succeeded);
+        self.refmaps.insert(wid, next);
+
+        // Purge only docs whose ref is gone — never docs that merely failed to
+        // read/ingest this cycle (protected via the memo above).
+        let stale: Vec<Uuid> = store
+            .list(false, 0, u32::MAX)?
+            .into_iter()
+            .filter_map(|d| Uuid::parse_str(&d.id).ok())
+            .filter(|id| !protected.contains(id))
+            .collect();
+        if !stale.is_empty() {
+            let purged = store.purge_many(stale);
+            for f in &purged.failed {
+                tracing::warn!(%wid, id = %f.id, "knowledge purge failed: {}", f.error);
+            }
+        }
+        store.compact()?;
+        Ok(())
+    }
+}
+
+/// Build the new per-target memo and the purge keep-set from this cycle's scan
+/// (`reads`: path → content-hash id read, or `None` on read failure) and the ids
+/// `succeeded` confirms are in the store. A still-referenced target that fails to
+/// read is protected via its remembered `last_indexed_id`; a removed ref is
+/// absent from `reads`, so its id isn't kept and is purged.
+fn build_keepset(
+    prev: &HashMap<String, TargetState>,
+    reads: &[(String, Option<Uuid>)],
+    succeeded: &HashSet<Uuid>,
+) -> (HashMap<String, TargetState>, HashSet<Uuid>) {
+    let mut next = HashMap::new();
+    let mut protected = HashSet::new();
+    for (path, read_id) in reads {
+        let prior_id = prev.get(path).and_then(|s| s.last_indexed_id);
+        let state = match read_id {
+            Some(id) if succeeded.contains(id) => {
+                protected.insert(*id);
+                TargetState {
+                    last_indexed_id: Some(*id),
+                    outcome: Outcome::Indexed,
+                }
+            }
+            Some(_) => {
+                if let Some(id) = prior_id {
+                    protected.insert(id);
+                }
+                TargetState {
+                    last_indexed_id: prior_id,
+                    outcome: Outcome::IngestFailed,
+                }
+            }
+            None => {
+                if let Some(id) = prior_id {
+                    protected.insert(id);
+                }
+                TargetState {
+                    last_indexed_id: prior_id,
+                    outcome: Outcome::ReadFailed,
+                }
+            }
+        };
+        next.insert(path.clone(), state);
+    }
+    (next, protected)
+}
+
+/// Ingest one batch, folding confirmed ids into `succeeded`; per-item failures
+/// are logged, not fatal.
+async fn ingest_batch(
+    store: &mut Store,
+    batch: Vec<(Vec<u8>, FileType)>,
+    wid: Uuid,
+    succeeded: &mut HashSet<Uuid>,
+) -> anyhow::Result<()> {
+    let result = store.ingest_many(batch, PdfEngine::default()).await?;
+    for f in &result.failed {
+        tracing::warn!(%wid, "knowledge ingest failed: {}", f.error);
+    }
+    succeeded.extend(result.succeeded);
+    Ok(())
+}
+
+/// Read an entire file into memory via the unified tree.
+async fn read_all(fs: &WorkspaceFs, path: &str) -> FsResult<Vec<u8>> {
+    let mut file = fs
+        .open(
+            path,
+            OpenOptions {
+                read: true,
+                ..Default::default()
+            },
+        )
+        .await?;
+    let mut out = Vec::new();
+    loop {
+        let chunk = file.read_bytes(READ_CHUNK).await?;
+        if chunk.is_empty() {
+            break;
+        }
+        out.extend_from_slice(&chunk);
+    }
+    Ok(out)
+}
+
+/// Walk `/files/knowledge`, resolve each `*.ref` to its target(s), and return the
+/// indexable files' paths + types — without reading their bytes.
+async fn collect_targets(
+    fs: &WorkspaceFs,
+    max_file_bytes: u64,
+) -> anyhow::Result<Vec<(String, FileType)>> {
+    let mut out = Vec::new();
+    let mut stream = match fs.read_dir(KNOWLEDGE_DIR).await {
+        Ok(s) => s,
+        Err(FsError::NotFound) => return Ok(out),
+        Err(e) => anyhow::bail!("read {KNOWLEDGE_DIR}: {e:?}"),
+    };
+    while let Some(entry) = stream.next().await {
+        let entry = entry.map_err(|e| anyhow::anyhow!("read {KNOWLEDGE_DIR}: {e:?}"))?;
+        let name = String::from_utf8_lossy(&entry.name()).into_owned();
+        if !name.ends_with(REF_SUFFIX) {
+            continue;
+        }
+        let ref_path = format!("{KNOWLEDGE_DIR}/{name}");
+        let bytes = match read_all(fs, &ref_path).await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("skipping unreadable reference {ref_path}: {e:?}");
+                continue;
+            }
+        };
+        let target = match serde_json::from_slice::<KnowledgeRef>(&bytes) {
+            Ok(r) => r.path,
+            Err(e) => {
+                tracing::warn!("skipping malformed reference {ref_path}: {e}");
+                continue;
+            }
+        };
+        if !is_safe_target(&target) || is_under_knowledge(&target) {
+            tracing::warn!("skipping unsafe/self reference target {target}");
+            continue;
+        }
+        add_target(fs, &target, max_file_bytes, &mut out).await?;
+    }
+    // A directory ref overlapping a file ref (or two refs to the same target) can
+    // enumerate the same path twice; keep the first so a path is indexed once.
+    let mut seen = HashSet::new();
+    out.retain(|(path, _)| seen.insert(path.clone()));
+    Ok(out)
+}
+
+/// Enumerate a target into `out`: a file contributes itself, a directory its
+/// indexable descendants. Oversized and missing targets are skipped.
+async fn add_target(
+    fs: &WorkspaceFs,
+    target: &str,
+    max_file_bytes: u64,
+    out: &mut Vec<(String, FileType)>,
+) -> anyhow::Result<()> {
+    let meta = match fs.metadata(target).await {
+        Ok(m) => m,
+        Err(FsError::NotFound | FsError::Forbidden) => {
+            tracing::warn!("skipping unresolvable target {target}");
+            return Ok(());
+        }
+        Err(e) => anyhow::bail!("stat {target}: {e:?}"),
+    };
+
+    if !meta.is_dir() {
+        if let Some(ft) = FileType::from_path(Path::new(target)) {
+            if meta.len > max_file_bytes {
+                tracing::warn!("skipping oversized target {target} ({} bytes)", meta.len);
+            } else {
+                out.push((target.to_string(), ft));
+            }
+        }
+        return Ok(());
+    }
+
+    let mut stack = vec![target.trim_end_matches('/').to_string()];
+    while let Some(dir) = stack.pop() {
+        let mut stream = fs
+            .read_dir(&dir)
+            .await
+            .map_err(|e| anyhow::anyhow!("read {dir}: {e:?}"))?;
+        while let Some(entry) = stream.next().await {
+            let entry = entry.map_err(|e| anyhow::anyhow!("read {dir}: {e:?}"))?;
+            let name = String::from_utf8_lossy(&entry.name()).into_owned();
+            let child = format!("{dir}/{name}");
+            let is_dir = entry.metadata().map(|s| s.is_dir()).unwrap_or(false);
+            if is_dir {
+                stack.push(child);
+            } else if let Some(ft) = FileType::from_path(Path::new(&name)) {
+                let len = entry.metadata().map(|s| s.len).unwrap_or(0);
+                if len > max_file_bytes {
+                    tracing::warn!("skipping oversized target {child} ({len} bytes)");
+                } else {
+                    out.push((child, ft));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A reference target must be an absolute unified-tree path of normal segments.
+fn is_safe_target(path: &str) -> bool {
+    if !path.starts_with('/') {
+        return false;
+    }
+    let mut any = false;
+    for seg in path.split('/').filter(|s| !s.is_empty()) {
+        any = true;
+        if seg == "." || seg == ".." {
+            return false;
+        }
+    }
+    any
+}
+
+/// True when `path` is `/files/knowledge` or lives under it.
+fn is_under_knowledge(path: &str) -> bool {
+    let p = path.trim_start_matches('/');
+    p == "files/knowledge" || p.starts_with("files/knowledge/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::path::Path;
+
+    use ::workspace::{FsConfig, WorkspaceFs};
+    use uuid::Uuid;
+
+    use super::{
+        KnowledgeRef, Outcome, TargetState, build_keepset, collect_targets, is_safe_target,
+    };
+
+    fn indexed(id: Uuid) -> TargetState {
+        TargetState {
+            last_indexed_id: Some(id),
+            outcome: Outcome::Indexed,
+        }
+    }
+
+    async fn write(root: &Path, rel: &str, body: &[u8]) {
+        let p = root.join(rel);
+        tokio::fs::create_dir_all(p.parent().unwrap()).await.unwrap();
+        tokio::fs::write(p, body).await.unwrap();
+    }
+
+    async fn write_ref(root: &Path, name: &str, target: &str) {
+        let body = KnowledgeRef {
+            path: target.into(),
+        }
+        .to_bytes();
+        write(root, &format!("knowledge/{name}"), &body).await;
+    }
+
+    /// A still-referenced target that fails to read keeps its document (protected
+    /// via its prior id) rather than being purged on a transient blip.
+    #[test]
+    fn transient_read_failure_protects_prior_doc() {
+        let id = Uuid::from_u128(1);
+        let mut prev = HashMap::new();
+        prev.insert("/files/a.md".to_string(), indexed(id));
+        let reads = vec![("/files/a.md".to_string(), None)];
+        let (_next, protected) = build_keepset(&prev, &reads, &HashSet::new());
+        assert!(protected.contains(&id));
+    }
+
+    /// A removed ref (absent from this cycle's reads) is not protected → purged.
+    #[test]
+    fn removed_ref_not_protected() {
+        let id = Uuid::from_u128(2);
+        let mut prev = HashMap::new();
+        prev.insert("/files/gone.md".to_string(), indexed(id));
+        let (_next, protected) = build_keepset(&prev, &[], &HashSet::new());
+        assert!(!protected.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn collects_file_and_dir_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let files = tmp.path();
+        write(files, "docs/a.md", b"AAA").await;
+        write(files, "docs/sub/b.md", b"BBB").await;
+        write(files, "docs/sub/ignore.bin", b"nope").await;
+        write_ref(files, "a.ref", "/files/docs/a.md").await;
+        write_ref(files, "dir.ref", "/files/docs/sub").await;
+        write_ref(files, "missing.ref", "/files/docs/gone.md").await;
+        write_ref(files, "self.ref", "/files/knowledge/a.ref").await;
+
+        let fs = WorkspaceFs::from_config(FsConfig {
+            local_root: Some(files.to_path_buf()),
+            mounts: vec![],
+        })
+        .unwrap();
+        let mut paths: Vec<String> = collect_targets(&fs, u64::MAX)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec!["/files/docs/a.md".to_string(), "/files/docs/sub/b.md".to_string()]
+        );
+    }
+
+    #[test]
+    fn safe_target_rules() {
+        assert!(is_safe_target("/files/a.md"));
+        assert!(!is_safe_target("a.md"));
+        assert!(!is_safe_target("/a/../b"));
+        assert!(!is_safe_target("/"));
+    }
+}

--- a/backend/src/state/mod.rs
+++ b/backend/src/state/mod.rs
@@ -8,11 +8,13 @@ use uuid::Uuid;
 use crate::{auth::JwtConfig, event::EventQueue};
 
 mod agent;
+mod knowledge;
 mod session;
 mod user;
 mod workspace;
 
 pub use agent::*;
+pub use knowledge::*;
 pub use session::*;
 pub use user::*;
 pub use workspace::*;

--- a/backend/src/state/workspace/mod.rs
+++ b/backend/src/state/workspace/mod.rs
@@ -253,14 +253,6 @@ impl WorkspacesState {
     }
 }
 
-/// True when a workspace-relative path lives under `knowledge/`. Classification
-/// is the backend's policy, not the `workspace` crate's.
-fn is_knowledge(rel: &str) -> bool {
-    // Local files live under the `/files` mount, so knowledge files are
-    // `files/knowledge/…` in the unified namespace.
-    rel.trim_start_matches('/').starts_with("files/knowledge/")
-}
-
 /// The change hook attached to every [`WorkspaceFs`] this backend builds: it
 /// runs the `knowledge/` side-processing (today just logging; ingestion/indexing
 /// lands later) and ignores everything else.
@@ -276,7 +268,9 @@ struct KnowledgeHook {
 impl FsHook for KnowledgeHook {
     fn on_change(&self, event: FsEvent<'_>) {
         let touched = match event {
-            FsEvent::Created(p) | FsEvent::Modified(p) | FsEvent::Removed(p) => is_knowledge(p),
+            FsEvent::Created(p) | FsEvent::Modified(p) | FsEvent::Removed(p) => {
+                super::knowledge::is_under_knowledge(p)
+            }
         };
         if touched {
             if let Some(r) = &self.resyncer {

--- a/backend/src/state/workspace/mod.rs
+++ b/backend/src/state/workspace/mod.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use sqlx::{Row as _, SqlitePool, sqlite::SqliteRow};
 use uuid::Uuid;
 
+use super::knowledge::Resyncer;
 use super::{StateError, StateResult, User, parse_ts, parse_uuid};
 
 mod mount;
@@ -78,14 +79,20 @@ pub struct WorkspacesState {
     /// rebuilt each [`Self::get_fs`]. Cloning shares the mounts' `Arc<Resource>`,
     /// so cache hits reuse the same caches. Evicted on mount change or removal.
     fs_cache: Mutex<HashMap<Uuid, WorkspaceFs>>,
+    /// Knowledge resync engine, shared into every [`WorkspaceFs`] this hands out
+    /// (so `/files/knowledge` writes trigger a resync) and reused by the router
+    /// and periodic sweep.
+    resyncer: Resyncer,
 }
 
 impl WorkspacesState {
     pub fn new(db: SqlitePool, data_root: PathBuf) -> Self {
+        let resyncer = Resyncer::new(db.clone(), data_root.clone());
         Self {
             db,
             data_root,
             fs_cache: Mutex::new(HashMap::new()),
+            resyncer,
         }
     }
 
@@ -109,6 +116,21 @@ impl WorkspacesState {
     /// Evict `wid`'s cached [`WorkspaceFs`] so the next [`Self::get_fs`] rebuilds it.
     pub(super) fn invalidate_fs(&self, wid: Uuid) {
         self.fs_cache.lock().unwrap().remove(&wid);
+    }
+
+    /// The workspace knowledge resyncer.
+    pub fn resyncer(&self) -> &Resyncer {
+        &self.resyncer
+    }
+
+    /// Ids of every workspace, for the periodic resync sweep.
+    pub async fn all_ids(&self) -> StateResult<Vec<Uuid>> {
+        let rows = sqlx::query("SELECT id FROM workspaces")
+            .fetch_all(&self.db)
+            .await?;
+        rows.iter()
+            .map(|r| parse_uuid(r.get::<String, _>("id"), "workspaces.id"))
+            .collect()
     }
 
     pub async fn get(&self, id: Uuid) -> StateResult<Option<Workspace>> {
@@ -174,6 +196,8 @@ impl WorkspacesState {
     /// database. Idempotent. Deleting files before the rows means a filesystem
     /// failure aborts before anything is removed from the database.
     pub async fn remove_files(&self, id: Uuid) -> StateResult<()> {
+        // Evict the cached knowledge Store before unlinking its on-disk index.
+        self.resyncer.forget(id).await;
         let dir = self.workspace_dir(id);
         if tokio::fs::try_exists(&dir).await? {
             tokio::fs::remove_dir_all(&dir).await?;
@@ -213,7 +237,7 @@ impl WorkspacesState {
     pub async fn get_fs(&self, wid: Uuid) -> StateResult<WorkspaceFs> {
         // Cached assembly (local `/files` + providers); the hook is per-call.
         let fs = self.fs_for(wid).await?;
-        Ok(fs.with_hook(knowledge_hook(wid)))
+        Ok(fs.with_hook(knowledge_hook(wid, Some(self.resyncer.clone()))))
     }
 
     /// Absolute on-disk path of workspace `wid`'s file root
@@ -244,28 +268,26 @@ struct KnowledgeHook {
     /// The workspace this hook is bound to — the crate is workspace-agnostic, so
     /// the backend carries the DB identity here rather than in `WorkspaceFs`.
     wid: Uuid,
+    /// Resync trigger. `None` for the guest-serving handle (the session run loop
+    /// builds it without one), so guest writes don't auto-resync.
+    resyncer: Option<Resyncer>,
 }
 
 impl FsHook for KnowledgeHook {
     fn on_change(&self, event: FsEvent<'_>) {
-        let wid = self.wid;
-        match event {
-            FsEvent::Created(p) if is_knowledge(p) => {
-                tracing::info!("insert_knowledge (workspace={wid}, path={p})");
+        let touched = match event {
+            FsEvent::Created(p) | FsEvent::Modified(p) | FsEvent::Removed(p) => is_knowledge(p),
+        };
+        if touched {
+            if let Some(r) = &self.resyncer {
+                r.spawn_resync(self.wid);
             }
-            FsEvent::Modified(p) if is_knowledge(p) => {
-                tracing::info!("update_knowledge (workspace={wid}, path={p})");
-            }
-            FsEvent::Removed(p) if is_knowledge(p) => {
-                tracing::info!("remove_knowledge (workspace={wid}, path={p})");
-            }
-            _ => {}
         }
     }
 }
 
-fn knowledge_hook(wid: Uuid) -> Option<Arc<dyn FsHook>> {
-    Some(Arc::new(KnowledgeHook { wid }))
+fn knowledge_hook(wid: Uuid, resyncer: Option<Resyncer>) -> Option<Arc<dyn FsHook>> {
+    Some(Arc::new(KnowledgeHook { wid, resyncer }))
 }
 
 /// Build a [`WorkspaceFs`] for `wid` rooted under `data_root`, with `vfs`
@@ -290,7 +312,7 @@ pub(crate) fn workspace_fs(
     config.local_root = Some(root);
     let fs = WorkspaceFs::from_config(config)
         .map_err(|e| StateError::InvalidData(format!("workspace fs: {e}")))?;
-    Ok(fs.with_hook(knowledge_hook(wid)))
+    Ok(fs.with_hook(knowledge_hook(wid, None)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

Enables the backend to access workspace sources — local files and mounted remote sources (S3/Notion) — for indexing, and adds the structures and APIs for the app to designate which targets get indexed.

Index membership is a set of **references** under `/knowledge`: each `*.ref` file holds the unified-tree path of a target (local file, mounted object, or directory), and one scanner reads them all through `WorkspaceFs` — making the indexer a **third client** of the unified tree alongside the WebDAV (browser) and in-guest FUSE (sandbox) frontends.

Indexing delegates to the existing `agent_k::knowledge_base::Store`. Because document ids are a content hash, change detection falls out of a resync/reconcile — **no fingerprint table, no schema change.**

## Reference format (Alternative suggestions are welcome.!)

A small JSON file under `/knowledge`, named `<slug>-<nanoid>.ref`:

```jsonc
// /knowledge/q3-report-a1B2c3.ref
{ "path": "/notion/reports/q3.pdf" }
```

`path` is a unified-tree absolute path — local (`/docs/a.md`) or mounted (`/notion/…`) — pointing at a file or a directory.
A reference whose target points into /knowledge is skipped, so the reference files never index themselves (and a directory target can't recurse into `/knowledge`).

### Why references (not a folder of files)

- Mounted external items are read-only and live in the provider; they can't physically be dropped into a `knowledge/` folder. A reference expresses "index this" as a path, so local and external are handled identically.
- Reading at the unified `WorkspaceFs` level (not the raw `Vfs`/`Resource` layer) means a single scanner covers both local disk and mounts.
- No per-item state to persist. Content-hash document ids mean identity comes from the bytes, and each resync reconciles the referenced set against `Store.list()` — so the `Store` is the sole source of index state, with no `(path → fingerprint)` table.

## Changes

**Core (`state/workspace/`)**
- `resync.rs` (new) — `Resyncer`: per-workspace `Store` cache + resync lock; `resync()` reconcile (scan `/knowledge` refs → resolve targets via `WorkspaceFs` → `ingest_many` → purge unreferenced → `compact`); `collect_referenced()`/`add_target()` scanner; `KnowledgeRef`.
- `fs.rs` — `WorkspaceFs` gains a `read_to_end` helper and an injected `Resyncer`; `/knowledge` mutations (write/flush, rename, copy, delete) now spawn a resync, replacing the former logging stubs.
- `mod.rs` — `WorkspacesState` owns the `Resyncer`, injects it into every `get_fs`, and exposes `resyncer()` / `all_ids()`.

**HTTP + scheduling**
- `router/knowledge.rs` (new) — browser-facing membership API:
  - `GET/POST /workspaces/{wid}/knowledge/refs` — list / create a reference (validates the target exists, local or mounted)
  - `DELETE /workspaces/{wid}/knowledge/refs/{name}`
  - `POST /workspaces/{wid}/knowledge/resync` — force a resync
- `main.rs` — optional periodic resync loop (`AGENT_K_INDEX_INTERVAL_SECS`, disabled by default) to pick up provider-side changes to external targets, which produce no local write event.

## Testing

- `resync::tests` — scanner gathers local files, a directory's indexable descendants, and a mounted object while skipping non-`.ref` files, self-references, missing targets, and unsupported extensions; absent `/knowledge` yields an empty set.
- Full suite green (`cargo test -p agent-k-backend`); no clippy warnings in changed files.

## Notes

- **Change detection is automatic:** unchanged bytes → same content-hash id → `ingest` is a no-op; changed bytes → new id, old id purged as stale. Resyncs are serialized per workspace.
- **Purge safety valve:** a non-empty member set that ingests *nothing* (e.g. metadata provider unavailable) skips the purge, so a healthy index isn't wiped.
- **Ingest needs an ailoy provider** (title/purpose via ailoy's process-global default), which `backend_v2` doesn't initialize yet — so ingest currently fails at runtime (the safety valve prevents index loss). Wiring it is a prerequisite for this to actually index.
- **`/knowledge` is references-only:** dropping a real file there won't index it; create a reference.
- **Planned follow-ups:** skip re-reading unchanged large external targets via etag/version; isolate each source in its own `Store`.