### PR TITLE
feat(session): titles, inline rename/delete, activity ordering, message dates

### DIFF
--- a/app_v2/src/api/__tests__/messages.test.ts
+++ b/app_v2/src/api/__tests__/messages.test.ts
@@ -89,6 +89,21 @@ describe('streamSessionMessages', () => {
     expect(results[0]).toEqual({ kind: 'run', payload });
   });
 
+  it('maps title frames correctly', async () => {
+    vi.mocked(streamSse).mockReturnValue(makeStream([
+      { event: 'title', data: JSON.stringify({ title: 'My Chat' }) },
+    ]));
+
+    const ctrl = new AbortController();
+    const results = [];
+    for await (const ev of streamSessionMessages('s1', undefined, ctrl.signal)) {
+      results.push(ev);
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({ kind: 'title', title: 'My Chat' });
+  });
+
   it('ignores unknown event names', async () => {
     vi.mocked(streamSse).mockReturnValue(makeStream([
       { event: 'unknown_type', data: '{"foo":"bar"}' },

--- a/app_v2/src/api/__tests__/messages.test.ts
+++ b/app_v2/src/api/__tests__/messages.test.ts
@@ -58,7 +58,7 @@ describe('streamSessionMessages', () => {
   }
 
   it('maps message frames correctly', async () => {
-    const item: MessageItem = { seq: 1, message: { role: 'user', contents: [{ type: 'text', text: 'hi' }] } };
+    const item: MessageItem = { seq: 1, message: { role: 'user', contents: [{ type: 'text', text: 'hi' }] }, created_at: '2026-01-01T00:00:00Z' };
     vi.mocked(streamSse).mockReturnValue(makeStream([
       { event: 'message', data: JSON.stringify(item) },
     ]));

--- a/app_v2/src/api/messages.ts
+++ b/app_v2/src/api/messages.ts
@@ -1,5 +1,11 @@
 import { ApiError, request, streamSse } from './client';
-import type { MessageItem, RunEventPayload } from './types';
+import type { MessageItem, RunEventPayload, TitleEventPayload } from './types';
+
+/// One decoded frame from the session SSE stream.
+export type StreamEvent =
+  | { kind: 'message'; item: MessageItem }
+  | { kind: 'run'; payload: RunEventPayload }
+  | { kind: 'title'; title: string };
 
 export async function listMessages(sessionId: string): Promise<MessageItem[]> {
   const result = await request<{ items: MessageItem[] }>(`/sessions/${sessionId}/messages`);
@@ -27,22 +33,21 @@ export async function* streamSessionMessages(
   sessionId: string,
   lastSeq: number | undefined,
   signal: AbortSignal,
-): AsyncGenerator<{ kind: 'message'; item: MessageItem } | { kind: 'run'; payload: RunEventPayload }> {
+): AsyncGenerator<StreamEvent> {
   const qs = lastSeq !== undefined ? `?last_seq=${lastSeq}` : '';
   const path = `/sessions/${sessionId}/messages/stream${qs}`;
 
   for await (const ev of streamSse(path, { method: 'GET', signal })) {
     // Parse inside try so a bad frame is skipped; yield outside so an
     // exception thrown into the generator by the consumer is not swallowed.
-    let out:
-      | { kind: 'message'; item: MessageItem }
-      | { kind: 'run'; payload: RunEventPayload }
-      | null = null;
+    let out: StreamEvent | null = null;
     try {
       if (ev.event === 'message') {
         out = { kind: 'message', item: JSON.parse(ev.data) as MessageItem };
       } else if (ev.event === 'run') {
         out = { kind: 'run', payload: JSON.parse(ev.data) as RunEventPayload };
+      } else if (ev.event === 'title') {
+        out = { kind: 'title', title: (JSON.parse(ev.data) as TitleEventPayload).title };
       }
       // Silently ignore unknown event names.
     } catch {

--- a/app_v2/src/api/sessions.ts
+++ b/app_v2/src/api/sessions.ts
@@ -2,6 +2,9 @@ import { request } from './client';
 import { getWorkspaceId } from '@/stores/workspace';
 import type { SessionResponse, AgentType } from './types';
 
+/** Max length for a session title, matching the backend clamp (auto + manual). */
+export const SESSION_TITLE_MAX_LEN = 60;
+
 export async function listSessions(): Promise<SessionResponse[]> {
   const result = await request<{ items: SessionResponse[] }>('/sessions');
   return result.items;

--- a/app_v2/src/api/sessions.ts
+++ b/app_v2/src/api/sessions.ts
@@ -26,3 +26,11 @@ export async function createSession(input: {
 export async function deleteSession(id: string): Promise<void> {
   await request<void>(`/sessions/${id}`, { method: 'DELETE' });
 }
+
+/** Rename a session. The server rejects an empty/whitespace-only title. */
+export async function updateSessionTitle(id: string, title: string): Promise<SessionResponse> {
+  return request<SessionResponse>(`/sessions/${id}`, {
+    method: 'PATCH',
+    body: { title },
+  });
+}

--- a/app_v2/src/api/types.ts
+++ b/app_v2/src/api/types.ts
@@ -61,6 +61,8 @@ export type AgentType = 'coworker' | 'deep_research';
 export interface MessageItem {
   seq: number;
   message: AiloyMessage;
+  /** RFC3339 timestamp of when the message was persisted. */
+  created_at: string;
 }
 
 export type RunEventPayload =

--- a/app_v2/src/api/types.ts
+++ b/app_v2/src/api/types.ts
@@ -66,3 +66,9 @@ export interface MessageItem {
 export type RunEventPayload =
   | { run: 'started' | 'finished' | 'idle' }
   | { run: 'error'; message: string };
+
+/// `title` SSE frame: an auto-generated session title, published once when an
+/// untitled session's title is first persisted (concurrent with its run).
+export interface TitleEventPayload {
+  title: string;
+}

--- a/app_v2/src/components/SessionTitle.tsx
+++ b/app_v2/src/components/SessionTitle.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 // Per-character reveal speed and the ceiling on how long the shimmer runs
 // before giving up and showing the fallback (a recent session whose generation
@@ -49,6 +50,7 @@ export function SessionTitle({
   skeletonClassName,
   fallback,
 }: SessionTitleProps) {
+  const { t } = useTranslation('session');
   const pending = isTitlePending(title, createdAt);
   const [shown, setShown] = useState(title ?? '');
   const [expired, setExpired] = useState(false);
@@ -100,7 +102,7 @@ export function SessionTitle({
       <span
         className={`cw-title-skeleton${skeletonClassName ? ` ${skeletonClassName}` : ''}`}
         role="status"
-        aria-label="제목 생성 중"
+        aria-label={t('ui.title_generating')}
       />
     );
   }

--- a/app_v2/src/components/SessionTitle.tsx
+++ b/app_v2/src/components/SessionTitle.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Per-character reveal speed and the ceiling on how long the shimmer runs
+// before giving up and showing the fallback (a recent session whose generation
+// hangs must not shimmer forever).
+const TYPE_MS = 32;
+const SHIMMER_TIMEOUT_MS = 15_000;
+// A title is generated on a new session's first run; only sessions created
+// within this window are still plausibly "generating". Older untitled sessions
+// (predating the feature, or a failed generation) show their fallback at once
+// instead of a misleading shimmer.
+const PENDING_WINDOW_MS = 2 * 60_000;
+
+/** Whether an untitled session is plausibly still generating its title. */
+export function isTitlePending(title: string | null, createdAt?: string): boolean {
+  if (title != null) return false;
+  if (createdAt == null) return true; // unknown yet — assume a title may be incoming
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) return true;
+  return Date.now() - created < PENDING_WINDOW_MS;
+}
+
+interface SessionTitleProps {
+  /** The session's title; `null` while it is still being generated. */
+  title: string | null;
+  /** Session creation time (RFC3339); gates whether a null title shimmers. */
+  createdAt?: string;
+  /** Class for the text span (e.g. `cw-chat-title`, `cw-session-title`). */
+  className?: string;
+  /** Extra class on the shimmer skeleton for context-specific sizing. */
+  skeletonClassName?: string;
+  /** Shown when the title is absent and not (or no longer) pending. */
+  fallback?: string;
+}
+
+/**
+ * Renders a session title with two flourishes:
+ *   - a shimmer skeleton while the auto-title is being generated (`title` null),
+ *   - a typewriter reveal when the title *first* arrives (a `null → value`
+ *     transition observed while mounted — i.e. a fresh generation).
+ *
+ * A title that is already present at mount (revisiting an existing session) or
+ * a viewer who prefers reduced motion gets the text instantly, with no typing.
+ */
+export function SessionTitle({
+  title,
+  createdAt,
+  className,
+  skeletonClassName,
+  fallback,
+}: SessionTitleProps) {
+  const pending = isTitlePending(title, createdAt);
+  const [shown, setShown] = useState(title ?? '');
+  const [expired, setExpired] = useState(false);
+  const prevTitle = useRef(title);
+
+  useEffect(() => {
+    const prev = prevTitle.current;
+    prevTitle.current = title;
+
+    if (title == null) {
+      setShown('');
+      setExpired(false);
+      // Only arm the backstop while we believe a title is coming; a
+      // non-pending (legacy) session renders its fallback immediately.
+      if (!pending) return;
+      const t = setTimeout(() => setExpired(true), SHIMMER_TIMEOUT_MS);
+      return () => clearTimeout(t);
+    }
+
+    setExpired(false);
+    const freshlyGenerated = prev == null; // null → value: the title just became known
+    const reduceMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (!freshlyGenerated || reduceMotion) {
+      setShown(title);
+      return;
+    }
+
+    // Typewriter reveal.
+    setShown('');
+    let i = 0;
+    const id = setInterval(() => {
+      i += 1;
+      setShown(title.slice(0, i));
+      if (i >= title.length) clearInterval(id);
+    }, TYPE_MS);
+    return () => clearInterval(id);
+  }, [title, pending]);
+
+  if (title == null) {
+    // Shimmer only while a title is plausibly incoming; otherwise (legacy
+    // session, or generation gave up) show the fallback with no shimmer/swap.
+    if (!pending || expired) {
+      return <span className={className}>{fallback}</span>;
+    }
+    return (
+      <span
+        className={`cw-title-skeleton${skeletonClassName ? ` ${skeletonClassName}` : ''}`}
+        role="status"
+        aria-label="제목 생성 중"
+      />
+    );
+  }
+
+  const typing = shown.length < title.length;
+  return (
+    <span className={className} aria-label={title}>
+      {shown}
+      {typing && <span className="cw-title-caret" aria-hidden="true" />}
+    </span>
+  );
+}

--- a/app_v2/src/components/__tests__/SessionTitle.test.tsx
+++ b/app_v2/src/components/__tests__/SessionTitle.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { SessionTitle, isTitlePending } from '@/components/SessionTitle';
+
+const recentIso = () => new Date(Date.now() - 1_000).toISOString();
+const oldIso = () => new Date(Date.now() - 10 * 60_000).toISOString();
+
+describe('isTitlePending', () => {
+  it('is false once a title exists', () => {
+    expect(isTitlePending('Some title', recentIso())).toBe(false);
+  });
+
+  it('is true for a null title with no createdAt (unknown yet)', () => {
+    expect(isTitlePending(null, undefined)).toBe(true);
+  });
+
+  it('is true for a null title on a recently created session', () => {
+    expect(isTitlePending(null, recentIso())).toBe(true);
+  });
+
+  it('is false for a null title on an old session (legacy / gave up)', () => {
+    expect(isTitlePending(null, oldIso())).toBe(false);
+  });
+
+  it('is true for an unparseable createdAt', () => {
+    expect(isTitlePending(null, 'not-a-date')).toBe(true);
+  });
+});
+
+describe('SessionTitle rendering', () => {
+  it('shows the title text when present', () => {
+    render(<SessionTitle title="Walking benefits" createdAt={recentIso()} fallback="abcd1234" />);
+    expect(screen.getByText('Walking benefits')).toBeTruthy();
+  });
+
+  it('shows a shimmer skeleton while a recent session is still generating', () => {
+    render(<SessionTitle title={null} createdAt={recentIso()} fallback="abcd1234" />);
+    // The skeleton carries role="status"; no fallback text is shown.
+    expect(screen.getByRole('status')).toBeTruthy();
+    expect(screen.queryByText('abcd1234')).toBeNull();
+  });
+
+  it('shows the fallback (not a skeleton) for an old untitled session', () => {
+    render(<SessionTitle title={null} createdAt={oldIso()} fallback="abcd1234" />);
+    expect(screen.getByText('abcd1234')).toBeTruthy();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('shows an already-present title instantly (no typewriter on mount)', () => {
+    render(<SessionTitle title="Instant title" createdAt={oldIso()} fallback="abcd1234" />);
+    // Full text is present on the first paint — not revealed one char at a time.
+    expect(screen.getByText('Instant title')).toBeTruthy();
+  });
+});
+
+describe('SessionTitle typewriter on first arrival', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('reveals the title progressively when it transitions from null to a value', () => {
+    const createdAt = recentIso();
+    const { rerender } = render(
+      <SessionTitle title={null} createdAt={createdAt} fallback="abcd1234" />,
+    );
+    // Generating → skeleton, no final text yet.
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    // Title arrives: null → value transition triggers the typewriter.
+    act(() => {
+      rerender(<SessionTitle title="Hello" createdAt={createdAt} fallback="abcd1234" />);
+    });
+    // Mid-reveal: not yet the full string.
+    act(() => {
+      vi.advanceTimersByTime(32);
+    });
+    expect(screen.queryByText('Hello')).toBeNull();
+
+    // After enough ticks for every character, the full title is shown.
+    act(() => {
+      vi.advanceTimersByTime(32 * 'Hello'.length);
+    });
+    expect(screen.getByText('Hello')).toBeTruthy();
+  });
+});

--- a/app_v2/src/components/chat/Composer.tsx
+++ b/app_v2/src/components/chat/Composer.tsx
@@ -15,7 +15,8 @@ export function Composer({ running, sessionId, onSend }: ComposerProps) {
   const canSend = value.trim().length > 0 && !running;
 
   function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // Skip Enter mid-IME-composition — it commits the composed char, not submit.
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       void submit();
     }

--- a/app_v2/src/components/chat/MessageList.tsx
+++ b/app_v2/src/components/chat/MessageList.tsx
@@ -14,7 +14,7 @@ export function MessageList({ entries, running }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   // Subscribe to language changes so timestamps re-render on toggle (not just
   // after a refresh); the value is passed into the date formatters below.
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation('session');
   const lng = i18n.language;
 
   // Auto-scroll to bottom when new entries arrive or the run status toggles
@@ -65,7 +65,7 @@ export function MessageList({ entries, running }: MessageListProps) {
         {running && (
           <div className="cw-typing" aria-live="polite">
             <span className="cw-status-dot cw-status-dot--connected" aria-hidden="true" />
-            <span className="cw-status-running">AI is responding…</span>
+            <span className="cw-status-running">{t('ui.ai_responding')}</span>
           </div>
         )}
         <div ref={bottomRef} />

--- a/app_v2/src/components/chat/MessageList.tsx
+++ b/app_v2/src/components/chat/MessageList.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { ToolCallDetails } from './ToolCallDetails';
 import type { TranscriptEntry } from '@/lib/transcript';
+import { formatMessageDate, formatMessageDateFull } from '@/lib/formatMessageDate';
 
 interface MessageListProps {
   entries: TranscriptEntry[];
@@ -10,6 +12,10 @@ interface MessageListProps {
 
 export function MessageList({ entries, running }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  // Subscribe to language changes so timestamps re-render on toggle (not just
+  // after a refresh); the value is passed into the date formatters below.
+  const { i18n } = useTranslation();
+  const lng = i18n.language;
 
   // Auto-scroll to bottom when new entries arrive or the run status toggles
   // (so the "responding" indicator is scrolled into view when it appears).
@@ -40,6 +46,16 @@ export function MessageList({ entries, running }: MessageListProps) {
                     <ToolCallDetails key={tc.id} tc={tc} isStreaming={running && idx === entries.length - 1} />
                   ))}
                 </div>
+              )}
+              {/* Timestamp revealed on hover of the message. */}
+              {entry.createdAt && (
+                <time
+                  className="cw-message-time"
+                  dateTime={entry.createdAt}
+                  title={formatMessageDateFull(entry.createdAt, lng)}
+                >
+                  {formatMessageDate(entry.createdAt, lng)}
+                </time>
               )}
             </div>
           </div>

--- a/app_v2/src/components/chat/MessageList.tsx
+++ b/app_v2/src/components/chat/MessageList.tsx
@@ -11,10 +11,11 @@ interface MessageListProps {
 export function MessageList({ entries, running }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // Auto-scroll to bottom when new entries arrive.
+  // Auto-scroll to bottom when new entries arrive or the run status toggles
+  // (so the "responding" indicator is scrolled into view when it appears).
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [entries.length]);
+  }, [entries.length, running]);
 
   return (
     <div className="cw-messages-scroll">
@@ -43,6 +44,14 @@ export function MessageList({ entries, running }: MessageListProps) {
             </div>
           </div>
         ))}
+        {/* Typing indicator below the last message — only while a run is in
+            flight, so it (and its dot) disappear the moment the run ends. */}
+        {running && (
+          <div className="cw-typing" aria-live="polite">
+            <span className="cw-status-dot cw-status-dot--connected" aria-hidden="true" />
+            <span className="cw-status-running">AI is responding…</span>
+          </div>
+        )}
         <div ref={bottomRef} />
       </div>
     </div>

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -43,6 +43,16 @@ function SessionRow({
   const [deletePending, setDeletePending] = useState(false);
   const [removing, setRemoving] = useState(false);
   const menuRef = useRef<HTMLSpanElement>(null);
+  const removeTimerRef = useRef<number | null>(null);
+
+  // Cancel the pending post-animation removal if the row unmounts first (e.g. a
+  // concurrent ['sessions'] refetch drops it), so the timer can't fire a stale
+  // cache write afterwards.
+  useEffect(() => {
+    return () => {
+      if (removeTimerRef.current !== null) window.clearTimeout(removeTimerRef.current);
+    };
+  }, []);
 
   // Close the ⋯ menu on any click outside it (standard dropdown dismissal).
   useEffect(() => {
@@ -106,11 +116,13 @@ function SessionRow({
     setRemoving(true);
     // If the open session was the one deleted, leave its (now-404) route.
     if (isActive) void navigate({ to: '/' });
-    window.setTimeout(() => {
+    // Drop the row from the cache once the exit animation has played. The
+    // server delete already succeeded and this local filter reflects it, so no
+    // refetch is needed. Tracked in a ref so an early unmount can cancel it.
+    removeTimerRef.current = window.setTimeout(() => {
       qc.setQueryData<SessionResponse[]>(['sessions'], (list) =>
         list?.filter((s) => s.id !== session.id),
       );
-      void qc.invalidateQueries({ queryKey: ['sessions'] });
     }, REMOVE_ANIM_MS);
   }
 

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -9,10 +9,11 @@ import { useState, useRef, type ReactNode } from 'react';
 import { Link, useNavigate, useParams, useRouterState } from '@tanstack/react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { listSessions, updateSessionTitle, SESSION_TITLE_MAX_LEN } from '@/api/sessions';
+import { listSessions, updateSessionTitle, deleteSession, SESSION_TITLE_MAX_LEN } from '@/api/sessions';
 import type { SessionResponse } from '@/api/types';
 import { LanguageToggle } from '@/components/LanguageToggle';
 import { SessionTitle } from '@/components/SessionTitle';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { Icon } from '@/components/Icon';
 
 /** One Recents row: opens the session on click, with a hover ⋯ menu that
@@ -29,10 +30,13 @@ function SessionRow({
 }) {
   const { t } = useTranslation('common');
   const qc = useQueryClient();
+  const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
   const cancelEditRef = useRef(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deletePending, setDeletePending] = useState(false);
 
   function patchTitle(next: string | null) {
     qc.setQueryData<SessionResponse[]>(['sessions'], (list) =>
@@ -61,6 +65,29 @@ function SessionRow({
       await updateSessionTitle(session.id, next);
     } catch {
       patchTitle(prev); // revert on failure
+    }
+  }
+
+  function openDelete() {
+    setMenuOpen(false);
+    setDeleting(true);
+  }
+
+  async function confirmDelete() {
+    setDeletePending(true);
+    try {
+      await deleteSession(session.id);
+      // Drop it from the cached list immediately, then reconcile from the server.
+      qc.setQueryData<SessionResponse[]>(['sessions'], (list) =>
+        list?.filter((s) => s.id !== session.id),
+      );
+      void qc.invalidateQueries({ queryKey: ['sessions'] });
+      setDeleting(false);
+      setDeletePending(false);
+      // If the open session was the one deleted, leave its (now-404) route.
+      if (isActive) void navigate({ to: '/' });
+    } catch {
+      setDeletePending(false); // keep the dialog open so the user can retry
     }
   }
 
@@ -99,71 +126,99 @@ function SessionRow({
   }
 
   return (
-    <div
-      className={`cw-session-row${isActive ? ' is-active' : ''}`}
-      role="button"
-      tabIndex={0}
-      onClick={onOpen}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      title={session.title ?? undefined}
-    >
-      <span className="cw-pocket"><Icon name="message-square" size={12} /></span>
-      <SessionTitle
-        title={session.title}
-        createdAt={session.created_at}
-        className="cw-session-title"
-        skeletonClassName="cw-title-skeleton--row"
-        fallback={session.id.slice(0, 8)}
-      />
-      <span className="cw-session-menu-wrap">
-        <button
-          type="button"
-          className="cw-session-menu-btn"
-          aria-label={t('nav.more', 'More')}
-          aria-haspopup="menu"
-          aria-expanded={menuOpen}
-          onClick={(e) => {
-            e.stopPropagation();
-            setMenuOpen((v) => !v);
-          }}
-        >
-          <Icon name="more" size={14} />
-        </button>
-        {menuOpen && (
-          <>
-            {/* Full-viewport click-away catcher; closes the menu without a
-                document listener and swallows the click so it doesn't open the
-                session. */}
-            <div
-              className="cw-session-menu-overlay"
-              onClick={(e) => {
-                e.stopPropagation();
-                setMenuOpen(false);
-              }}
-            />
-            <div className="cw-session-menu" role="menu">
-              <button
-                type="button"
-                className="cw-session-menu-item"
-                role="menuitem"
+    <>
+      <div
+        className={`cw-session-row${isActive ? ' is-active' : ''}`}
+        role="button"
+        tabIndex={0}
+        onClick={onOpen}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onOpen();
+          }
+        }}
+        title={session.title ?? undefined}
+      >
+        <span className="cw-pocket"><Icon name="message-square" size={12} /></span>
+        <SessionTitle
+          title={session.title}
+          createdAt={session.created_at}
+          className="cw-session-title"
+          skeletonClassName="cw-title-skeleton--row"
+          fallback={session.id.slice(0, 8)}
+        />
+        <span className="cw-session-menu-wrap">
+          <button
+            type="button"
+            className="cw-session-menu-btn"
+            aria-label={t('nav.more', 'More')}
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            onClick={(e) => {
+              e.stopPropagation();
+              setMenuOpen((v) => !v);
+            }}
+          >
+            <Icon name="more" size={14} />
+          </button>
+          {menuOpen && (
+            <>
+              {/* Full-viewport click-away catcher; closes the menu without a
+                  document listener and swallows the click so it doesn't open the
+                  session. */}
+              <div
+                className="cw-session-menu-overlay"
                 onClick={(e) => {
                   e.stopPropagation();
-                  startEdit();
+                  setMenuOpen(false);
                 }}
-              >
-                <Icon name="writing" size={13} />
-                <span>{t('nav.rename', 'Rename')}</span>
-              </button>
-            </div>
-          </>
-        )}
-      </span>
-    </div>
+              />
+              <div className="cw-session-menu" role="menu">
+                <button
+                  type="button"
+                  className="cw-session-menu-item"
+                  role="menuitem"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    startEdit();
+                  }}
+                >
+                  <Icon name="writing" size={13} />
+                  <span>{t('nav.rename', 'Rename')}</span>
+                </button>
+                <button
+                  type="button"
+                  className="cw-session-menu-item cw-session-menu-item--danger"
+                  role="menuitem"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openDelete();
+                  }}
+                >
+                  <Icon name="trash" size={13} />
+                  <span>{t('nav.delete', 'Delete')}</span>
+                </button>
+              </div>
+            </>
+          )}
+        </span>
+      </div>
+      {deleting && (
+        <ConfirmDialog
+          title={t('session_delete.title', 'Delete session')}
+          body={t(
+            'session_delete.body',
+            'This session and its messages will be permanently deleted. This cannot be undone.',
+          )}
+          confirmLabel={t('session_delete.confirm', 'Delete')}
+          destructive
+          pending={deletePending}
+          onConfirm={() => void confirmDelete()}
+          onClose={() => setDeleting(false)}
+        />
+      )}
+    </>
   );
 }
 

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -5,14 +5,162 @@
 // action, a Workspace nav link (with a subtle divider below it), a Recents
 // session list, and the LanguageToggle in the footer.
 
-import type { ReactNode } from 'react';
+import { useState, useRef, type ReactNode } from 'react';
 import { Link, useNavigate, useParams, useRouterState } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { listSessions } from '@/api/sessions';
+import { listSessions, updateSessionTitle } from '@/api/sessions';
+import type { SessionResponse } from '@/api/types';
 import { LanguageToggle } from '@/components/LanguageToggle';
 import { SessionTitle } from '@/components/SessionTitle';
 import { Icon } from '@/components/Icon';
+
+/** One Recents row: opens the session on click, with a hover ⋯ menu that
+ *  swaps the title into an inline rename input (same save/cancel rules as the
+ *  chat header). */
+function SessionRow({
+  session,
+  isActive,
+  onOpen,
+}: {
+  session: SessionResponse;
+  isActive: boolean;
+  onOpen: () => void;
+}) {
+  const { t } = useTranslation('common');
+  const qc = useQueryClient();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const cancelEditRef = useRef(false);
+
+  function patchTitle(next: string | null) {
+    qc.setQueryData<SessionResponse[]>(['sessions'], (list) =>
+      list?.map((s) => (s.id === session.id ? { ...s, title: next } : s)),
+    );
+  }
+
+  function startEdit() {
+    setMenuOpen(false);
+    cancelEditRef.current = false;
+    setDraft(session.title ?? '');
+    setEditing(true);
+  }
+
+  async function commitEdit() {
+    setEditing(false);
+    if (cancelEditRef.current) {
+      cancelEditRef.current = false;
+      return;
+    }
+    const next = draft.trim();
+    if (next === '' || next === session.title) return;
+    const prev = session.title;
+    patchTitle(next); // optimistic; the server echoes a title event too
+    try {
+      await updateSessionTitle(session.id, next);
+    } catch {
+      patchTitle(prev); // revert on failure
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className={`cw-session-row${isActive ? ' is-active' : ''}`}>
+        <span className="cw-pocket"><Icon name="message-square" size={12} /></span>
+        <input
+          className="cw-session-rename-input"
+          value={draft}
+          autoFocus
+          maxLength={200}
+          aria-label={t('nav.rename', 'Rename session')}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={(e) => e.currentTarget.select()}
+          onClick={(e) => e.stopPropagation()}
+          onBlur={() => void commitEdit()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.currentTarget.blur(); // routes through onBlur → commit
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancelEditRef.current = true;
+              e.currentTarget.blur();
+            }
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`cw-session-row${isActive ? ' is-active' : ''}`}
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      title={session.title ?? undefined}
+    >
+      <span className="cw-pocket"><Icon name="message-square" size={12} /></span>
+      <SessionTitle
+        title={session.title}
+        createdAt={session.created_at}
+        className="cw-session-title"
+        skeletonClassName="cw-title-skeleton--row"
+        fallback={session.id.slice(0, 8)}
+      />
+      <span className="cw-session-menu-wrap">
+        <button
+          type="button"
+          className="cw-session-menu-btn"
+          aria-label={t('nav.more', 'More')}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          onClick={(e) => {
+            e.stopPropagation();
+            setMenuOpen((v) => !v);
+          }}
+        >
+          <Icon name="more" size={14} />
+        </button>
+        {menuOpen && (
+          <>
+            {/* Full-viewport click-away catcher; closes the menu without a
+                document listener and swallows the click so it doesn't open the
+                session. */}
+            <div
+              className="cw-session-menu-overlay"
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpen(false);
+              }}
+            />
+            <div className="cw-session-menu" role="menu">
+              <button
+                type="button"
+                className="cw-session-menu-item"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  startEdit();
+                }}
+              >
+                <Icon name="writing" size={13} />
+                <span>{t('nav.rename', 'Rename')}</span>
+              </button>
+            </div>
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
 
 function SessionNavList() {
   const { t } = useTranslation('common');
@@ -30,34 +178,14 @@ function SessionNavList() {
 
   return (
     <div className="cw-sessions-list">
-      {sessions.map((s) => {
-        const isActive = s.id === activeSessionId;
-        return (
-          <div
-            key={s.id}
-            className={`cw-session-row${isActive ? ' is-active' : ''}`}
-            role="button"
-            tabIndex={0}
-            onClick={() => navigate({ to: '/sessions/$sessionId', params: { sessionId: s.id } })}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                void navigate({ to: '/sessions/$sessionId', params: { sessionId: s.id } });
-              }
-            }}
-            title={s.title ?? undefined}
-          >
-            <span className="cw-pocket"><Icon name="message-square" size={12} /></span>
-            <SessionTitle
-              title={s.title}
-              createdAt={s.created_at}
-              className="cw-session-title"
-              skeletonClassName="cw-title-skeleton--row"
-              fallback={s.id.slice(0, 8)}
-            />
-          </div>
-        );
-      })}
+      {sessions.map((s) => (
+        <SessionRow
+          key={s.id}
+          session={s}
+          isActive={s.id === activeSessionId}
+          onOpen={() => navigate({ to: '/sessions/$sessionId', params: { sessionId: s.id } })}
+        />
+      ))}
     </div>
   );
 }

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -11,6 +11,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { listSessions } from '@/api/sessions';
 import { LanguageToggle } from '@/components/LanguageToggle';
+import { SessionTitle } from '@/components/SessionTitle';
 import { Icon } from '@/components/Icon';
 
 function SessionNavList() {
@@ -31,7 +32,6 @@ function SessionNavList() {
     <div className="cw-sessions-list">
       {sessions.map((s) => {
         const isActive = s.id === activeSessionId;
-        const title = s.title ?? s.id.slice(0, 8);
         return (
           <div
             key={s.id}
@@ -45,10 +45,16 @@ function SessionNavList() {
                 void navigate({ to: '/sessions/$sessionId', params: { sessionId: s.id } });
               }
             }}
-            title={title}
+            title={s.title ?? undefined}
           >
             <span className="cw-pocket"><Icon name="message-square" size={12} /></span>
-            <span className="cw-session-title">{title}</span>
+            <SessionTitle
+              title={s.title}
+              createdAt={s.created_at}
+              className="cw-session-title"
+              skeletonClassName="cw-title-skeleton--row"
+              fallback={s.id.slice(0, 8)}
+            />
           </div>
         );
       })}

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@
 // action, a Workspace nav link (with a subtle divider below it), a Recents
 // session list, and the LanguageToggle in the footer.
 
-import { useState, useRef, type ReactNode } from 'react';
+import { useState, useRef, useEffect, type ReactNode } from 'react';
 import { Link, useNavigate, useParams, useRouterState } from '@tanstack/react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +15,10 @@ import { LanguageToggle } from '@/components/LanguageToggle';
 import { SessionTitle } from '@/components/SessionTitle';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { Icon } from '@/components/Icon';
+
+// Duration of the row's delete exit animation; keep in sync with the
+// `.cw-session-row.is-removing` transition in globals.css.
+const REMOVE_ANIM_MS = 220;
 
 /** One Recents row: opens the session on click, with a hover ⋯ menu that
  *  swaps the title into an inline rename input (same save/cancel rules as the
@@ -37,6 +41,20 @@ function SessionRow({
   const cancelEditRef = useRef(false);
   const [deleting, setDeleting] = useState(false);
   const [deletePending, setDeletePending] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const menuRef = useRef<HTMLSpanElement>(null);
+
+  // Close the ⋯ menu on any click outside it (standard dropdown dismissal).
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onDown(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [menuOpen]);
 
   function patchTitle(next: string | null) {
     qc.setQueryData<SessionResponse[]>(['sessions'], (list) =>
@@ -77,18 +95,23 @@ function SessionRow({
     setDeletePending(true);
     try {
       await deleteSession(session.id);
-      // Drop it from the cached list immediately, then reconcile from the server.
+    } catch {
+      setDeletePending(false); // keep the dialog open so the user can retry
+      return;
+    }
+    // Server delete succeeded: close the dialog, play the fade + height-collapse
+    // exit, then drop the row from the cache (which unmounts it).
+    setDeleting(false);
+    setDeletePending(false);
+    setRemoving(true);
+    // If the open session was the one deleted, leave its (now-404) route.
+    if (isActive) void navigate({ to: '/' });
+    window.setTimeout(() => {
       qc.setQueryData<SessionResponse[]>(['sessions'], (list) =>
         list?.filter((s) => s.id !== session.id),
       );
       void qc.invalidateQueries({ queryKey: ['sessions'] });
-      setDeleting(false);
-      setDeletePending(false);
-      // If the open session was the one deleted, leave its (now-404) route.
-      if (isActive) void navigate({ to: '/' });
-    } catch {
-      setDeletePending(false); // keep the dialog open so the user can retry
-    }
+    }, REMOVE_ANIM_MS);
   }
 
   if (editing) {
@@ -128,7 +151,7 @@ function SessionRow({
   return (
     <>
       <div
-        className={`cw-session-row${isActive ? ' is-active' : ''}`}
+        className={`cw-session-row${isActive ? ' is-active' : ''}${menuOpen ? ' is-menu-open' : ''}${removing ? ' is-removing' : ''}`}
         role="button"
         tabIndex={0}
         onClick={onOpen}
@@ -148,7 +171,7 @@ function SessionRow({
           skeletonClassName="cw-title-skeleton--row"
           fallback={session.id.slice(0, 8)}
         />
-        <span className="cw-session-menu-wrap">
+        <span className="cw-session-menu-wrap" ref={menuRef}>
           <button
             type="button"
             className="cw-session-menu-btn"
@@ -163,17 +186,6 @@ function SessionRow({
             <Icon name="more" size={14} />
           </button>
           {menuOpen && (
-            <>
-              {/* Full-viewport click-away catcher; closes the menu without a
-                  document listener and swallows the click so it doesn't open the
-                  session. */}
-              <div
-                className="cw-session-menu-overlay"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenuOpen(false);
-                }}
-              />
               <div className="cw-session-menu" role="menu">
                 {/* Rename only after the title lands (not during generation). */}
                 {session.title != null && (
@@ -203,7 +215,6 @@ function SessionRow({
                   <span>{t('nav.delete', 'Delete')}</span>
                 </button>
               </div>
-            </>
           )}
         </span>
       </div>

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -175,18 +175,21 @@ function SessionRow({
                 }}
               />
               <div className="cw-session-menu" role="menu">
-                <button
-                  type="button"
-                  className="cw-session-menu-item"
-                  role="menuitem"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    startEdit();
-                  }}
-                >
-                  <Icon name="writing" size={13} />
-                  <span>{t('nav.rename', 'Rename')}</span>
-                </button>
+                {/* Rename only after the title lands (not during generation). */}
+                {session.title != null && (
+                  <button
+                    type="button"
+                    className="cw-session-menu-item"
+                    role="menuitem"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      startEdit();
+                    }}
+                  >
+                    <Icon name="writing" size={13} />
+                    <span>{t('nav.rename', 'Rename')}</span>
+                  </button>
+                )}
                 <button
                   type="button"
                   className="cw-session-menu-item cw-session-menu-item--danger"

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -156,6 +156,11 @@ function SessionRow({
         tabIndex={0}
         onClick={onOpen}
         onKeyDown={(e) => {
+          // Only the row itself opens on Enter/Space. Keydowns bubbling up from
+          // the nested ⋯ button or menu items (which stopPropagation only on
+          // click) must not also navigate, or activating the menu by keyboard
+          // would open the session too.
+          if (e.target !== e.currentTarget) return;
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             onOpen();

--- a/app_v2/src/components/layout/AppShell.tsx
+++ b/app_v2/src/components/layout/AppShell.tsx
@@ -9,7 +9,7 @@ import { useState, useRef, type ReactNode } from 'react';
 import { Link, useNavigate, useParams, useRouterState } from '@tanstack/react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { listSessions, updateSessionTitle } from '@/api/sessions';
+import { listSessions, updateSessionTitle, SESSION_TITLE_MAX_LEN } from '@/api/sessions';
 import type { SessionResponse } from '@/api/types';
 import { LanguageToggle } from '@/components/LanguageToggle';
 import { SessionTitle } from '@/components/SessionTitle';
@@ -72,7 +72,7 @@ function SessionRow({
           className="cw-session-rename-input"
           value={draft}
           autoFocus
-          maxLength={200}
+          maxLength={SESSION_TITLE_MAX_LEN}
           aria-label={t('nav.rename', 'Rename session')}
           onChange={(e) => setDraft(e.target.value)}
           onFocus={(e) => e.currentTarget.select()}
@@ -89,6 +89,11 @@ function SessionRow({
             }
           }}
         />
+        {draft.length >= SESSION_TITLE_MAX_LEN - 15 && (
+          <span className="cw-title-count">
+            {draft.length}/{SESSION_TITLE_MAX_LEN}
+          </span>
+        )}
       </div>
     );
   }

--- a/app_v2/src/hooks/__tests__/useMessageStream.test.tsx
+++ b/app_v2/src/hooks/__tests__/useMessageStream.test.tsx
@@ -16,10 +16,10 @@ vi.mock('@/api/messages', () => ({
   listMessages: vi.fn(),
 }));
 
-import { streamSessionMessages } from '@/api/messages';
+import { streamSessionMessages, type StreamEvent } from '@/api/messages';
 import { ApiError } from '@/api/client';
 import { useMessageStream } from '@/hooks/useMessageStream';
-import type { MessageItem, RunEventPayload } from '@/api/types';
+import type { MessageItem, RunEventPayload, SessionResponse } from '@/api/types';
 
 function wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -27,9 +27,9 @@ function wrapper({ children }: { children: ReactNode }) {
 }
 
 async function* makeStream(
-  events: Array<{ kind: 'message'; item: MessageItem } | { kind: 'run'; payload: RunEventPayload }>,
+  events: StreamEvent[],
   holdOpen = false,
-): AsyncGenerator<{ kind: 'message'; item: MessageItem } | { kind: 'run'; payload: RunEventPayload }> {
+): AsyncGenerator<StreamEvent> {
   for (const ev of events) yield ev;
   if (holdOpen) {
     // Never resolve — simulates an open connection.
@@ -72,6 +72,35 @@ describe('useMessageStream', () => {
 
     const { result } = renderHook(() => useMessageStream('s1'), { wrapper });
     await waitFor(() => expect(result.current.running).toBe(false));
+  });
+
+  it('patches the sessions cache on a title event', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData<SessionResponse[]>(['sessions'], [
+      {
+        id: 's1',
+        workspace_id: 'w1',
+        agent_id: null,
+        title: null,
+        spec: {},
+        created_at: '',
+        updated_at: '',
+      },
+    ]);
+    const exposingWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    vi.mocked(streamSessionMessages)
+      .mockReturnValueOnce(makeStream([{ kind: 'title', title: 'Generated Title' }]))
+      .mockReturnValue(makeStream([], true)); // hold reconnect open
+
+    renderHook(() => useMessageStream('s1'), { wrapper: exposingWrapper });
+
+    await waitFor(() => {
+      const cached = qc.getQueryData<SessionResponse[]>(['sessions']);
+      expect(cached?.[0]?.title).toBe('Generated Title');
+    });
   });
 
   it('sets runError on run:error event', async () => {

--- a/app_v2/src/hooks/__tests__/useMessageStream.test.tsx
+++ b/app_v2/src/hooks/__tests__/useMessageStream.test.tsx
@@ -47,7 +47,7 @@ afterEach(() => {
 
 describe('useMessageStream', () => {
   it('deduplicates messages by seq', async () => {
-    const item: MessageItem = { seq: 1, message: { role: 'user', contents: [] } };
+    const item: MessageItem = { seq: 1, message: { role: 'user', contents: [] }, created_at: '2026-01-01T00:00:00Z' };
     // Return stream twice so reconnect after first stream completes doesn't hang.
     vi.mocked(streamSessionMessages)
       .mockReturnValueOnce(makeStream([
@@ -168,9 +168,9 @@ describe('useMessageStream', () => {
   // call failed the guard and returned prev, dropping every frame.
   it('delivers all frames under React StrictMode (regression: impure updater)', async () => {
     const items: MessageItem[] = [
-      { seq: 0, message: { role: 'user', contents: [] } },
-      { seq: 1, message: { role: 'assistant', contents: [] } },
-      { seq: 2, message: { role: 'user', contents: [] } },
+      { seq: 0, message: { role: 'user', contents: [] }, created_at: '2026-01-01T00:00:00Z' },
+      { seq: 1, message: { role: 'assistant', contents: [] }, created_at: '2026-01-01T00:00:01Z' },
+      { seq: 2, message: { role: 'user', contents: [] }, created_at: '2026-01-01T00:00:02Z' },
     ];
 
     vi.mocked(streamSessionMessages)

--- a/app_v2/src/hooks/useMessageStream.ts
+++ b/app_v2/src/hooks/useMessageStream.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { ApiError } from '@/api/client';
 import { streamSessionMessages } from '@/api/messages';
-import type { MessageItem } from '@/api/types';
+import type { MessageItem, SessionResponse } from '@/api/types';
 
 export interface MessageStreamState {
   messages: MessageItem[];
@@ -15,6 +16,7 @@ export function useMessageStream(sessionId: string): MessageStreamState {
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
+  const qc = useQueryClient();
 
   const lastSeqRef = useRef<number | undefined>(undefined);
   const abortRef = useRef<AbortController | null>(null);
@@ -64,8 +66,7 @@ export function useMessageStream(sessionId: string): MessageStreamState {
               next.sort((a, b) => a.seq - b.seq);
               return next;
             });
-          } else {
-            // ev.kind === 'run'
+          } else if (ev.kind === 'run') {
             const payload = ev.payload;
             if ('run' in payload) {
               if (payload.run === 'started') {
@@ -78,6 +79,13 @@ export function useMessageStream(sessionId: string): MessageStreamState {
                 setRunError((payload as { run: 'error'; message: string }).message);
               }
             }
+          } else {
+            // ev.kind === 'title' — an auto-generated title arrived. Patch the
+            // cached session list in place so the sidebar (and anything else
+            // reading ['sessions']) reflects it live, without a refetch.
+            qc.setQueryData<SessionResponse[]>(['sessions'], (prev) =>
+              prev?.map((s) => (s.id === sessionId ? { ...s, title: ev.title } : s)),
+            );
           }
         }
         // Stream ended normally — reconnect with capped backoff so a server
@@ -116,7 +124,7 @@ export function useMessageStream(sessionId: string): MessageStreamState {
       abortRef.current?.abort();
       abortRef.current = null;
     };
-  }, [sessionId]);
+  }, [sessionId, qc]);
 
   return { messages, running, runError, connected };
 }

--- a/app_v2/src/i18n/locales/en/common.json
+++ b/app_v2/src/i18n/locales/en/common.json
@@ -33,7 +33,9 @@
     "new_chat": "New Chat",
     "recents": "Recents",
     "recents_empty": "No recent chats yet",
-    "workspace": "Workspace"
+    "workspace": "Workspace",
+    "more": "More",
+    "rename": "Rename"
   },
   "intent": {
     "general": { "label": "General", "note": "Start freely" },

--- a/app_v2/src/i18n/locales/en/common.json
+++ b/app_v2/src/i18n/locales/en/common.json
@@ -35,7 +35,13 @@
     "recents_empty": "No recent chats yet",
     "workspace": "Workspace",
     "more": "More",
-    "rename": "Rename"
+    "rename": "Rename",
+    "delete": "Delete"
+  },
+  "session_delete": {
+    "title": "Delete session",
+    "body": "This session and its messages will be permanently deleted. This cannot be undone.",
+    "confirm": "Delete"
   },
   "intent": {
     "general": { "label": "General", "note": "Start freely" },

--- a/app_v2/src/i18n/locales/en/session.json
+++ b/app_v2/src/i18n/locales/en/session.json
@@ -51,7 +51,10 @@
     "new_message": "New message",
     "scroll_to_bottom": "Scroll to bottom",
     "copy": "Copy",
-    "title_fallback": "…"
+    "title_fallback": "…",
+    "title_generating": "Generating title",
+    "title_input_aria": "Session title",
+    "rename": "Rename"
   },
   "chat": {
     "started_by": "Started by",

--- a/app_v2/src/i18n/locales/ko/common.json
+++ b/app_v2/src/i18n/locales/ko/common.json
@@ -33,7 +33,9 @@
     "new_chat": "새 대화",
     "recents": "최근",
     "recents_empty": "최근 대화가 없어요",
-    "workspace": "워크스페이스"
+    "workspace": "워크스페이스",
+    "more": "더보기",
+    "rename": "이름 변경"
   },
   "intent": {
     "general": { "label": "일반", "note": "자유롭게 시작" },

--- a/app_v2/src/i18n/locales/ko/common.json
+++ b/app_v2/src/i18n/locales/ko/common.json
@@ -35,7 +35,13 @@
     "recents_empty": "최근 대화가 없어요",
     "workspace": "워크스페이스",
     "more": "더보기",
-    "rename": "이름 변경"
+    "rename": "이름 변경",
+    "delete": "삭제"
+  },
+  "session_delete": {
+    "title": "세션 삭제",
+    "body": "이 세션과 대화 기록이 영구히 삭제됩니다. 되돌릴 수 없어요.",
+    "confirm": "삭제"
   },
   "intent": {
     "general": { "label": "일반", "note": "자유롭게 시작" },

--- a/app_v2/src/i18n/locales/ko/session.json
+++ b/app_v2/src/i18n/locales/ko/session.json
@@ -51,7 +51,10 @@
     "new_message": "새 메시지",
     "scroll_to_bottom": "맨 아래로",
     "copy": "복사",
-    "title_fallback": "…"
+    "title_fallback": "…",
+    "title_generating": "제목 생성 중",
+    "title_input_aria": "세션 제목",
+    "rename": "이름 변경"
   },
   "chat": {
     "started_by": "시작한 사람:",

--- a/app_v2/src/lib/__tests__/transcript.test.ts
+++ b/app_v2/src/lib/__tests__/transcript.test.ts
@@ -3,7 +3,7 @@ import { buildTranscript } from '@/lib/transcript';
 import type { MessageItem } from '@/api/types';
 
 function makeItem(seq: number, role: string, overrides: Partial<MessageItem['message']> = {}): MessageItem {
-  return { seq, message: { role, ...overrides } };
+  return { seq, message: { role, ...overrides }, created_at: '2026-01-01T00:00:00Z' };
 }
 
 describe('buildTranscript', () => {

--- a/app_v2/src/lib/formatMessageDate.ts
+++ b/app_v2/src/lib/formatMessageDate.ts
@@ -1,0 +1,31 @@
+import dayjs from 'dayjs';
+import i18n from '@/i18n';
+
+// `lng` is passed by callers (from useTranslation) so the component re-renders
+// on language change; falls back to the global i18n language otherwise.
+function isKorean(lng?: string): boolean {
+  return (lng ?? i18n.language ?? 'en').startsWith('ko');
+}
+
+/**
+ * Date only (no time), localized:
+ *   ko → "7월 17일"   en → "Jul 17"
+ * Empty string for missing/invalid input.
+ */
+export function formatMessageDate(iso: string | null | undefined, lng?: string): string {
+  if (!iso) return '';
+  const t = dayjs(iso);
+  if (!t.isValid()) return '';
+  return isKorean(lng) ? t.format('M월 D일') : t.format('MMM D');
+}
+
+/**
+ * Fuller date for the hover tooltip, still no time:
+ *   ko → "2026년 7월 17일"   en → "Jul 17, 2026"
+ */
+export function formatMessageDateFull(iso: string | null | undefined, lng?: string): string {
+  if (!iso) return '';
+  const t = dayjs(iso);
+  if (!t.isValid()) return '';
+  return isKorean(lng) ? t.format('YYYY년 M월 D일') : t.format('MMM D, YYYY');
+}

--- a/app_v2/src/lib/transcript.ts
+++ b/app_v2/src/lib/transcript.ts
@@ -15,6 +15,8 @@ export interface TranscriptEntry {
   kind: 'user' | 'assistant';
   text: string;
   toolCalls: ToolCallEntry[];
+  /** RFC3339 timestamp of the underlying message; '' for optimistic entries. */
+  createdAt: string;
 }
 
 function extractText(contents: AiloyPart[] | undefined): string {
@@ -82,7 +84,7 @@ export function buildTranscript(items: MessageItem[]): TranscriptEntry[] {
       result: toolResults.get(tc.id),
     }));
 
-    entries.push({ kind, text, toolCalls });
+    entries.push({ kind, text, toolCalls, createdAt: it.created_at });
   }
 
   return entries;

--- a/app_v2/src/routes/index.tsx
+++ b/app_v2/src/routes/index.tsx
@@ -34,6 +34,16 @@ export function HomePage() {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Tab title on the home / "new chat" surface (e.g. after deleting the open
+  // session, which navigates here). Localized, re-set on language change.
+  useEffect(() => {
+    const label = t('nav.new_chat', { ns: 'common', defaultValue: 'New Chat' });
+    document.title = `${label} · Cowork`;
+    return () => {
+      document.title = 'Cowork';
+    };
+  }, [t]);
+
   // StrictMode-safe read-and-clear: useState initializer must NOT call
   // takePendingAttachment() because StrictMode double-invokes initializers in
   // dev, consuming the value on the discarded first call so the chip never

--- a/app_v2/src/routes/sessions.$sessionId.tsx
+++ b/app_v2/src/routes/sessions.$sessionId.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
 import { useMessageStream } from '@/hooks/useMessageStream';
 import { buildTranscript, type TranscriptEntry } from '@/lib/transcript';
 import { sendMessage } from '@/api/messages';
+import { listSessions } from '@/api/sessions';
 import { ApiError } from '@/api/client';
 import { MessageList } from '@/components/chat/MessageList';
 import { Composer } from '@/components/chat/Composer';
+import { SessionTitle } from '@/components/SessionTitle';
 import { takePendingMessage } from '@/stores/pendingMessage';
 
 export const Route = createFileRoute('/sessions/$sessionId')({
@@ -14,8 +17,18 @@ export const Route = createFileRoute('/sessions/$sessionId')({
 
 function SessionPage() {
   const { sessionId } = Route.useParams();
-  const { messages, running, runError, connected } = useMessageStream(sessionId);
+  const { messages, running, runError } = useMessageStream(sessionId);
   const [sendError, setSendError] = useState<string | null>(null);
+
+  // Session title, read from the shared ['sessions'] cache (populated by the
+  // sidebar and live-patched by useMessageStream when the auto-title arrives).
+  const { data: sessions } = useQuery({
+    queryKey: ['sessions'],
+    queryFn: listSessions,
+    staleTime: 30_000,
+  });
+  const session = sessions?.find((s) => s.id === sessionId);
+  const title = session?.title ?? null;
 
   // Optimistically-rendered user message: shown the instant it is sent, before
   // the server echoes it back over SSE (which only happens after the run's
@@ -81,14 +94,18 @@ function SessionPage() {
   return (
     <div className="cw-chat-surface">
       <div className="cw-chat-head">
-        <div className="cw-chat-status">
-          {connected ? (
-            <span className="cw-status-dot cw-status-dot--connected" title="Connected" />
-          ) : (
-            <span className="cw-status-dot cw-status-dot--disconnected" title="Connecting…" />
-          )}
-          {running && <span className="cw-status-running">AI is responding…</span>}
-        </div>
+        {/* Key by sessionId so switching sessions remounts the title: the
+            router reuses this component across param changes, and without a
+            fresh mount an already-titled session would inherit the previous
+            session's null→value transition and appear to "type" itself. */}
+        <SessionTitle
+          key={sessionId}
+          title={title}
+          createdAt={session?.created_at}
+          className="cw-chat-title"
+          skeletonClassName="cw-title-skeleton--head"
+          fallback={sessionId.slice(0, 8)}
+        />
       </div>
 
       {runError && (

--- a/app_v2/src/routes/sessions.$sessionId.tsx
+++ b/app_v2/src/routes/sessions.$sessionId.tsx
@@ -33,6 +33,14 @@ function SessionPage() {
   const session = sessions?.find((s) => s.id === sessionId);
   const title = session?.title ?? null;
 
+  // Reflect the session title in the browser tab; restore the base on leave.
+  useEffect(() => {
+    document.title = title ? `${title} · Cowork` : 'Cowork';
+    return () => {
+      document.title = 'Cowork';
+    };
+  }, [title]);
+
   // Inline title rename. Editing routes save/cancel through the input's blur
   // so Enter and click-away commit exactly once; Escape flags a cancel first.
   const [editing, setEditing] = useState(false);

--- a/app_v2/src/routes/sessions.$sessionId.tsx
+++ b/app_v2/src/routes/sessions.$sessionId.tsx
@@ -4,7 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMessageStream } from '@/hooks/useMessageStream';
 import { buildTranscript, type TranscriptEntry } from '@/lib/transcript';
 import { sendMessage } from '@/api/messages';
-import { listSessions, updateSessionTitle } from '@/api/sessions';
+import { listSessions, updateSessionTitle, SESSION_TITLE_MAX_LEN } from '@/api/sessions';
 import type { SessionResponse } from '@/api/types';
 import { ApiError } from '@/api/client';
 import { MessageList } from '@/components/chat/MessageList';
@@ -136,26 +136,33 @@ function SessionPage() {
     <div className="cw-chat-surface">
       <div className="cw-chat-head">
         {editing ? (
-          <input
-            className="cw-chat-title-input"
-            value={draft}
-            autoFocus
-            maxLength={200}
-            aria-label="세션 제목"
-            onChange={(e) => setDraft(e.target.value)}
-            onFocus={(e) => e.currentTarget.select()}
-            onBlur={() => void commitEdit()}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                e.currentTarget.blur(); // routes through onBlur → commit
-              } else if (e.key === 'Escape') {
-                e.preventDefault();
-                cancelEditRef.current = true;
-                e.currentTarget.blur();
-              }
-            }}
-          />
+          <>
+            <input
+              className="cw-chat-title-input"
+              value={draft}
+              autoFocus
+              maxLength={SESSION_TITLE_MAX_LEN}
+              aria-label="세션 제목"
+              onChange={(e) => setDraft(e.target.value)}
+              onFocus={(e) => e.currentTarget.select()}
+              onBlur={() => void commitEdit()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  e.currentTarget.blur(); // routes through onBlur → commit
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelEditRef.current = true;
+                  e.currentTarget.blur();
+                }
+              }}
+            />
+            {draft.length >= SESSION_TITLE_MAX_LEN - 15 && (
+              <span className="cw-title-count">
+                {draft.length}/{SESSION_TITLE_MAX_LEN}
+              </span>
+            )}
+          </>
         ) : (
           <>
             {/* Key by sessionId so switching sessions remounts the title: the

--- a/app_v2/src/routes/sessions.$sessionId.tsx
+++ b/app_v2/src/routes/sessions.$sessionId.tsx
@@ -113,6 +113,9 @@ function SessionPage() {
     setOptimistic(text);
     try {
       await sendMessage(sessionId, text);
+      // The server bumps the session's updated_at on run; refresh the list so
+      // Recents reorders this session to the top.
+      void qc.invalidateQueries({ queryKey: ['sessions'] });
       return true;
     } catch (err) {
       setOptimistic(null);

--- a/app_v2/src/routes/sessions.$sessionId.tsx
+++ b/app_v2/src/routes/sessions.$sessionId.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createFileRoute } from '@tanstack/react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMessageStream } from '@/hooks/useMessageStream';
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/sessions/$sessionId')({
 
 function SessionPage() {
   const { sessionId } = Route.useParams();
+  const { t } = useTranslation('session');
   const { messages, running, runError } = useMessageStream(sessionId);
   const [sendError, setSendError] = useState<string | null>(null);
   const qc = useQueryClient();
@@ -153,7 +155,7 @@ function SessionPage() {
               value={draft}
               autoFocus
               maxLength={SESSION_TITLE_MAX_LEN}
-              aria-label="세션 제목"
+              aria-label={t('ui.title_input_aria')}
               onChange={(e) => setDraft(e.target.value)}
               onFocus={(e) => e.currentTarget.select()}
               onBlur={() => void commitEdit()}
@@ -193,8 +195,8 @@ function SessionPage() {
                 type="button"
                 className="cw-title-edit"
                 onClick={startEdit}
-                aria-label="이름 변경"
-                title="이름 변경"
+                aria-label={t('ui.rename')}
+                title={t('ui.rename')}
               >
                 <Icon name="writing" size={13} />
               </button>

--- a/app_v2/src/routes/sessions.$sessionId.tsx
+++ b/app_v2/src/routes/sessions.$sessionId.tsx
@@ -1,14 +1,16 @@
 import { useState, useEffect, useRef } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMessageStream } from '@/hooks/useMessageStream';
 import { buildTranscript, type TranscriptEntry } from '@/lib/transcript';
 import { sendMessage } from '@/api/messages';
-import { listSessions } from '@/api/sessions';
+import { listSessions, updateSessionTitle } from '@/api/sessions';
+import type { SessionResponse } from '@/api/types';
 import { ApiError } from '@/api/client';
 import { MessageList } from '@/components/chat/MessageList';
 import { Composer } from '@/components/chat/Composer';
 import { SessionTitle } from '@/components/SessionTitle';
+import { Icon } from '@/components/Icon';
 import { takePendingMessage } from '@/stores/pendingMessage';
 
 export const Route = createFileRoute('/sessions/$sessionId')({
@@ -19,6 +21,7 @@ function SessionPage() {
   const { sessionId } = Route.useParams();
   const { messages, running, runError } = useMessageStream(sessionId);
   const [sendError, setSendError] = useState<string | null>(null);
+  const qc = useQueryClient();
 
   // Session title, read from the shared ['sessions'] cache (populated by the
   // sidebar and live-patched by useMessageStream when the auto-title arrives).
@@ -29,6 +32,44 @@ function SessionPage() {
   });
   const session = sessions?.find((s) => s.id === sessionId);
   const title = session?.title ?? null;
+
+  // Inline title rename. Editing routes save/cancel through the input's blur
+  // so Enter and click-away commit exactly once; Escape flags a cancel first.
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const cancelEditRef = useRef(false);
+
+  function startEdit() {
+    if (title == null) return; // can't rename a title that hasn't generated yet
+    cancelEditRef.current = false;
+    setDraft(title);
+    setEditing(true);
+  }
+
+  function patchTitle(next: string | null) {
+    qc.setQueryData<SessionResponse[]>(['sessions'], (list) =>
+      list?.map((s) => (s.id === sessionId ? { ...s, title: next } : s)),
+    );
+  }
+
+  async function commitEdit() {
+    setEditing(false);
+    if (cancelEditRef.current) {
+      cancelEditRef.current = false;
+      return;
+    }
+    const next = draft.trim();
+    // Empty is rejected (never clears the title); no-op if unchanged.
+    if (next === '' || next === title) return;
+
+    const prev = title;
+    patchTitle(next); // optimistic; the server echoes a title event too
+    try {
+      await updateSessionTitle(sessionId, next);
+    } catch {
+      patchTitle(prev); // revert on failure
+    }
+  }
 
   // Optimistically-rendered user message: shown the instant it is sent, before
   // the server echoes it back over SSE (which only happens after the run's
@@ -94,18 +135,54 @@ function SessionPage() {
   return (
     <div className="cw-chat-surface">
       <div className="cw-chat-head">
-        {/* Key by sessionId so switching sessions remounts the title: the
-            router reuses this component across param changes, and without a
-            fresh mount an already-titled session would inherit the previous
-            session's null→value transition and appear to "type" itself. */}
-        <SessionTitle
-          key={sessionId}
-          title={title}
-          createdAt={session?.created_at}
-          className="cw-chat-title"
-          skeletonClassName="cw-title-skeleton--head"
-          fallback={sessionId.slice(0, 8)}
-        />
+        {editing ? (
+          <input
+            className="cw-chat-title-input"
+            value={draft}
+            autoFocus
+            maxLength={200}
+            aria-label="세션 제목"
+            onChange={(e) => setDraft(e.target.value)}
+            onFocus={(e) => e.currentTarget.select()}
+            onBlur={() => void commitEdit()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                e.currentTarget.blur(); // routes through onBlur → commit
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                cancelEditRef.current = true;
+                e.currentTarget.blur();
+              }
+            }}
+          />
+        ) : (
+          <>
+            {/* Key by sessionId so switching sessions remounts the title: the
+                router reuses this component across param changes, and without a
+                fresh mount an already-titled session would inherit the previous
+                session's null→value transition and appear to "type" itself. */}
+            <SessionTitle
+              key={sessionId}
+              title={title}
+              createdAt={session?.created_at}
+              className="cw-chat-title"
+              skeletonClassName="cw-title-skeleton--head"
+              fallback={sessionId.slice(0, 8)}
+            />
+            {title != null && (
+              <button
+                type="button"
+                className="cw-title-edit"
+                onClick={startEdit}
+                aria-label="이름 변경"
+                title="이름 변경"
+              >
+                <Icon name="writing" size={13} />
+              </button>
+            )}
+          </>
+        )}
       </div>
 
       {runError && (

--- a/app_v2/src/routes/sessions.$sessionId.tsx
+++ b/app_v2/src/routes/sessions.$sessionId.tsx
@@ -132,7 +132,7 @@ function SessionPage() {
   // (guards the one-render window between the message arriving and the effect).
   const showOptimistic = optimistic !== null && userMsgCount <= baselineUsers.current;
   const entries: TranscriptEntry[] = showOptimistic
-    ? [...transcript, { kind: 'user', text: optimistic, toolCalls: [] }]
+    ? [...transcript, { kind: 'user', text: optimistic, toolCalls: [], createdAt: new Date().toISOString() }]
     : transcript;
 
   return (

--- a/app_v2/src/styles/globals.css
+++ b/app_v2/src/styles/globals.css
@@ -215,6 +215,8 @@ button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-
   font-size: 12.5px; text-align: left;
 }
 .cw-session-menu-item:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
+.cw-session-menu-item--danger { color: var(--cw-destructive); }
+.cw-session-menu-item--danger:hover { background: var(--cw-destructive-soft); color: var(--cw-destructive); }
 /* Inline rename input inside a session row. */
 .cw-session-rename-input {
   flex: 1; min-width: 0; font: inherit; font-size: 12.5px;

--- a/app_v2/src/styles/globals.css
+++ b/app_v2/src/styles/globals.css
@@ -309,7 +309,48 @@ select.cw-input { appearance: auto; }
   border-bottom: 1px solid var(--cw-border);
   display: flex; align-items: center; gap: 10px; flex-shrink: 0;
 }
+.cw-chat-title {
+  font-size: var(--cw-text-sm); font-weight: 600; color: var(--cw-fg-1);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
+}
+/* Shimmer skeleton shown in a title slot while the auto-title is being
+   generated (see SessionTitle) — the real text is typed in when it arrives. */
+.cw-title-skeleton {
+  display: inline-block; height: 1.05em; min-width: 80px;
+  border-radius: var(--cw-radius-md, 6px);
+  background: linear-gradient(
+    100deg,
+    var(--cw-bg-subtle) 30%,
+    var(--cw-bg-muted) 50%,
+    var(--cw-bg-subtle) 70%
+  );
+  background-size: 200% 100%;
+  animation: cw-title-shimmer 1.3s ease-in-out infinite;
+  vertical-align: middle;
+}
+.cw-title-skeleton--head { width: 180px; max-width: 45%; }
+.cw-title-skeleton--row { width: 70%; height: 0.95em; }
+/* Blinking caret trailing the text during the typewriter reveal. */
+.cw-title-caret {
+  display: inline-block; width: 2px; height: 1em; margin-left: 1px;
+  background: currentColor; vertical-align: text-bottom;
+  animation: cw-caret-blink 0.9s step-end infinite;
+}
+@keyframes cw-title-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@keyframes cw-caret-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .cw-title-skeleton { animation: none; }
+  .cw-title-caret { animation: none; }
+}
 .cw-chat-status { display: flex; align-items: center; gap: 8px; font-size: var(--cw-text-xs); color: var(--cw-fg-3); }
+/* "AI is responding…" typing indicator, rendered below the last message while
+   a run is in flight (see MessageList). Disappears with the run. */
+.cw-typing { display: flex; align-items: center; gap: 8px; font-size: var(--cw-text-xs); color: var(--cw-fg-3); }
+.cw-typing .cw-status-dot { animation: cw-typing-pulse 1.2s ease-in-out infinite; }
+@keyframes cw-typing-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
 .cw-status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
 .cw-status-dot--connected { background: var(--cw-ok); }
 .cw-status-dot--disconnected { background: var(--cw-warn); }

--- a/app_v2/src/styles/globals.css
+++ b/app_v2/src/styles/globals.css
@@ -369,6 +369,11 @@ select.cw-input { appearance: auto; }
   outline: none;
 }
 .cw-chat-title-input:focus { border-color: var(--cw-border-strong, var(--cw-border-hover)); }
+/* Character counter, shown only as the title nears the length limit. */
+.cw-title-count {
+  flex-shrink: 0; font-size: var(--cw-text-xs); color: var(--cw-fg-3);
+  font-variant-numeric: tabular-nums; white-space: nowrap;
+}
 /* Shimmer skeleton shown in a title slot while the auto-title is being
    generated (see SessionTitle) — the real text is typed in when it arrives. */
 .cw-title-skeleton {

--- a/app_v2/src/styles/globals.css
+++ b/app_v2/src/styles/globals.css
@@ -161,7 +161,10 @@ button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-
   transition: background 120ms, color 120ms, transform 120ms;
 }
 .cw-nav-row:hover, .cw-session-row:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
-.cw-nav-row:active, .cw-session-row:active { transform: translateY(1px); }
+.cw-nav-row:active { transform: translateY(1px); }
+/* Press animation for the row, but not when the press is on the ⋯ button or its
+   menu (whose active state otherwise propagates up to the row). */
+.cw-session-row:active:not(:has(.cw-session-menu-wrap:active)) { transform: translateY(1px); }
 .cw-nav-row.is-active { background: var(--cw-bg-muted); color: var(--cw-fg-1); font-weight: 600; }
 .cw-nav-row span, .cw-session-row span:not(.cw-pocket):not(.cw-session-menu-wrap) {
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -170,6 +173,16 @@ button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-
 .cw-session-row {
   min-height: 28px; padding: 5px 8px; font-size: 12.5px;
   color: var(--cw-fg-3); cursor: pointer;
+  /* Baseline for the delete collapse to animate from (rows are single-line). */
+  max-height: 40px;
+}
+/* Delete exit: fade out while the row collapses so the rows below slide up. */
+.cw-session-row.is-removing {
+  opacity: 0; max-height: 0; min-height: 0;
+  padding-top: 0; padding-bottom: 0;
+  overflow: hidden; pointer-events: none;
+  transition: opacity 0.15s ease, max-height 0.22s ease,
+    min-height 0.22s ease, padding 0.22s ease;
 }
 .cw-session-row .cw-session-title { flex: 1; min-width: 0; }
 .cw-session-row.is-active {
@@ -188,6 +201,10 @@ button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-
 .cw-session-row-delete:hover { background: var(--cw-destructive-soft); color: var(--cw-destructive); }
 
 /* ── Session row ⋯ menu (rename) ─────────────────────────────────────────── */
+/* Lift the whole row while its menu is open, so the dropdown paints above the
+   following rows instead of behind them (which would let clicks fall through
+   to the next row's ⋯). */
+.cw-session-row.is-menu-open { position: relative; z-index: 20; }
 .cw-session-menu-wrap { position: relative; flex-shrink: 0; display: inline-flex; }
 .cw-session-menu-btn {
   opacity: 0; flex-shrink: 0;
@@ -200,8 +217,6 @@ button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-
 .cw-session-row:focus-within .cw-session-menu-btn,
 .cw-session-menu-btn[aria-expanded="true"] { opacity: 1; }
 .cw-session-menu-btn:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
-/* Full-viewport click-away catcher, painted under the open menu. */
-.cw-session-menu-overlay { position: fixed; inset: 0; z-index: 200; }
 .cw-session-menu {
   position: absolute; top: calc(100% + 2px); right: 0; z-index: 201;
   min-width: 132px; padding: 4px;

--- a/app_v2/src/styles/globals.css
+++ b/app_v2/src/styles/globals.css
@@ -449,9 +449,21 @@ select.cw-input { appearance: auto; }
 .cw-message { display: flex; align-items: flex-start; gap: 10px; width: 100%; margin-bottom: 22px; }
 .cw-message.is-self { flex-direction: row-reverse; }
 .cw-message-body {
+  position: relative;
   min-width: 0; max-width: min(560px, calc(100% - 44px));
   display: flex; flex-direction: column; gap: 4px;
 }
+/* Timestamp under a message, revealed on hover. Absolutely placed into the
+   inter-message margin so it never shifts the layout. */
+.cw-message-time {
+  position: absolute; top: calc(100% + 2px);
+  font-size: var(--cw-text-xs); color: var(--cw-fg-3);
+  white-space: nowrap; pointer-events: none;
+  opacity: 0; transition: opacity 0.12s ease;
+}
+.cw-message.is-ai .cw-message-time { left: 2px; }
+.cw-message.is-self .cw-message-time { right: 2px; }
+.cw-message:hover .cw-message-time { opacity: 1; }
 .cw-message.is-self .cw-message-body { align-items: flex-end; }
 .cw-message-bubble {
   padding: 9px 13px; border-radius: 12px;

--- a/app_v2/src/styles/globals.css
+++ b/app_v2/src/styles/globals.css
@@ -313,6 +313,26 @@ select.cw-input { appearance: auto; }
   font-size: var(--cw-text-sm); font-weight: 600; color: var(--cw-fg-1);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
 }
+/* Pencil affordance — hidden until the header is hovered or the button is
+   keyboard-focused, so it doesn't clutter the header at rest. */
+.cw-title-edit {
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 0; background: transparent; color: var(--cw-fg-3); cursor: pointer;
+  padding: 3px; border-radius: var(--cw-radius-sm, 4px); flex-shrink: 0;
+  opacity: 0; transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+.cw-chat-head:hover .cw-title-edit,
+.cw-title-edit:focus-visible { opacity: 1; }
+.cw-title-edit:hover { color: var(--cw-fg-1); background: var(--cw-bg-subtle); }
+/* Inline rename input, styled to sit in place of the title text. */
+.cw-chat-title-input {
+  font: inherit; font-size: var(--cw-text-sm); font-weight: 600; color: var(--cw-fg-1);
+  flex: 1; min-width: 0; max-width: 460px;
+  padding: 3px 8px; border-radius: var(--cw-radius-md, 6px);
+  background: var(--cw-bg-subtle); border: 1px solid var(--cw-border);
+  outline: none;
+}
+.cw-chat-title-input:focus { border-color: var(--cw-border-strong, var(--cw-border-hover)); }
 /* Shimmer skeleton shown in a title slot while the auto-title is being
    generated (see SessionTitle) — the real text is typed in when it arrives. */
 .cw-title-skeleton {

--- a/app_v2/src/styles/globals.css
+++ b/app_v2/src/styles/globals.css
@@ -187,6 +187,42 @@ button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-
 .cw-session-row:focus-within .cw-session-row-delete { opacity: 1; }
 .cw-session-row-delete:hover { background: var(--cw-destructive-soft); color: var(--cw-destructive); }
 
+/* ── Session row ⋯ menu (rename) ─────────────────────────────────────────── */
+.cw-session-menu-wrap { position: relative; flex-shrink: 0; display: inline-flex; }
+.cw-session-menu-btn {
+  opacity: 0; flex-shrink: 0;
+  width: 22px; height: 22px; border: 0; border-radius: var(--cw-radius-sm);
+  background: transparent; color: var(--cw-fg-4);
+  display: inline-grid; place-items: center; cursor: pointer;
+  transition: opacity 120ms, background 120ms, color 120ms;
+}
+.cw-session-row:hover .cw-session-menu-btn,
+.cw-session-row:focus-within .cw-session-menu-btn,
+.cw-session-menu-btn[aria-expanded="true"] { opacity: 1; }
+.cw-session-menu-btn:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
+/* Full-viewport click-away catcher, painted under the open menu. */
+.cw-session-menu-overlay { position: fixed; inset: 0; z-index: 200; }
+.cw-session-menu {
+  position: absolute; top: calc(100% + 2px); right: 0; z-index: 201;
+  min-width: 132px; padding: 4px;
+  background: var(--cw-bg-elevated); border: 1px solid var(--cw-border);
+  border-radius: var(--cw-radius-md); box-shadow: var(--cw-shadow-lg);
+}
+.cw-session-menu-item {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 6px 8px; border: 0; background: transparent; cursor: pointer;
+  border-radius: var(--cw-radius-sm); color: var(--cw-fg-2);
+  font-size: 12.5px; text-align: left;
+}
+.cw-session-menu-item:hover { background: var(--cw-bg-muted); color: var(--cw-fg-1); }
+/* Inline rename input inside a session row. */
+.cw-session-rename-input {
+  flex: 1; min-width: 0; font: inherit; font-size: 12.5px;
+  color: var(--cw-fg-1); background: var(--cw-bg-elevated);
+  border: 1px solid var(--cw-border-strong, var(--cw-border-hover));
+  border-radius: var(--cw-radius-sm); padding: 2px 6px; outline: none;
+}
+
 /* ── Icon pocket (nav / session leading glyph) ──────────────────────────── */
 .cw-pocket {
   width: 18px; height: 18px; border-radius: 5px;

--- a/backend_v2/src/event.rs
+++ b/backend_v2/src/event.rs
@@ -72,6 +72,8 @@ pub fn message_channel(session_id: Uuid) -> String {
 pub struct MessageEvent {
     pub seq: i64,
     pub message: Message,
+    /// RFC3339 timestamp of when the message was persisted.
+    pub created_at: String,
 }
 
 /// Run lifecycle payload on the `message/{session_id}` channel. Tagged by the

--- a/backend_v2/src/event.rs
+++ b/backend_v2/src/event.rs
@@ -90,9 +90,28 @@ pub enum RunEvent {
     Idle,
 }
 
+/// Title-update payload on the `message/{session_id}` channel. Published once
+/// when a session's auto-generated title is first set (see
+/// [`crate::state::SessionsState::run`]). Like [`RunEvent`] it carries no
+/// `seq`; the SSE handler routes it to the `title` event by the presence of
+/// the `title` field, so seq-filtering clients ignore it.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TitleEvent {
+    pub title: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn title_event_json() {
+        let json = serde_json::to_string(&TitleEvent {
+            title: "Hello".into(),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"title":"Hello"}"#);
+    }
 
     #[test]
     fn run_event_started_json() {

--- a/backend_v2/src/main.rs
+++ b/backend_v2/src/main.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod event;
 mod router;
+mod services;
 mod state;
 mod vfs;
 

--- a/backend_v2/src/router/message.rs
+++ b/backend_v2/src/router/message.rs
@@ -34,6 +34,8 @@ use super::{error::{ApiError, err}, workspace::require_owned_session};
 pub struct MessageResponse {
     pub seq: i64,
     pub message: Message,
+    /// RFC3339 timestamp of when the message was persisted.
+    pub created_at: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -80,7 +82,11 @@ pub(super) async fn list_messages(
     Ok(Json(MessageListResponse {
         items: messages
             .into_iter()
-            .map(|(seq, message)| MessageResponse { seq, message })
+            .map(|(seq, message, created_at)| MessageResponse {
+                seq,
+                message,
+                created_at,
+            })
             .collect(),
     }))
 }
@@ -142,8 +148,8 @@ pub(super) async fn stream_messages(
                     return;
                 }
             };
-            for (seq, message) in rows {
-                let payload = match serde_json::to_string(&MessageEvent { seq, message }) {
+            for (seq, message, created_at) in rows {
+                let payload = match serde_json::to_string(&MessageEvent { seq, message, created_at }) {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::error!(session = %sid, "ws catch-up serialize error: {e}");
@@ -229,8 +235,8 @@ pub(super) async fn stream_messages_sse(
                     return;
                 }
             };
-            for (seq, message) in rows {
-                let data = match serde_json::to_string(&MessageEvent { seq, message }) {
+            for (seq, message, created_at) in rows {
+                let data = match serde_json::to_string(&MessageEvent { seq, message, created_at }) {
                     Ok(d) => d,
                     Err(e) => {
                         tracing::error!(session = %sid, "sse catch-up serialize error: {e}");

--- a/backend_v2/src/router/message.rs
+++ b/backend_v2/src/router/message.rs
@@ -421,4 +421,82 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
+
+    // ── PATCH /sessions/{id} (rename) ──────────────────────────────────────
+
+    async fn read_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn patch_title_req(sid: Uuid, token: &str, body: &str) -> Request<Body> {
+        Request::builder()
+            .method("PATCH")
+            .uri(format!("/sessions/{sid}"))
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn patch_session_trims_and_returns_new_title() {
+        let state = make_state().await;
+        let (user, token) = create_user_and_token(&state).await;
+        let sid = create_session(&state, &user).await;
+        let app = get_router(state);
+        let resp = app
+            .oneshot(patch_title_req(sid, &token, r#"{"title":"  My Renamed Session  "}"#))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = read_json(resp).await;
+        assert_eq!(body["title"], "My Renamed Session");
+    }
+
+    #[tokio::test]
+    async fn patch_session_rejects_blank_title() {
+        let state = make_state().await;
+        let (user, token) = create_user_and_token(&state).await;
+        let sid = create_session(&state, &user).await;
+        let app = get_router(state);
+        let resp = app
+            .oneshot(patch_title_req(sid, &token, r#"{"title":"   "}"#))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn patch_session_clamps_to_max_len() {
+        let state = make_state().await;
+        let (user, token) = create_user_and_token(&state).await;
+        let sid = create_session(&state, &user).await;
+        let app = get_router(state);
+        let long = "a".repeat(100);
+        let resp = app
+            .oneshot(patch_title_req(sid, &token, &format!(r#"{{"title":"{long}"}}"#)))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = read_json(resp).await;
+        assert_eq!(body["title"].as_str().unwrap().chars().count(), 60);
+    }
+
+    #[tokio::test]
+    async fn patch_session_without_auth_is_401() {
+        let state = make_state().await;
+        let sid = Uuid::new_v4(); // 401 fires before the session is looked up
+        let app = get_router(state);
+        let req = Request::builder()
+            .method("PATCH")
+            .uri(format!("/sessions/{sid}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"title":"x"}"#))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
 }

--- a/backend_v2/src/router/message.rs
+++ b/backend_v2/src/router/message.rs
@@ -193,6 +193,10 @@ pub(super) async fn stream_messages(
 ///   event: message   data: {"seq":N,"message":{...}}          (MessageEvent)
 ///   event: run       data: {"run":"started"|"finished"|"idle"} or
 ///                          {"run":"error","message":"..."}     (RunEvent)
+///   event: title     data: {"title":"..."}                     (TitleEvent)
+///
+/// The `title` frame fires once, when an untitled session's auto-generated
+/// title is first persisted (concurrent with the run that triggered it).
 ///
 /// A run-status snapshot (`started`/`idle`) is emitted after EVERY DB
 /// catch-up (initial attach and post-Lagged reconciliation), so re-attaching
@@ -262,9 +266,13 @@ pub(super) async fn stream_messages_sse(
                                 last_seq = seq;
                             }
                             None => {
-                                // Seq-less payloads are run lifecycle events.
+                                // Seq-less payloads are lifecycle events, tagged
+                                // by their discriminant field: `run` for run
+                                // status, `title` for an auto-generated title.
                                 if value.as_ref().is_some_and(|v| v.get("run").is_some()) {
                                     yield Ok(Event::default().event("run").data(payload));
+                                } else if value.as_ref().is_some_and(|v| v.get("title").is_some()) {
+                                    yield Ok(Event::default().event("title").data(payload));
                                 }
                             }
                         }

--- a/backend_v2/src/router/mod.rs
+++ b/backend_v2/src/router/mod.rs
@@ -90,7 +90,9 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
         )
         .api_route(
             "/sessions/{id}",
-            get(session::get_session).delete(session::delete_session),
+            get(session::get_session)
+                .patch(session::update_session)
+                .delete(session::delete_session),
         )
         .api_route(
             "/sessions/{id}/messages",

--- a/backend_v2/src/router/session.rs
+++ b/backend_v2/src/router/session.rs
@@ -17,8 +17,13 @@ use uuid::Uuid;
 
 use crate::{
     auth::AuthUser,
+    event::{TitleEvent, message_channel},
     state::{AppState, Session},
 };
+
+/// Upper bound on a manually-set title. Generous versus the auto-title's 60,
+/// but bounded so a crafted request can't bloat the row or the header.
+const MAX_TITLE_LEN: usize = 200;
 
 use super::{
     error::{ApiError, err},
@@ -260,6 +265,45 @@ pub(super) async fn get_session(
 ) -> Result<Json<SessionResponse>, ApiError> {
     let session = require_owned_session(&state, &auth, id).await?;
     Ok(Json(SessionResponse::from(session)))
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateSessionRequest {
+    /// New title. Trimmed; an empty (or whitespace-only) value is rejected so
+    /// the title is never cleared by a rename.
+    pub title: String,
+}
+
+/// `PATCH /sessions/{id}` — rename a session. Persists the trimmed, length-
+/// clamped title and republishes it on the session channel as a
+/// [`TitleEvent`], so every attached SSE client (the header, the sidebar)
+/// updates live — the same path the auto-titler uses.
+pub(super) async fn update_session(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<UpdateSessionRequest>,
+) -> Result<Json<SessionResponse>, ApiError> {
+    require_owned_session(&state, &auth, id).await?;
+
+    let trimmed = payload.title.trim();
+    if trimmed.is_empty() {
+        return Err(err(StatusCode::BAD_REQUEST, "title must not be empty"));
+    }
+    let title: String = trimmed.chars().take(MAX_TITLE_LEN).collect();
+
+    state.sessions.set_title(id, &title).await?;
+
+    // Fan the new title out to attached clients, mirroring the auto-titler.
+    if let Ok(payload) = serde_json::to_string(&TitleEvent {
+        title: title.clone(),
+    }) {
+        state.events.publish(&message_channel(id), payload);
+    }
+
+    let updated = require_owned_session(&state, &auth, id).await?;
+    Ok(Json(SessionResponse::from(updated)))
 }
 
 pub(super) async fn delete_session(

--- a/backend_v2/src/router/session.rs
+++ b/backend_v2/src/router/session.rs
@@ -21,9 +21,9 @@ use crate::{
     state::{AppState, Session},
 };
 
-/// Upper bound on a manually-set title. Generous versus the auto-title's 60,
-/// but bounded so a crafted request can't bloat the row or the header.
-const MAX_TITLE_LEN: usize = 200;
+/// Upper bound on a manually-set title. Matches the auto-title limit (60) so
+/// both surfaces agree.
+const MAX_TITLE_LEN: usize = 60;
 
 use super::{
     error::{ApiError, err},

--- a/backend_v2/src/services/mod.rs
+++ b/backend_v2/src/services/mod.rs
@@ -1,0 +1,5 @@
+//! Cross-cutting helpers that don't belong to a single piece of application
+//! state — e.g. one-off LLM calls that support a feature (session titling)
+//! rather than a persistent agent run.
+
+pub mod session_title;

--- a/backend_v2/src/services/session_title.rs
+++ b/backend_v2/src/services/session_title.rs
@@ -1,0 +1,99 @@
+use std::time::Duration;
+
+use ailoy::{
+    agent::AgentBuilder,
+    message::{Message, Part, Role},
+};
+use futures_util::StreamExt as _;
+
+pub const TITLE_MAX_LEN: usize = 60;
+const TITLE_TIMEOUT_SECS: u64 = 15;
+
+/// Model used to summarise the first user turn into a session title. A cheap,
+/// fast model is enough — the output is a short phrase, not an answer.
+///
+/// v2 has no runtime model-chain resolution (see `backend`'s
+/// `resolve_title_model`), so the model is pinned here.
+const TITLE_MODEL: &str = "anthropic/claude-haiku-4-5";
+
+/// Generate a one-line title for a session from its first user message.
+///
+/// Falls back to the first [`TITLE_MAX_LEN`] characters of the message on any
+/// error or timeout, so a title is always produced.
+pub async fn generate_session_title(first_user_text: &str) -> String {
+    let result = tokio::time::timeout(
+        Duration::from_secs(TITLE_TIMEOUT_SECS),
+        call_llm_for_session_title(first_user_text),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(title)) if !title.trim().is_empty() => sanitize_session_title(&title),
+        Ok(Ok(_)) => sanitize_session_title(first_user_text),
+        Ok(Err(e)) => {
+            tracing::warn!("session title generation failed ({e}); using first message");
+            sanitize_session_title(first_user_text)
+        }
+        Err(_) => {
+            tracing::warn!(
+                "session title generation timed out after {TITLE_TIMEOUT_SECS}s; using first message"
+            );
+            sanitize_session_title(first_user_text)
+        }
+    }
+}
+
+async fn call_llm_for_session_title(text: &str) -> Result<String, String> {
+    let mut agent = AgentBuilder::new(TITLE_MODEL)
+        .instruction(format!(
+            "You are a concise title generator. \
+             Try to summarize user's question in a single short phrase (under {TITLE_MAX_LEN} characters). \
+             Just summarize it, DO NOT try to generate the answer of the question. \
+             No quotes, no trailing punctuation."
+        ))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let msg = Message::new(Role::User).with_contents([Part::text(text)]);
+    let mut run = agent.run(msg);
+    let mut parts: Vec<String> = Vec::new();
+
+    while let Some(item) = run.next().await {
+        let output = item.map_err(|e| e.to_string())?;
+        for part in &output.message.contents {
+            if let Some(t) = part.as_text() {
+                parts.push(t.to_string());
+            }
+        }
+    }
+
+    Ok(parts.join(""))
+}
+
+/// Strip control characters and clamp to [`TITLE_MAX_LEN`] characters.
+fn sanitize_session_title(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control())
+        .collect::<String>()
+        .trim()
+        .chars()
+        .take(TITLE_MAX_LEN)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_trims_and_clamps() {
+        let long = "a".repeat(100);
+        assert_eq!(sanitize_session_title(&long).chars().count(), TITLE_MAX_LEN);
+        assert_eq!(sanitize_session_title("  hello\n"), "hello");
+    }
+
+    #[test]
+    fn sanitize_drops_control_chars() {
+        assert_eq!(sanitize_session_title("a\tb\u{7}c"), "abc");
+    }
+}

--- a/backend_v2/src/services/session_title.rs
+++ b/backend_v2/src/services/session_title.rs
@@ -47,9 +47,10 @@ async fn call_llm_for_session_title(text: &str) -> Result<String, String> {
     let mut agent = AgentBuilder::new(TITLE_MODEL)
         .instruction(format!(
             "You are a concise title generator. \
-             Try to summarize user's question in a single short phrase (under {TITLE_MAX_LEN} characters). \
-             Just summarize it, DO NOT try to generate the answer of the question. \
-             No quotes, no trailing punctuation."
+             Summarize the user's request as a single short title phrase (under {TITLE_MAX_LEN} characters). \
+             Output ONLY the title, on ONE line, as plain text: \
+             no markdown, no formatting, no headings, no quotes, no trailing punctuation. \
+             Do NOT answer the question or add any extra lines."
         ))
         .build()
         .map_err(|e| e.to_string())?;
@@ -70,12 +71,29 @@ async fn call_llm_for_session_title(text: &str) -> Result<String, String> {
     Ok(parts.join(""))
 }
 
-/// Strip control characters and clamp to [`TITLE_MAX_LEN`] characters.
+/// Reduce a raw model (or fallback) string to a clean one-line title.
+///
+/// Titles are a single line, so only the first non-empty line is kept — models
+/// occasionally tack on a second line (a section header, or the answer itself).
+/// Markdown emphasis/heading markers are turned into spaces (so removing `**`
+/// doesn't glue two words together), non-whitespace control chars are dropped,
+/// internal whitespace is collapsed, and the result is clamped to
+/// [`TITLE_MAX_LEN`] characters.
 fn sanitize_session_title(s: &str) -> String {
-    s.chars()
-        .filter(|c| !c.is_control())
-        .collect::<String>()
-        .trim()
+    let line = s
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    let cleaned: String = line
+        .chars()
+        .map(|c| if matches!(c, '*' | '_' | '`' | '#') { ' ' } else { c })
+        .filter(|c| !(c.is_control() && !c.is_whitespace()))
+        .collect();
+    cleaned
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
         .chars()
         .take(TITLE_MAX_LEN)
         .collect()
@@ -94,6 +112,22 @@ mod tests {
 
     #[test]
     fn sanitize_drops_control_chars() {
-        assert_eq!(sanitize_session_title("a\tb\u{7}c"), "abc");
+        // Bell is dropped; the tab collapses to a single space.
+        assert_eq!(sanitize_session_title("a\tb\u{7}c"), "a bc");
+    }
+
+    #[test]
+    fn sanitize_keeps_only_first_line() {
+        assert_eq!(
+            sanitize_session_title("Walking Benefits Research Report\n**Physical Health Benefits**"),
+            "Walking Benefits Research Report"
+        );
+    }
+
+    #[test]
+    fn sanitize_strips_markdown_without_gluing_words() {
+        assert_eq!(sanitize_session_title("**Bold Title**"), "Bold Title");
+        assert_eq!(sanitize_session_title("Report**Physical"), "Report Physical");
+        assert_eq!(sanitize_session_title("# Heading"), "Heading");
     }
 }

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -129,11 +129,11 @@ impl SessionsState {
         self.data_root.join("sessions").join(id.to_string())
     }
 
-    /// Every session in `workspace_id`, oldest first.
+    /// Every session in `workspace_id`, newest first (for the Recents list).
     pub async fn list_by_workspace(&self, workspace_id: Uuid) -> StateResult<Vec<Session>> {
         let rows = sqlx::query(
             "SELECT id, workspace_id, agent_id, title, spec, runenv, created_at, updated_at \
-             FROM sessions WHERE workspace_id = ? ORDER BY created_at ASC",
+             FROM sessions WHERE workspace_id = ? ORDER BY created_at DESC",
         )
         .bind(workspace_id.to_string())
         .fetch_all(&self.db)

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -269,15 +269,30 @@ impl SessionsState {
         let events = self.events.clone();
         tokio::spawn(async move {
             let title = crate::services::session_title::generate_session_title(&first_text).await;
+            // Gate on `title IS NULL`: the inline `needs_title` precheck ran
+            // before the (slow) LLM call, so a manual rename (`set_title`) may
+            // have landed since. Writing conditionally means we only ever fill
+            // an untitled session and never clobber a user's rename.
+            //
             // Like `set_title`, does not touch updated_at — titling shouldn't
             // reorder Recents.
-            if let Err(e) = sqlx::query("UPDATE sessions SET title = ? WHERE id = ?")
-                .bind(&title)
-                .bind(id.to_string())
-                .execute(&db)
-                .await
+            let affected = match sqlx::query(
+                "UPDATE sessions SET title = ? WHERE id = ? AND title IS NULL",
+            )
+            .bind(&title)
+            .bind(id.to_string())
+            .execute(&db)
+            .await
             {
-                tracing::warn!(session = %id, "failed to persist session title: {e}");
+                Ok(r) => r.rows_affected(),
+                Err(e) => {
+                    tracing::warn!(session = %id, "failed to persist session title: {e}");
+                    return;
+                }
+            };
+            // A rename beat us to it — leave their title in place and don't
+            // publish, or we'd broadcast a title the DB no longer holds.
+            if affected == 0 {
                 return;
             }
             match serde_json::to_string(&TitleEvent { title }) {

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -269,6 +269,13 @@ impl SessionsState {
         let events = self.events.clone();
         tokio::spawn(async move {
             let title = crate::services::session_title::generate_session_title(&first_text).await;
+            // A markdown-only first message (e.g. "###") sanitizes to "" and the
+            // fallback is empty too. Persisting "" would leave a non-null but
+            // blank title — an empty title bar with no shimmer/fallback. Skip
+            // the write so the title stays NULL and can be regenerated later.
+            if title.trim().is_empty() {
+                return;
+            }
             // Gate on `title IS NULL`: the inline `needs_title` precheck ran
             // before the (slow) LLM call, so a manual rename (`set_title`) may
             // have landed since. Writing conditionally means we only ever fill

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -347,21 +347,22 @@ impl SessionsState {
 
     /// Return all messages for `session_id`, ordered by `seq` ascending. Backs
     /// the `GET /sessions/{id}/messages` endpoint; the WS catch-up path uses
-    /// [`SessionsState::list_messages_since`] instead.
-    pub async fn list_messages(&self, session_id: Uuid) -> StateResult<Vec<(i64, Message)>> {
+    /// [`SessionsState::list_messages_since`] instead. Each tuple is
+    /// `(seq, message, created_at)` where `created_at` is an RFC3339 string.
+    pub async fn list_messages(&self, session_id: Uuid) -> StateResult<Vec<(i64, Message, String)>> {
         self.list_messages_since(session_id, -1).await
     }
 
     /// Return messages for `session_id` with `seq > since`, ordered ascending.
     /// The WS handler uses this for catch-up before switching to the live
-    /// event subscription.
+    /// event subscription. Tuples are `(seq, message, created_at)`.
     pub async fn list_messages_since(
         &self,
         session_id: Uuid,
         since: i64,
-    ) -> StateResult<Vec<(i64, Message)>> {
+    ) -> StateResult<Vec<(i64, Message, String)>> {
         let rows = sqlx::query(
-            "SELECT seq, content FROM messages \
+            "SELECT seq, content, created_at FROM messages \
              WHERE session_id = ? AND seq > ? ORDER BY seq ASC",
         )
         .bind(session_id.to_string())
@@ -369,11 +370,12 @@ impl SessionsState {
         .fetch_all(&self.db)
         .await?;
         rows.into_iter()
-            .map(|r| -> StateResult<(i64, Message)> {
+            .map(|r| -> StateResult<(i64, Message, String)> {
                 let seq: i64 = r.get("seq");
                 let content: String = r.get("content");
+                let created_at: String = r.get("created_at");
                 let message: Message = serde_json::from_str(&content)?;
-                Ok((seq, message))
+                Ok((seq, message, created_at))
             })
             .collect()
     }
@@ -512,6 +514,7 @@ impl SessionsState {
                     let mut agent = Agent::try_with_state(spec, state)?;
 
                     let user_msg = Message::new(Role::User).with_contents(query);
+                    let created_at = Utc::now().to_rfc3339();
                     sqlx::query(
                         "INSERT INTO messages (session_id, seq, content, created_at) \
                          VALUES (?, ?, ?, ?)",
@@ -519,7 +522,7 @@ impl SessionsState {
                     .bind(&session_key)
                     .bind(next_seq)
                     .bind(serde_json::to_string(&user_msg)?)
-                    .bind(Utc::now().to_rfc3339())
+                    .bind(&created_at)
                     .execute(&db)
                     .await?;
                     events.publish(
@@ -527,6 +530,7 @@ impl SessionsState {
                         serde_json::to_string(&MessageEvent {
                             seq: next_seq,
                             message: user_msg.clone(),
+                            created_at,
                         })?,
                     );
                     next_seq += 1;
@@ -539,6 +543,7 @@ impl SessionsState {
                             next = stream.next() => {
                                 let Some(output) = next else { break };
                                 let output = output?;
+                                let created_at = Utc::now().to_rfc3339();
                                 sqlx::query(
                                     "INSERT INTO messages (session_id, seq, content, created_at) \
                                      VALUES (?, ?, ?, ?)",
@@ -546,7 +551,7 @@ impl SessionsState {
                                 .bind(&session_key)
                                 .bind(next_seq)
                                 .bind(serde_json::to_string(&output.message)?)
-                                .bind(Utc::now().to_rfc3339())
+                                .bind(&created_at)
                                 .execute(&db)
                                 .await?;
                                 events.publish(
@@ -554,6 +559,7 @@ impl SessionsState {
                                     serde_json::to_string(&MessageEvent {
                                         seq: next_seq,
                                         message: output.message,
+                                        created_at,
                                     })?,
                                 );
                                 next_seq += 1;

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -218,6 +218,24 @@ impl SessionsState {
         Ok(())
     }
 
+    /// Set a session's title and bump `updated_at`. Backs the manual rename
+    /// endpoint; the auto-titler writes its own UPDATE inline (see
+    /// [`Self::maybe_generate_title`]).
+    pub async fn set_title(&self, id: Uuid, title: &str) -> StateResult<()> {
+        let now = Utc::now().to_rfc3339();
+        let affected = sqlx::query("UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?")
+            .bind(title)
+            .bind(now)
+            .bind(id.to_string())
+            .execute(&self.db)
+            .await?
+            .rows_affected();
+        if affected == 0 {
+            return Err(StateError::NotFound);
+        }
+        Ok(())
+    }
+
     /// Whether `id` exists and has no title yet — the gate for auto-titling.
     async fn needs_title(&self, id: Uuid) -> StateResult<bool> {
         let row = sqlx::query("SELECT title FROM sessions WHERE id = ?")
@@ -602,5 +620,13 @@ mod tests {
         let state = SessionsState::new(pool, std::env::temp_dir(), EventQueue::new());
         let unknown_id = Uuid::new_v4();
         assert!(!state.is_running(unknown_id).await);
+    }
+
+    #[tokio::test]
+    async fn set_title_missing_session_is_not_found() {
+        let pool = fresh_db().await;
+        let state = SessionsState::new(pool, std::env::temp_dir(), EventQueue::new());
+        let result = state.set_title(Uuid::new_v4(), "x").await;
+        assert!(matches!(result, Err(StateError::NotFound)));
     }
 }

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use super::{StateError, StateResult, parse_ts, parse_uuid};
-use crate::event::{EventQueue, MessageEvent, RunEvent, message_channel};
+use crate::event::{EventQueue, MessageEvent, RunEvent, TitleEvent, message_channel};
 
 #[derive(Debug, Clone)]
 pub struct Session {
@@ -90,6 +90,12 @@ impl Session {
             updated_at: parse_ts(&row.get::<String, _>("updated_at"), "sessions.updated_at")?,
         })
     }
+}
+
+/// Concatenate the text parts of a user turn for title generation. Non-text
+/// parts (images, tool calls) are skipped.
+fn first_user_text(parts: &[Part]) -> String {
+    parts.iter().filter_map(|p| p.as_text()).collect()
 }
 
 pub struct SessionsState {
@@ -212,6 +218,57 @@ impl SessionsState {
         Ok(())
     }
 
+    /// Whether `id` exists and has no title yet — the gate for auto-titling.
+    async fn needs_title(&self, id: Uuid) -> StateResult<bool> {
+        let row = sqlx::query("SELECT title FROM sessions WHERE id = ?")
+            .bind(id.to_string())
+            .fetch_optional(&self.db)
+            .await?;
+        Ok(matches!(row, Some(r) if r.get::<Option<String>, _>("title").is_none()))
+    }
+
+    /// If `id` still has no title, spawn a best-effort background task that
+    /// summarises `first_text` into one, persists it, and publishes a
+    /// [`TitleEvent`] on the session channel. Runs concurrently with the agent
+    /// run and never blocks or fails it: on any error the title is simply left
+    /// unset and can be regenerated on the next turn.
+    async fn maybe_generate_title(&self, id: Uuid, first_text: String) {
+        if first_text.trim().is_empty() {
+            return;
+        }
+        match self.needs_title(id).await {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(e) => {
+                tracing::warn!(session = %id, "title precheck failed: {e}");
+                return;
+            }
+        }
+
+        let db = self.db.clone();
+        let events = self.events.clone();
+        tokio::spawn(async move {
+            let title = crate::services::session_title::generate_session_title(&first_text).await;
+            let now = Utc::now().to_rfc3339();
+            if let Err(e) = sqlx::query("UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?")
+                .bind(&title)
+                .bind(&now)
+                .bind(id.to_string())
+                .execute(&db)
+                .await
+            {
+                tracing::warn!(session = %id, "failed to persist session title: {e}");
+                return;
+            }
+            match serde_json::to_string(&TitleEvent { title }) {
+                Ok(payload) => {
+                    events.publish(&message_channel(id), payload);
+                }
+                Err(e) => tracing::error!(session = %id, "title event serialize failed: {e}"),
+            }
+        });
+    }
+
     pub async fn remove(&self, id: Uuid) -> StateResult<Session> {
         let existing = self.get(id).await?.ok_or(StateError::NotFound)?;
         // Signal any in-flight run to stop before we tear down the row. The
@@ -323,6 +380,12 @@ impl SessionsState {
         let data_root = self.data_root.clone();
         let events = self.events.clone();
         let runs = self.runs.clone();
+
+        // Auto-title an untitled session from this user turn, concurrent with
+        // the run. `query` is moved into the run task below, so extract the
+        // text first. Best-effort: `maybe_generate_title` only does a quick
+        // "needs a title?" check inline, then spawns the LLM call.
+        self.maybe_generate_title(id, first_user_text(&query)).await;
 
         // Publishing before spawn guarantees a subscriber attached before the
         // POST 202 returns observes `started` before the user-message event.

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -220,14 +220,14 @@ impl SessionsState {
         Ok(())
     }
 
-    /// Set a session's title and bump `updated_at`. Backs the manual rename
-    /// endpoint; the auto-titler writes its own UPDATE inline (see
-    /// [`Self::maybe_generate_title`]).
+    /// Set a session's title. Backs the manual rename endpoint; the auto-titler
+    /// writes its own UPDATE inline (see [`Self::maybe_generate_title`]).
+    ///
+    /// Deliberately does NOT touch `updated_at`: a rename must not reorder the
+    /// Recents list, which sorts by last activity (see [`Self::list_by_workspace`]).
     pub async fn set_title(&self, id: Uuid, title: &str) -> StateResult<()> {
-        let now = Utc::now().to_rfc3339();
-        let affected = sqlx::query("UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?")
+        let affected = sqlx::query("UPDATE sessions SET title = ? WHERE id = ?")
             .bind(title)
-            .bind(now)
             .bind(id.to_string())
             .execute(&self.db)
             .await?
@@ -269,10 +269,10 @@ impl SessionsState {
         let events = self.events.clone();
         tokio::spawn(async move {
             let title = crate::services::session_title::generate_session_title(&first_text).await;
-            let now = Utc::now().to_rfc3339();
-            if let Err(e) = sqlx::query("UPDATE sessions SET title = ?, updated_at = ? WHERE id = ?")
+            // Like `set_title`, does not touch updated_at — titling shouldn't
+            // reorder Recents.
+            if let Err(e) = sqlx::query("UPDATE sessions SET title = ? WHERE id = ?")
                 .bind(&title)
-                .bind(&now)
                 .bind(id.to_string())
                 .execute(&db)
                 .await

--- a/backend_v2/src/state/session.rs
+++ b/backend_v2/src/state/session.rs
@@ -129,11 +129,13 @@ impl SessionsState {
         self.data_root.join("sessions").join(id.to_string())
     }
 
-    /// Every session in `workspace_id`, newest first (for the Recents list).
+    /// Every session in `workspace_id`, most-recently-active first (for the
+    /// Recents list). `updated_at` is bumped on each run (see [`Self::run`]),
+    /// so a session rises to the top when the user messages it.
     pub async fn list_by_workspace(&self, workspace_id: Uuid) -> StateResult<Vec<Session>> {
         let rows = sqlx::query(
             "SELECT id, workspace_id, agent_id, title, spec, runenv, created_at, updated_at \
-             FROM sessions WHERE workspace_id = ? ORDER BY created_at DESC",
+             FROM sessions WHERE workspace_id = ? ORDER BY updated_at DESC",
         )
         .bind(workspace_id.to_string())
         .fetch_all(&self.db)
@@ -398,6 +400,14 @@ impl SessionsState {
         let data_root = self.data_root.clone();
         let events = self.events.clone();
         let runs = self.runs.clone();
+
+        // Bump last-activity so the Recents list surfaces this session first.
+        // Best-effort: a failure here must never block starting the run.
+        let _ = sqlx::query("UPDATE sessions SET updated_at = ? WHERE id = ?")
+            .bind(Utc::now().to_rfc3339())
+            .bind(id.to_string())
+            .execute(&self.db)
+            .await;
 
         // Auto-title an untitled session from this user turn, concurrent with
         // the run. `query` is moved into the run task below, so extract the


### PR DESCRIPTION
## Summary
End-to-end session title & management for app_v2: auto-generated titles that stream in live, inline rename and delete from both the chat header and the sidebar, activity-based Recents ordering, and per-message dates on hover.

## Features
- **Auto-titles** — generated from the first user turn (cheap model, 15s timeout, first-message fallback) and published over SSE so the sidebar/header fill in live; sanitized to one clean line and capped at 60 chars.
- **Rename** — inline edit from the chat header (click the title) and from each sidebar row's ⋯ menu; Enter/blur saves, Esc cancels, empty rejected, optimistic update with revert on failure; disabled while the title is still generating.
- **Delete** — from the sidebar ⋯ menu behind a confirm dialog; the row fades + collapses out, then is removed once the server delete confirms; deleting the open session navigates home.
- **Recents ordering** — sorted by last activity (`updated_at`, bumped on each run; title changes intentionally don't bump it) and refreshed on send so it reorders live.
- **Title UX** — shimmer skeleton while generating, then a one-shot typewriter reveal on first arrival (instant for existing sessions / reduced motion); near-limit character counter.
- **Message dates** — hovering a message reveals its date under the bubble, localized and date-only (ko "7월 17일", en "Jul 17"; tooltip adds the year), re-rendering on language toggle.
- **Browser tab** — the tab title reflects the current session (`{title} · Cowork`), updating live as the title streams in; the home / new-chat surface shows "New Chat · Cowork", so deleting the open session drops the tab back to a new-chat state.

## Backend (backend_v2)
- `PATCH /sessions/{id}` to rename (trim, reject empty, clamp 60, republish a `TitleEvent`); `SessionsState::set_title`.
- `TitleEvent` on the session channel; auto-titler in `SessionsState::run`.
- `MessageEvent`/`MessageResponse` and `list_messages(_since)` now carry `created_at`; the run loop stamps live events.
- `list_by_workspace` orders by `updated_at DESC`.

## Tests
**Frontend** (vitest, 108 pass)
- `SessionTitle`     — null→shimmer, ready→text, first arrival→typewriter reveal
- `messages`         — SSE `title` frame decodes into a title stream event
- `useMessageStream` — a `title` event patches the `['sessions']` query cache
- `transcript`       — each message's `created_at` flows through to the entry

**Backend** (cargo, 49 pass)
- `patch rename`     — trims the input and returns the updated title
- `patch blank`      — a whitespace-only title is rejected with 400
- `patch clamp`      — an over-long title is clamped to 60 characters
- `patch auth`       — a request without a bearer token gets 401
- `set_title`        — renaming a missing session returns NotFound
- `title sanitize`   — strips markdown and keeps only the first line

## Notes
- Also includes a cherry-picked IME-composition fix for the Composer — already on `app-v2-init`, so a no-op there.
- Message hover date currently shows for both user and assistant messages.
