### PR TITLE
fix(workspace): enforce path containment in WorkspaceFs::resolve

### DIFF
--- a/backend/src/state/workspace/fs.rs
+++ b/backend/src/state/workspace/fs.rs
@@ -12,8 +12,9 @@
 //! *every* caller of the filesystem — not just the WebDAV one — observes the
 //! same effects.
 
+use std::ffi::OsString;
 use std::io::{self, SeekFrom};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 
 use bytes::{Buf, Bytes, BytesMut};
@@ -215,8 +216,32 @@ impl WorkspaceFs {
 
     /// Absolute on-disk path of `rel_path` (a workspace-relative path such as
     /// `/knowledge/foo.txt`) inside this workspace.
+    ///
+    /// Containment is enforced here so it holds for every caller, not just the
+    /// protocol layers that happen to pre-normalise (WebDAV's `DavPath`). We fold
+    /// the relative path in isolation — pushing `Normal` segments and popping on
+    /// `..` — then append it to an untouched `self.root`. Because `..` only ever
+    /// pops from `parts` (never from the root) and a pop on an empty stack is a
+    /// no-op, a `..` can never climb above the workspace root: an escaping path
+    /// like `/../../etc/passwd` folds back to an in-root path rather than reaching
+    /// the host filesystem. This is lexical (POSIX-style `/..` == `/`); it does
+    /// not resolve symlinks, which are not creatable through this API.
     fn resolve(&self, rel_path: &str) -> PathBuf {
-        self.root.join(rel_path.trim_start_matches('/'))
+        let mut parts: Vec<OsString> = Vec::new();
+        for comp in Path::new(rel_path.trim_start_matches('/')).components() {
+            match comp {
+                Component::Normal(c) => parts.push(c.to_os_string()),
+                Component::ParentDir => {
+                    parts.pop();
+                }
+                // `CurDir` is a no-op; `RootDir`/`Prefix` can't reach the root
+                // (the leading `/` is already trimmed) so they're ignored too.
+                _ => {}
+            }
+        }
+        let mut out = self.root.clone();
+        out.extend(parts);
+        out
     }
 
     pub async fn metadata(&self, rel_path: &str) -> FsResult<std::fs::Metadata> {
@@ -407,6 +432,51 @@ async fn rename_compat(from: &Path, to: &Path) -> io::Result<()> {
             } else {
                 Err(e)
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::WorkspaceFs;
+    use std::path::{Path, PathBuf};
+    use uuid::Uuid;
+
+    fn fs(root: &str) -> WorkspaceFs {
+        WorkspaceFs::new(PathBuf::from(root), Uuid::new_v4())
+    }
+
+    #[test]
+    fn resolves_normal_paths_and_folds_legit_dotdot() {
+        let f = fs("/data/ws/123/files");
+        assert_eq!(
+            f.resolve("/knowledge/foo.txt"),
+            PathBuf::from("/data/ws/123/files/knowledge/foo.txt"),
+        );
+        // A legitimate `..` is folded, not rejected (would break a valid `/a/b/../c`).
+        assert_eq!(f.resolve("/a/b/../c"), PathBuf::from("/data/ws/123/files/a/c"));
+        assert_eq!(f.resolve("/a/./b/../c"), PathBuf::from("/data/ws/123/files/a/c"));
+    }
+
+    #[test]
+    fn dotdot_can_never_escape_the_root() {
+        let root = Path::new("/data/ws/123/files");
+        let f = fs("/data/ws/123/files");
+        for input in [
+            "/../../etc/passwd",
+            "/../../../../../../../../etc/passwd",
+            "/files/../../../sibling/secret",
+            "/../ws/456/files/other-tenant.txt",
+            "/a/../../../../b",
+            "/..",
+            "/",
+            "",
+        ] {
+            let got = f.resolve(input);
+            assert!(
+                got.starts_with(root),
+                "escaped root: {input:?} -> {got:?}",
+            );
         }
     }
 }

--- a/backend/src/state/workspace/fs.rs
+++ b/backend/src/state/workspace/fs.rs
@@ -76,10 +76,35 @@ pub enum ReadDirMeta {
     None,
 }
 
-/// True when `rel_path` lives under the `knowledge/` directory. Component-wise
-/// match on the leading dir: `knowledge/x` hits, `knowledgebase/x` does not.
+/// Fold a workspace-relative path into its normalized components, clamped at the
+/// root: `Normal` segments push, `..` pops (a no-op on the empty base, so it can
+/// never climb above the workspace root), and `.`/`RootDir`/`Prefix` are dropped.
+///
+/// Shared by [`WorkspaceFs::resolve`] (→ on-disk path) and [`is_knowledge`] (→
+/// classification) so the two can't disagree on an unnormalized path: e.g.
+/// `/a/../knowledge/x` folds into `knowledge/` for both, and `/knowledge/../x`
+/// folds out of it for both.
+fn fold_rel(rel_path: &str) -> Vec<OsString> {
+    let mut parts: Vec<OsString> = Vec::new();
+    for comp in Path::new(rel_path.trim_start_matches('/')).components() {
+        match comp {
+            Component::Normal(c) => parts.push(c.to_os_string()),
+            Component::ParentDir => {
+                parts.pop();
+            }
+            _ => {}
+        }
+    }
+    parts
+}
+
+/// True when `rel_path`, once normalized, lives under the `knowledge/` directory.
+/// Derived from the same fold as `resolve`, so classification tracks the actual
+/// on-disk destination even for unnormalized input. Component-wise: `knowledge/x`
+/// hits, `knowledgebase/x` and the bare `knowledge` dir do not.
 fn is_knowledge(rel_path: &str) -> bool {
-    rel_path.trim_start_matches('/').starts_with("knowledge/")
+    let parts = fold_rel(rel_path);
+    parts.len() >= 2 && parts[0].to_str() == Some("knowledge")
 }
 
 // Side-processing for `knowledge/` mutations. Stubs for now: the real ingestion
@@ -217,30 +242,16 @@ impl WorkspaceFs {
     /// Absolute on-disk path of `rel_path` (a workspace-relative path such as
     /// `/knowledge/foo.txt`) inside this workspace.
     ///
-    /// Containment is enforced here so it holds for every caller, not just the
-    /// protocol layers that happen to pre-normalise (WebDAV's `DavPath`). We fold
-    /// the relative path in isolation — pushing `Normal` segments and popping on
-    /// `..` — then append it to an untouched `self.root`. Because `..` only ever
-    /// pops from `parts` (never from the root) and a pop on an empty stack is a
-    /// no-op, a `..` can never climb above the workspace root: an escaping path
-    /// like `/../../etc/passwd` folds back to an in-root path rather than reaching
-    /// the host filesystem. This is lexical (POSIX-style `/..` == `/`); it does
-    /// not resolve symlinks, which are not creatable through this API.
+    /// Containment is enforced here — via [`fold_rel`] — so it holds for every
+    /// caller, not just the protocol layers that happen to pre-normalise (WebDAV's
+    /// `DavPath`). The folded components are appended to an untouched `self.root`,
+    /// so a `..` can never climb above the root: an escaping path like
+    /// `/../../etc/passwd` folds back to an in-root path rather than reaching the
+    /// host filesystem. This is lexical (POSIX-style `/..` == `/`); it does not
+    /// resolve symlinks, which are not creatable through this API.
     fn resolve(&self, rel_path: &str) -> PathBuf {
-        let mut parts: Vec<OsString> = Vec::new();
-        for comp in Path::new(rel_path.trim_start_matches('/')).components() {
-            match comp {
-                Component::Normal(c) => parts.push(c.to_os_string()),
-                Component::ParentDir => {
-                    parts.pop();
-                }
-                // `CurDir` is a no-op; `RootDir`/`Prefix` can't reach the root
-                // (the leading `/` is already trimmed) so they're ignored too.
-                _ => {}
-            }
-        }
         let mut out = self.root.clone();
-        out.extend(parts);
+        out.extend(fold_rel(rel_path));
         out
     }
 
@@ -456,6 +467,27 @@ mod resolve_tests {
         // A legitimate `..` is folded, not rejected (would break a valid `/a/b/../c`).
         assert_eq!(f.resolve("/a/b/../c"), PathBuf::from("/data/ws/123/files/a/c"));
         assert_eq!(f.resolve("/a/./b/../c"), PathBuf::from("/data/ws/123/files/a/c"));
+    }
+
+    #[test]
+    fn is_knowledge_tracks_the_resolved_destination() {
+        use super::is_knowledge;
+        let f = fs("/data/ws/123/files");
+        let kroot = f.resolve("/knowledge");
+
+        // The two cases the review flagged: classification must match where the
+        // path actually resolves, not the raw prefix.
+        // `/knowledge/../secret.txt` resolves OUT of knowledge/ → not knowledge.
+        assert!(!is_knowledge("/knowledge/../secret.txt"));
+        assert!(!f.resolve("/knowledge/../secret.txt").starts_with(&kroot));
+        // `/a/../knowledge/doc.txt` resolves INTO knowledge/ → is knowledge.
+        assert!(is_knowledge("/a/../knowledge/doc.txt"));
+        assert!(f.resolve("/a/../knowledge/doc.txt").starts_with(&kroot));
+
+        // Baselines: a real child hits; the bare dir and a look-alike prefix don't.
+        assert!(is_knowledge("/knowledge/doc.txt"));
+        assert!(!is_knowledge("/knowledge"));
+        assert!(!is_knowledge("/knowledgebase/doc.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

`WorkspaceFs::resolve` joined a workspace-relative path onto the root without normalization, so a `rel_path` containing `..` climbed out of the workspace at the OS level (e.g. `/../../etc/passwd`, or `/../<other_wid>/files/...` into another workspace). `resolve` is the single choke point every local fs op passes through (`open` / `metadata` / `read` / `rename` / `copy` / `remove` / `readdir`), so the guard belongs here rather than in each protocol layer.

WebDAV happened to be safe because `DavPath` normalizes `..` before it reaches `resolve`, but that only protects the WebDAV caller. This hardens the shared primitive so containment holds for **every** caller (the concern raised in #204 / #201 / #206).

## Approach — clamp, not reject

`resolve` now folds the path lexically and clamps at the root instead of rejecting `..`. Rationale:

- **Doesn't break legitimate `..`** — `/a/b/../c` still resolves to `/a/c` (a blanket reject would `Forbidden` it, and the FUSE forwarder can forward a raw `..` lookup the kernel doesn't pre-resolve).
- **Keeps POSIX semantics** (`/..` == `/`) — it's path normalization, not a validity check that can fail.

## Testing

- `cargo test -p agent-k-backend` — green. Added `resolve_tests` covering normal paths, legitimate `..`, and a set of escape attempts (over-shoot `..`, cross-workspace, `/..`, empty) that all stay within the root.

## Notes

- Containment is **lexical**; it does not resolve symlinks. Acceptable because no symlink-creation op is exposed through this filesystem (WebDAV / ForwardFs / guest forwarder).