### PR TITLE
feat(backend): live token streaming 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1172,10 +1171,8 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,7 +14,7 @@ ailoy = { workspace = true }
 anyhow = "1"
 argon2 = { version = "0.5", features = ["std"] }
 async-stream = "0.3"
-axum = { version = "0.8", features = ["multipart", "ws"] }
+axum = { version = "0.8", features = ["multipart"] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
 bytes = "1"
 chrono = { version = "0.4.42", features = ["serde", "clock"] }

--- a/backend/src/agent_stream.rs
+++ b/backend/src/agent_stream.rs
@@ -1,0 +1,272 @@
+//! Reassembles ailoy's raw streaming output into discrete, actionable items.
+//!
+//! `Agent::run_stream` yields a uniform stream of [`MessageDeltaOutput`]s.
+//! ailoy's stream contract guarantees every message ends with a delta carrying a
+//! `finish_reason` (the LangModel layer synthesizes a terminal Stop delta when a
+//! provider ends the stream without one), so a message boundary is exactly
+//! "`finish_reason` present". [`MessageAssembler`] folds deltas to that boundary
+//! while also passing the assistant's text through for live rendering —
+//! recreating the shape of ailoy's old `AgentEvent` (Delta | Message) for
+//! consumers that want both views. A non-conforming stream (role change with no
+//! intervening `finish_reason`) fails loudly via `accumulate` rather than being
+//! silently healed.
+
+use ailoy::message::{
+    Delta as _, FinishReason, MessageDeltaOutput, MessageOutput, PartDelta, Role,
+};
+
+/// One actionable item derived from the raw delta stream.
+#[derive(Debug)]
+pub enum AgentStreamItem {
+    /// Newly streamed top-level assistant text for live rendering. Empty
+    /// fragments are never emitted, and tool results and sub-agent (depth ≥ 1)
+    /// output never appear here — they surface only as
+    /// [`AgentStreamItem::Completed`], matching the pre-streaming-API semantics.
+    Delta(String),
+    /// A message finalized at a boundary (equivalent to the old
+    /// `AgentEvent::Message`): a completed assistant turn or a tool result. Boxed
+    /// so this variant doesn't bloat the small `Delta` case.
+    Completed(Box<MessageOutput>),
+}
+
+/// Accumulates streamed [`MessageDeltaOutput`]s and emits [`AgentStreamItem`]s at
+/// message boundaries. Feed each delta to [`push`](Self::push); call
+/// [`finish`](Self::finish) once the stream ends to flush any trailing message.
+#[derive(Default)]
+pub struct MessageAssembler {
+    /// The message currently being streamed, accumulated across deltas.
+    acc: MessageDeltaOutput,
+}
+
+impl MessageAssembler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one streamed delta. Returns the items to act on, in order: an
+    /// optional `Delta` (assistant text from this delta), then an optional
+    /// `Completed` (when this delta carries the message's `finish_reason`).
+    /// `Err` carries a finalization/accumulation failure message; a role change
+    /// with no intervening `finish_reason` (contract violation) lands here via
+    /// `accumulate`'s role-mismatch rejection.
+    pub fn push(&mut self, delta: MessageDeltaOutput) -> Result<Vec<AgentStreamItem>, String> {
+        let mut items = Vec::new();
+
+        // 1. Live assistant text — top-level only. A sub-agent's answer is
+        //    re-emitted on this same stream as a role=Assistant one-shot at
+        //    depth ≥ 1; streaming it here would splice the sub-agent's internal
+        //    text into the top-level answer (and a stop would persist that mix).
+        //    A continuation delta carries no role/depth, so fall back to the
+        //    in-progress message's; exclude Tool rather than require Assistant
+        //    so text streamed before the role marker isn't dropped.
+        let effective_role = delta.delta.role.as_ref().or(self.acc.delta.role.as_ref());
+        let is_top_level = matches!(delta.depth.or(self.acc.depth), None | Some(0));
+        if is_top_level && !matches!(effective_role, Some(Role::Tool)) {
+            let mut fragment = String::new();
+            for part in &delta.delta.contents {
+                if let PartDelta::Text { text } = part {
+                    fragment.push_str(text);
+                }
+            }
+            if !fragment.is_empty() {
+                items.push(AgentStreamItem::Delta(fragment));
+            }
+        }
+
+        // 2. Fold this delta into the running message.
+        let acc = std::mem::take(&mut self.acc);
+        self.acc = acc.accumulate(delta).map_err(|e| e.to_string())?;
+
+        // 3. A delta carrying finish_reason finalizes the message — per ailoy's
+        //    stream contract, this is the message boundary.
+        if self.acc.finish_reason.is_some() {
+            let done = std::mem::take(&mut self.acc);
+            items.push(AgentStreamItem::Completed(Box::new(
+                done.finish().map_err(|e| e.to_string())?,
+            )));
+        }
+
+        Ok(items)
+    }
+
+    /// Flush a message still accumulating when the stream ends. Defensive:
+    /// ailoy's contract (every message ends with a finish_reason delta) makes
+    /// this a no-op for conforming streams — `Some` here means an upstream
+    /// producer broke the contract, so the caller should log it. The message is
+    /// still returned (finalized as Stop) rather than dropped, because losing a
+    /// completed answer is strictly worse than surfacing a contract bug quietly.
+    /// Returns `None` if nothing pending.
+    pub fn finish(&mut self) -> Result<Option<MessageOutput>, String> {
+        if self.acc.delta.role.is_none() {
+            return Ok(None);
+        }
+        let mut done = std::mem::take(&mut self.acc);
+        done.finish_reason.get_or_insert(FinishReason::Stop {});
+        Ok(Some(done.finish().map_err(|e| e.to_string())?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ailoy::message::MessageDelta;
+
+    use super::*;
+
+    /// Build a streamed delta with an optional role, text, and finish_reason.
+    fn delta(role: Option<Role>, text: &str, finish: bool) -> MessageDeltaOutput {
+        let mut md = MessageDelta::new();
+        if let Some(r) = role {
+            md = md.with_role(r);
+        }
+        if !text.is_empty() {
+            md = md.with_contents([PartDelta::Text { text: text.into() }]);
+        }
+        let mut out = MessageDeltaOutput::new();
+        out.delta = md;
+        out.depth = Some(0);
+        if finish {
+            out.finish_reason = Some(FinishReason::Stop {});
+        }
+        out
+    }
+
+    fn text_of(items: &[AgentStreamItem]) -> Vec<String> {
+        items
+            .iter()
+            .filter_map(|i| match i {
+                AgentStreamItem::Delta(t) => Some(t.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn completed(items: Vec<AgentStreamItem>) -> Vec<MessageOutput> {
+        items
+            .into_iter()
+            .filter_map(|i| match i {
+                AgentStreamItem::Completed(o) => Some(*o),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn streams_text_then_completes_on_finish_reason() {
+        let mut a = MessageAssembler::new();
+
+        let first = a.push(delta(Some(Role::Assistant), "Hel", false)).unwrap();
+        assert_eq!(text_of(&first), vec!["Hel"]);
+        assert!(completed(first).is_empty());
+
+        let second = a.push(delta(None, "lo", true)).unwrap();
+        assert_eq!(text_of(&second), vec!["lo"]);
+        let done = completed(second);
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].message.role, Role::Assistant);
+        assert_eq!(done[0].message.contents[0].as_text().unwrap(), "Hello");
+        assert!(matches!(done[0].finish_reason, FinishReason::Stop {}));
+
+        // Nothing pending after a clean finish.
+        assert!(a.finish().unwrap().is_none());
+    }
+
+    #[test]
+    fn flushes_trailing_message_when_stream_ends_without_finish_reason() {
+        // Defensive path: ailoy's contract means a conforming stream never ends
+        // mid-message, but if one does (upstream bug), the trailing message must
+        // be recovered — losing a completed answer is worse than the anomaly.
+        let mut a = MessageAssembler::new();
+
+        let items = a
+            .push(delta(Some(Role::Assistant), "answer", false))
+            .unwrap();
+        assert_eq!(text_of(&items), vec!["answer"]);
+        assert!(completed(items).is_empty());
+
+        let trailing = a.finish().unwrap().expect("trailing message must flush");
+        assert_eq!(trailing.message.role, Role::Assistant);
+        assert_eq!(trailing.message.contents[0].as_text().unwrap(), "answer");
+        assert!(matches!(trailing.finish_reason, FinishReason::Stop {}));
+    }
+
+    #[test]
+    fn tool_result_surfaces_only_as_completed_never_as_delta() {
+        let mut a = MessageAssembler::new();
+        // Finish an assistant turn first.
+        a.push(delta(Some(Role::Assistant), "calling", true))
+            .unwrap();
+
+        // A tool result arrives as its own role=Tool one-shot delta.
+        let items = a
+            .push(delta(Some(Role::Tool), "tool output", true))
+            .unwrap();
+        assert!(
+            text_of(&items).is_empty(),
+            "tool result must not stream as assistant text"
+        );
+        let done = completed(items);
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].message.role, Role::Tool);
+    }
+
+    #[test]
+    fn role_change_without_finish_reason_errors_loudly() {
+        // ailoy's contract guarantees a finish_reason delta closes every message
+        // before the role can change; a violation must surface as an error (via
+        // accumulate's role-mismatch rejection), not be silently healed into a
+        // split — silent healing would mask a broken producer.
+        let mut a = MessageAssembler::new();
+        let first = a
+            .push(delta(Some(Role::Assistant), "thinking", false))
+            .unwrap();
+        assert_eq!(text_of(&first), vec!["thinking"]);
+        assert!(completed(first).is_empty());
+
+        let err = a
+            .push(delta(Some(Role::Tool), "result", true))
+            .expect_err("role change without finish_reason must be rejected");
+        assert!(
+            err.contains("role"),
+            "error should mention the role mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn subagent_output_never_streams_as_live_delta() {
+        // A sub-agent's answer is re-emitted on the stream as a one-shot
+        // role=Assistant delta at depth >= 1. It must not surface as live
+        // top-level text (that would splice the sub-agent's internal answer
+        // into the main bubble, and a stop would persist the mix) — only as a
+        // Completed message, which the client routes to the sub-agent UI.
+        let mut a = MessageAssembler::new();
+        let mut d = delta(Some(Role::Assistant), "subagent internal answer", true);
+        d.depth = Some(1);
+        let items = a.push(d).unwrap();
+        assert!(
+            text_of(&items).is_empty(),
+            "sub-agent text must not stream as the top-level answer"
+        );
+        let done = completed(items);
+        assert_eq!(done.len(), 1);
+        assert_eq!(done[0].depth, Some(1));
+        assert_eq!(
+            done[0].message.contents[0].as_text().unwrap(),
+            "subagent internal answer"
+        );
+    }
+
+    #[test]
+    fn empty_fragments_are_not_emitted() {
+        let mut a = MessageAssembler::new();
+        // A role-only opener (e.g. message_start) carries no text.
+        let items = a.push(delta(Some(Role::Assistant), "", false)).unwrap();
+        assert!(text_of(&items).is_empty());
+        assert!(completed(items).is_empty());
+    }
+
+    #[test]
+    fn finish_on_empty_assembler_yields_nothing() {
+        let mut a = MessageAssembler::new();
+        assert!(a.finish().unwrap().is_none());
+    }
+}

--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -23,8 +23,8 @@ pub struct AuthUser {
 
 /// Decode `token`, load the subject, and require an active account, returning
 /// the authenticated principal. The single authentication gate shared by the
-/// `auth_required` middleware and the token-in-query endpoints (WebDAV and the
-/// message WebSocket) that bypass the middleware.
+/// `auth_required` middleware and the WebDAV routes, which bypass the
+/// middleware and authenticate inline from the `Authorization` header.
 pub async fn authenticate(state: &AppState, token: &str) -> Result<AuthUser, ApiError> {
     let claims = state.jwt.decode(token)?;
 
@@ -135,7 +135,7 @@ mod tests {
         assert_eq!(principal.id, user.id);
 
         // Deactivated account → rejected, even with a still-valid token. This
-        // closes the WebDAV/WS bypass that only checked token validity.
+        // closes the WebDAV bypass that only checked token validity.
         state
             .users
             .update(

--- a/backend/src/event.rs
+++ b/backend/src/event.rs
@@ -58,18 +58,57 @@ impl EventQueue {
 
 // channels & payloads
 
-/// `message/{session_id}` — fanout for messages appended to a session's
-/// history. Publishers (the run loop) and subscribers (the WS handler) both
+/// `message/{session_id}` — fanout for everything happening in a session: the
+/// messages appended to its history, live streaming deltas, and run lifecycle
+/// transitions. Publishers (the run loop) and subscribers (the WS handler) both
 /// build the name through this helper so they stay aligned.
 pub fn message_channel(session_id: Uuid) -> String {
     format!("message/{session_id}")
 }
 
-/// Payload shape for the `message/{session_id}` channel. Encoded to a JSON
-/// `String` before being handed to [`EventQueue::publish`]; subscribers parse
-/// the same shape back out to filter by `seq`.
+/// Payload shape for the `message/{session_id}` channel, JSON-encoded before
+/// being handed to [`EventQueue::publish`]. The WS handler forwards these to
+/// the client verbatim; only `Message` carries a `seq` (it is the persisted,
+/// catch-up-able record — `Delta` and `Run` are ephemeral and exist solely on
+/// the live stream).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct MessageEvent {
-    pub seq: i64,
-    pub message: Message,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionEvent {
+    /// A message persisted to the session's history at sequence `seq`. Mirrors
+    /// the HTTP `GET /sessions/{id}/messages` item shape so catch-up over
+    /// either transport is interchangeable on the client.
+    Message { seq: i64, message: Message },
+
+    /// Newly streamed top-level assistant text for the in-progress turn.
+    /// Ephemeral: not persisted, no seq. `text` is the newly produced
+    /// fragment; `cum_len` is the turn's total length (in UTF-16 code units,
+    /// matching JS `String.length`) after appending it. The client uses
+    /// `cum_len` to dedup/order across the catch-up↔live boundary: skip if
+    /// already applied, slice off any overlap. The catch-up path sends the
+    /// whole partial turn as one delta. Reconciled by the completed `Message`
+    /// that follows.
+    Delta { text: String, cum_len: u64 },
+
+    /// Run lifecycle transition. `Started` is also re-sent by the WS catch-up
+    /// when a client attaches while a run is in flight, so it reads as "a run
+    /// is active", not strictly "a run just began".
+    Run {
+        #[serde(flatten)]
+        status: RunStatus,
+    },
+}
+
+/// Terminal (and initial) states of an agent run, flattened into
+/// [`SessionEvent::Run`] as `{"status": "...", ...}`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RunStatus {
+    /// A run is in flight for this session.
+    Started,
+    /// The run finished on its own.
+    Done,
+    /// The run was cut short by a stop request.
+    Stopped,
+    /// The run failed; `message` is the error rendered for display.
+    Error { message: String },
 }

--- a/backend/src/event.rs
+++ b/backend/src/event.rs
@@ -50,7 +50,7 @@ impl EventQueue {
 
     /// Drop a channel. Any live subscribers will see `RecvError::Closed` on
     /// their next `recv()` and unwind cleanly. Used on session deletion to
-    /// kick attached WS clients off the now-dead session.
+    /// kick attached SSE subscribers off the now-dead session.
     pub fn remove_channel(&self, channel: &str) {
         self.channels.remove(channel);
     }
@@ -60,14 +60,14 @@ impl EventQueue {
 
 /// `message/{session_id}` — fanout for everything happening in a session: the
 /// messages appended to its history, live streaming deltas, and run lifecycle
-/// transitions. Publishers (the run loop) and subscribers (the WS handler) both
+/// transitions. Publishers (the run loop) and subscribers (the SSE handler) both
 /// build the name through this helper so they stay aligned.
 pub fn message_channel(session_id: Uuid) -> String {
     format!("message/{session_id}")
 }
 
 /// Payload shape for the `message/{session_id}` channel, JSON-encoded before
-/// being handed to [`EventQueue::publish`]. The WS handler forwards these to
+/// being handed to [`EventQueue::publish`]. The SSE handler forwards these to
 /// the client verbatim; only `Message` carries a `seq` (it is the persisted,
 /// catch-up-able record — `Delta` and `Run` are ephemeral and exist solely on
 /// the live stream).
@@ -89,7 +89,7 @@ pub enum SessionEvent {
     /// that follows.
     Delta { text: String, cum_len: u64 },
 
-    /// Run lifecycle transition. `Started` is also re-sent by the WS catch-up
+    /// Run lifecycle transition. `Started` is also re-sent by the SSE catch-up
     /// when a client attaches while a run is in flight, so it reads as "a run
     /// is active", not strictly "a run just began".
     Run {

--- a/backend/src/event.rs
+++ b/backend/src/event.rs
@@ -77,7 +77,17 @@ pub enum SessionEvent {
     /// A message persisted to the session's history at sequence `seq`. Mirrors
     /// the HTTP `GET /sessions/{id}/messages` item shape so catch-up over
     /// either transport is interchangeable on the client.
-    Message { seq: i64, message: Message },
+    Message {
+        seq: i64,
+        /// Nesting level relative to the top-level agent turn: `0` is the
+        /// conversation the user sees; `>= 1` is a sub-agent's internal
+        /// output (render it indented/collapsed under the calling turn).
+        depth: u8,
+        /// Name of the agent that produced the message, when known. `None`
+        /// for user turns and synthetic (interrupt) messages.
+        source_agent: Option<String>,
+        message: Message,
+    },
 
     /// Newly streamed top-level assistant text for the in-progress turn.
     /// Ephemeral: not persisted, no seq. `text` is the newly produced

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_stream;
 mod auth;
 mod event;
 mod router;

--- a/backend/src/router/message.rs
+++ b/backend/src/router/message.rs
@@ -17,15 +17,19 @@ use uuid::Uuid;
 
 use crate::{
     auth::{AuthUser, authenticate},
-    event::{MessageEvent, message_channel},
+    event::{RunStatus, SessionEvent, message_channel},
     state::AppState,
 };
 
-use super::{error::{ApiError, err}, workspace::require_owned_session};
+use super::{
+    error::{ApiError, err},
+    workspace::require_owned_session,
+};
 
 /// A single persisted message together with its session-local sequence
-/// number. Mirrors the `message/{id}` channel's [`MessageEvent`] shape so HTTP
-/// catch-up and the WS stream are interchangeable on the client.
+/// number. Mirrors the `message/{id}` channel's [`SessionEvent::Message`]
+/// shape (minus the `type` tag) so HTTP catch-up and the WS stream are
+/// interchangeable on the client.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct MessageResponse {
     pub seq: i64,
@@ -100,9 +104,11 @@ pub(super) async fn stop_run(
 
 /// Subscribe-then-catch-up: subscribe to the per-session channel first so any
 /// publish concurrent with our DB catch-up is buffered into `rx`; then drain
-/// rows with `seq > last_seq` from the DB; then forward live events filtered
-/// by `seq > last_seq` (dedup against the catch-up). On `Lagged` we replay
-/// the catch-up to reconcile.
+/// rows with `seq > last_seq` from the DB, followed by the in-flight turn's
+/// partial text (as one cumulative delta) when a run is active; then forward
+/// live events — `message` events filtered by `seq > last_seq` (dedup against
+/// the catch-up), `delta`/`run` events verbatim (the client dedups deltas by
+/// `cum_len`). On `Lagged` we replay the catch-up to reconcile.
 pub(super) async fn stream_messages(
     State(state): State<Arc<AppState>>,
     Path(sid): Path<Uuid>,
@@ -132,7 +138,8 @@ pub(super) async fn stream_messages(
                 }
             };
             for (seq, message) in rows {
-                let payload = match serde_json::to_string(&MessageEvent { seq, message }) {
+                let payload = match serde_json::to_string(&SessionEvent::Message { seq, message })
+                {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::error!(session = %sid, "ws catch-up serialize error: {e}");
@@ -145,21 +152,61 @@ pub(super) async fn stream_messages(
                 last_seq = seq;
             }
 
+            // A run in flight when we attach: tell the client, then hand it
+            // the in-progress turn's streamed-so-far text as one cumulative
+            // delta so it doesn't wait for the next fragment. Live deltas
+            // buffered in `rx` meanwhile overlap this snapshot; the client's
+            // `cum_len` dedup drops them.
+            if let Some(partial) = state.sessions.live_partial(sid).await {
+                let mut events = vec![SessionEvent::Run {
+                    status: RunStatus::Started,
+                }];
+                if !partial.is_empty() {
+                    let cum_len = partial.encode_utf16().count() as u64;
+                    events.push(SessionEvent::Delta {
+                        text: partial,
+                        cum_len,
+                    });
+                }
+                for event in events {
+                    let payload = match serde_json::to_string(&event) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::error!(session = %sid, "ws catch-up serialize error: {e}");
+                            return;
+                        }
+                    };
+                    if socket.send(WsMessage::Text(payload.into())).await.is_err() {
+                        return;
+                    }
+                }
+            }
+
             // Live pump until lag forces another catch-up or the channel closes.
             loop {
                 match rx.recv().await {
                     Ok(payload) => {
-                        let seq = serde_json::from_str::<serde_json::Value>(&payload)
-                            .ok()
-                            .and_then(|v| v.get("seq").and_then(|s| s.as_i64()));
-                        let Some(seq) = seq else { continue };
-                        if seq <= last_seq {
-                            continue;
-                        }
-                        if socket.send(WsMessage::Text(payload.into())).await.is_err() {
+                        // Only `message` events carry a seq and need dedup
+                        // against the catch-up; everything else (`delta`,
+                        // `run`) is ephemeral and forwarded verbatim.
+                        let value: serde_json::Value = match serde_json::from_str(&payload) {
+                            Ok(v) => v,
+                            Err(_) => continue,
+                        };
+                        if value.get("type").and_then(|t| t.as_str()) == Some("message") {
+                            let Some(seq) = value.get("seq").and_then(|s| s.as_i64()) else {
+                                continue;
+                            };
+                            if seq <= last_seq {
+                                continue;
+                            }
+                            if socket.send(WsMessage::Text(payload.into())).await.is_err() {
+                                return;
+                            }
+                            last_seq = seq;
+                        } else if socket.send(WsMessage::Text(payload.into())).await.is_err() {
                             return;
                         }
-                        last_seq = seq;
                     }
                     Err(RecvError::Lagged(missed)) => {
                         tracing::warn!(session = %sid, missed, "ws subscriber lagged — reconciling from DB");

--- a/backend/src/router/message.rs
+++ b/backend/src/router/message.rs
@@ -1,22 +1,20 @@
-use std::sync::Arc;
+use std::{convert::Infallible, sync::Arc};
 
 use ailoy::message::{Message, Part};
 use axum::{
     Extension, Json,
-    extract::{
-        Path, Query, State,
-        ws::{Message as WsMessage, WebSocketUpgrade},
-    },
-    http::StatusCode,
-    response::Response,
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::sse::{Event, KeepAlive, Sse},
 };
+use futures_util::Stream;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 use uuid::Uuid;
 
 use crate::{
-    auth::{AuthUser, authenticate},
+    auth::AuthUser,
     event::{RunStatus, SessionEvent, message_channel},
     state::AppState,
 };
@@ -28,7 +26,7 @@ use super::{
 
 /// A single persisted message together with its session-local sequence
 /// number. Mirrors the `message/{id}` channel's [`SessionEvent::Message`]
-/// shape (minus the `type` tag) so HTTP catch-up and the WS stream are
+/// shape (minus the `type` tag) so HTTP catch-up and the SSE stream are
 /// interchangeable on the client.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct MessageResponse {
@@ -50,13 +48,10 @@ pub struct PostMessageRequest {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct MessagesWsQuery {
-    /// Bearer JWT — passed as a query parameter because browser `WebSocket`
-    /// clients can't set custom headers on the upgrade request.
-    pub token: String,
-
+pub struct StreamQuery {
     /// Last seq the client already has. Resume forwards from `seq + 1`.
-    /// Omit to receive from the start of the session.
+    /// Omit to receive from the start of the session. On an SSE auto-reconnect
+    /// the `Last-Event-ID` header takes precedence over this.
     #[serde(default)]
     pub last_seq: Option<i64>,
 }
@@ -102,6 +97,9 @@ pub(super) async fn stop_run(
     }
 }
 
+/// `GET /sessions/{id}/messages/stream` — the session's live event stream as
+/// SSE, carrying [`SessionEvent`] JSON in each event's `data`.
+///
 /// Subscribe-then-catch-up: subscribe to the per-session channel first so any
 /// publish concurrent with our DB catch-up is buffered into `rx`; then drain
 /// rows with `seq > last_seq` from the DB, followed by the in-flight turn's
@@ -109,20 +107,27 @@ pub(super) async fn stop_run(
 /// live events — `message` events filtered by `seq > last_seq` (dedup against
 /// the catch-up), `delta`/`run` events verbatim (the client dedups deltas by
 /// `cum_len`). On `Lagged` we replay the catch-up to reconcile.
+///
+/// Only `message` events carry an SSE `id` (their `seq`), so the browser's
+/// `Last-Event-ID` on auto-reconnect resumes from the persisted cursor —
+/// ephemeral `delta`/`run` events never advance it.
 pub(super) async fn stream_messages(
     State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
     Path(sid): Path<Uuid>,
-    Query(query): Query<MessagesWsQuery>,
-    ws: WebSocketUpgrade,
-) -> Result<Response, ApiError> {
-    // Token via query (browser WebSockets can't set headers). authenticate +
-    // require_owned_session apply the same gate as the HTTP routes.
-    let user = authenticate(&state, &query.token).await?;
-    require_owned_session(&state, &user, sid).await?;
+    Query(query): Query<StreamQuery>,
+    headers: HeaderMap,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    require_owned_session(&state, &auth, sid).await?;
 
-    let last_seq = query.last_seq.unwrap_or(-1);
+    let last_seq = headers
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<i64>().ok())
+        .or(query.last_seq)
+        .unwrap_or(-1);
 
-    Ok(ws.on_upgrade(move |mut socket| async move {
+    let stream = async_stream::stream! {
         let mut last_seq = last_seq;
         let channel = message_channel(sid);
         let mut rx = state.events.subscribe(&channel);
@@ -133,7 +138,7 @@ pub(super) async fn stream_messages(
             let rows = match state.sessions.list_messages_since(sid, last_seq).await {
                 Ok(r) => r,
                 Err(e) => {
-                    tracing::error!(session = %sid, "ws catch-up DB error: {e}");
+                    tracing::error!(session = %sid, "sse catch-up DB error: {e}");
                     return;
                 }
             };
@@ -142,13 +147,11 @@ pub(super) async fn stream_messages(
                 {
                     Ok(s) => s,
                     Err(e) => {
-                        tracing::error!(session = %sid, "ws catch-up serialize error: {e}");
+                        tracing::error!(session = %sid, "sse catch-up serialize error: {e}");
                         return;
                     }
                 };
-                if socket.send(WsMessage::Text(payload.into())).await.is_err() {
-                    return;
-                }
+                yield Ok(Event::default().id(seq.to_string()).data(payload));
                 last_seq = seq;
             }
 
@@ -172,13 +175,11 @@ pub(super) async fn stream_messages(
                     let payload = match serde_json::to_string(&event) {
                         Ok(s) => s,
                         Err(e) => {
-                            tracing::error!(session = %sid, "ws catch-up serialize error: {e}");
+                            tracing::error!(session = %sid, "sse catch-up serialize error: {e}");
                             return;
                         }
                     };
-                    if socket.send(WsMessage::Text(payload.into())).await.is_err() {
-                        return;
-                    }
+                    yield Ok(Event::default().data(payload));
                 }
             }
 
@@ -200,21 +201,23 @@ pub(super) async fn stream_messages(
                             if seq <= last_seq {
                                 continue;
                             }
-                            if socket.send(WsMessage::Text(payload.into())).await.is_err() {
-                                return;
-                            }
+                            yield Ok(Event::default().id(seq.to_string()).data(payload));
                             last_seq = seq;
-                        } else if socket.send(WsMessage::Text(payload.into())).await.is_err() {
-                            return;
+                        } else {
+                            yield Ok(Event::default().data(payload));
                         }
                     }
                     Err(RecvError::Lagged(missed)) => {
-                        tracing::warn!(session = %sid, missed, "ws subscriber lagged — reconciling from DB");
+                        tracing::warn!(session = %sid, missed, "sse subscriber lagged — reconciling from DB");
                         break;
                     }
+                    // Channel removed (session deleted) — end the stream; a
+                    // reconnect attempt will get a 404 from the ownership gate.
                     Err(RecvError::Closed) => return,
                 }
             }
         }
-    }))
+    };
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }

--- a/backend/src/router/message.rs
+++ b/backend/src/router/message.rs
@@ -31,6 +31,11 @@ use super::{
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct MessageResponse {
     pub seq: i64,
+    /// Nesting level: `0` is the top-level conversation, `>= 1` a sub-agent's
+    /// internal output.
+    pub depth: u8,
+    /// Name of the agent that produced the message, when known.
+    pub source_agent: Option<String>,
     pub message: Message,
 }
 
@@ -68,7 +73,12 @@ pub(super) async fn list_messages(
     Ok(Json(MessageListResponse {
         items: messages
             .into_iter()
-            .map(|(seq, message)| MessageResponse { seq, message })
+            .map(|(seq, stored)| MessageResponse {
+                seq,
+                depth: stored.depth,
+                source_agent: stored.source_agent,
+                message: stored.message,
+            })
             .collect(),
     }))
 }
@@ -142,9 +152,14 @@ pub(super) async fn stream_messages(
                     return;
                 }
             };
-            for (seq, message) in rows {
-                let payload = match serde_json::to_string(&SessionEvent::Message { seq, message })
-                {
+            for (seq, stored) in rows {
+                let event = SessionEvent::Message {
+                    seq,
+                    depth: stored.depth,
+                    source_agent: stored.source_agent,
+                    message: stored.message,
+                };
+                let payload = match serde_json::to_string(&event) {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::error!(session = %sid, "sse catch-up serialize error: {e}");

--- a/backend/src/router/mod.rs
+++ b/backend/src/router/mod.rs
@@ -30,10 +30,10 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
     //   (admin + `/me` + workspaces + sessions HTTP), wrapping them as the
     //   outer layer so `AuthUser` is populated before `admin_required`
     //   inspects the role.
-    // - Public routes (`/auth/*`, the WS endpoint) are registered after
-    //   both layers and therefore bypass them. The WS endpoint authenticates
-    //   inline via a `?token=…` query parameter because browser `WebSocket`
-    //   clients can't send custom `Authorization` headers.
+    // - Public routes (`/auth/*`) are registered after both layers and
+    //   therefore bypass them. The SSE stream sits inside the auth layer like
+    //   any other session route — clients consume it via `fetch`, which can
+    //   send the `Authorization` header (unlike the native `EventSource`).
     ApiRouter::new()
         .api_route(
             "/admin/users",
@@ -106,16 +106,17 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
             get(message::list_messages).post(message::start_run),
         )
         .api_route("/sessions/{id}/messages/stop", post(message::stop_run))
+        // Plain route (not api_route): aide can't document an SSE stream.
+        .route(
+            "/sessions/{id}/messages/stream",
+            axum::routing::get(message::stream_messages),
+        )
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth_required,
         ))
         .api_route("/auth/signup", post(auth::signup))
         .api_route("/auth/login", post(auth::login))
-        .route(
-            "/sessions/{id}/messages/ws",
-            axum::routing::get(message::stream_messages),
-        )
         // WebDAV serves the unified workspace tree (local under `files/`, each
         // provider mount as a sibling) at `/sources`. Two routes: matchit's
         // `{*rest}` wildcard needs one-or-more segments, so the bare collection

--- a/backend/src/state/session.rs
+++ b/backend/src/state/session.rs
@@ -107,7 +107,7 @@ struct ActiveRun {
 
     /// Exact snapshot of the in-progress assistant turn's streamed text,
     /// mirrored from the run task on every delta. Lets a client that attaches
-    /// mid-turn catch up without a hole (the WS handler sends it as one
+    /// mid-turn catch up without a hole (the SSE handler sends it as one
     /// cumulative delta). A `std` mutex — only ever held for a clone/replace.
     partial: Arc<StdMutex<String>>,
 }
@@ -241,7 +241,7 @@ impl SessionsState {
         if tokio::fs::try_exists(&dir).await? {
             tokio::fs::remove_dir_all(&dir).await?;
         }
-        // Drop the channel so any attached WS subscribers wake up with
+        // Drop the channel so any attached SSE subscribers wake up with
         // RecvError::Closed instead of waiting on a session that no longer
         // exists.
         self.events.remove_channel(&message_channel(id));
@@ -289,14 +289,14 @@ impl SessionsState {
     }
 
     /// Return all messages for `session_id`, ordered by `seq` ascending. Backs
-    /// the `GET /sessions/{id}/messages` endpoint; the WS catch-up path uses
+    /// the `GET /sessions/{id}/messages` endpoint; the SSE catch-up path uses
     /// [`SessionsState::list_messages_since`] instead.
     pub async fn list_messages(&self, session_id: Uuid) -> StateResult<Vec<(i64, Message)>> {
         self.list_messages_since(session_id, -1).await
     }
 
     /// Return messages for `session_id` with `seq > since`, ordered ascending.
-    /// The WS handler uses this for catch-up before switching to the live
+    /// The SSE handler uses this for catch-up before switching to the live
     /// event subscription.
     pub async fn list_messages_since(
         &self,

--- a/backend/src/state/session.rs
+++ b/backend/src/state/session.rs
@@ -99,6 +99,41 @@ impl Session {
     }
 }
 
+/// One persisted history row: the message plus the agent-loop provenance a
+/// bare [`Message`] can't carry. This is the JSON shape of `messages.content`;
+/// rows written before provenance was recorded are a bare `Message` and are
+/// read back as depth-0 with no source (see [`parse_stored_message`]).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SessionMessage {
+    /// Nesting level relative to the top-level agent turn: `0` is the
+    /// conversation the user sees; `>= 1` is a sub-agent's internal output.
+    /// Only depth-0 rows are replayed into the model's history on the next
+    /// run.
+    #[serde(default)]
+    pub depth: u8,
+
+    /// Name of the agent that produced the message, when known. `None` for
+    /// user turns and synthetic (interrupt) messages.
+    #[serde(default)]
+    pub source_agent: Option<String>,
+
+    pub message: Message,
+}
+
+/// Decode one `messages.content` value. New rows store the wrapped
+/// [`SessionMessage`] shape; legacy rows are a bare [`Message`] (which lacks
+/// the `message` field, so the first parse fails cleanly) and fall back to
+/// depth-0 with no source.
+fn parse_stored_message(content: &str) -> serde_json::Result<SessionMessage> {
+    serde_json::from_str::<SessionMessage>(content).or_else(|_| {
+        serde_json::from_str::<Message>(content).map(|message| SessionMessage {
+            depth: 0,
+            source_agent: None,
+            message,
+        })
+    })
+}
+
 /// Book-keeping for one in-flight run, held in [`SessionsState::runs`].
 struct ActiveRun {
     /// Wakes the spawned task at its next safe point on
@@ -277,7 +312,7 @@ impl SessionsState {
 
     /// The streamed-so-far text of the in-progress assistant turn, if a run is
     /// in flight for `id`. `Some("")` means a run is active but hasn't
-    /// streamed top-level text yet; `None` means no active run. The WS
+    /// streamed top-level text yet; `None` means no active run. The SSE
     /// catch-up path uses this so a client attaching mid-turn starts from the
     /// full partial answer instead of the next delta.
     pub async fn live_partial(&self, id: Uuid) -> Option<String> {
@@ -291,7 +326,7 @@ impl SessionsState {
     /// Return all messages for `session_id`, ordered by `seq` ascending. Backs
     /// the `GET /sessions/{id}/messages` endpoint; the SSE catch-up path uses
     /// [`SessionsState::list_messages_since`] instead.
-    pub async fn list_messages(&self, session_id: Uuid) -> StateResult<Vec<(i64, Message)>> {
+    pub async fn list_messages(&self, session_id: Uuid) -> StateResult<Vec<(i64, SessionMessage)>> {
         self.list_messages_since(session_id, -1).await
     }
 
@@ -302,7 +337,7 @@ impl SessionsState {
         &self,
         session_id: Uuid,
         since: i64,
-    ) -> StateResult<Vec<(i64, Message)>> {
+    ) -> StateResult<Vec<(i64, SessionMessage)>> {
         let rows = sqlx::query(
             "SELECT seq, content FROM messages \
              WHERE session_id = ? AND seq > ? ORDER BY seq ASC",
@@ -312,11 +347,10 @@ impl SessionsState {
         .fetch_all(&self.db)
         .await?;
         rows.into_iter()
-            .map(|r| -> StateResult<(i64, Message)> {
+            .map(|r| -> StateResult<(i64, SessionMessage)> {
                 let seq: i64 = r.get("seq");
                 let content: String = r.get("content");
-                let message: Message = serde_json::from_str(&content)?;
-                Ok((seq, message))
+                Ok((seq, parse_stored_message(&content)?))
             })
             .collect()
     }
@@ -429,15 +463,28 @@ impl SessionsState {
                 };
 
                 let rows = sqlx::query(
-                    "SELECT content FROM messages WHERE session_id = ? ORDER BY seq ASC",
+                    "SELECT seq, content FROM messages WHERE session_id = ? ORDER BY seq ASC",
                 )
                 .bind(&session_key)
                 .fetch_all(&db)
                 .await?;
+                // Sequence numbers continue from the last persisted row — not
+                // from the replayed-history length, which is shorter once
+                // sub-agent rows are filtered out below.
+                let next_seq_start = rows.last().map(|r| r.get::<i64, _>("seq") + 1).unwrap_or(0);
+                // Replay only the top-level conversation (depth 0). A
+                // sub-agent's work reaches the model through its capped
+                // depth-0 tool result, never its internal transcript —
+                // mirroring ailoy's own in-memory history, which only ever
+                // holds depth-0 messages.
                 let history: Vec<Message> = rows
                     .iter()
-                    .map(|r| serde_json::from_str::<Message>(&r.get::<String, _>("content")))
-                    .collect::<Result<_, _>>()?;
+                    .map(|r| parse_stored_message(&r.get::<String, _>("content")))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .filter(|stored| stored.depth == 0)
+                    .map(|stored| stored.message)
+                    .collect();
 
                 // Drive — stream the model's raw deltas, publishing live text
                 // fragments as they arrive and persisting each message at its
@@ -445,7 +492,7 @@ impl SessionsState {
                 // how this exits, so capture the drive's Result and propagate
                 // it after archiving.
                 let drive: anyhow::Result<bool> = async {
-                    let mut next_seq = history.len() as i64;
+                    let mut next_seq = next_seq_start;
                     let mut state = AgentState::new().with_history(history);
                     if let Some(ref r) = runenv {
                         state = state.with_runenv(r.clone());
@@ -453,8 +500,19 @@ impl SessionsState {
                     let mut agent = Agent::try_with_state(spec, state)?;
 
                     let user_msg = Message::new(Role::User).with_contents(query);
-                    persist_message(&db, &events, &channel, &session_key, next_seq, user_msg.clone())
-                        .await?;
+                    persist_message(
+                        &db,
+                        &events,
+                        &channel,
+                        &session_key,
+                        next_seq,
+                        SessionMessage {
+                            depth: 0,
+                            source_agent: None,
+                            message: user_msg.clone(),
+                        },
+                    )
+                    .await?;
                     next_seq += 1;
 
                     // `run_stream` yields raw `MessageDeltaOutput`s; the
@@ -607,7 +665,11 @@ impl SessionsState {
                                         &channel,
                                         &session_key,
                                         next_seq,
-                                        output.message,
+                                        SessionMessage {
+                                            depth: output.depth.unwrap_or(0),
+                                            source_agent: output.source_agent,
+                                            message: output.message,
+                                        },
                                     )
                                     .await?;
                                     next_seq += 1;
@@ -648,8 +710,19 @@ impl SessionsState {
                                     .with_contents([Part::text(
                                         "[Interrupted: the user stopped response generation before this tool call completed]",
                                     )]);
-                                persist_message(&db, &events, &channel, &session_key, next_seq, stub)
-                                    .await?;
+                                persist_message(
+                                    &db,
+                                    &events,
+                                    &channel,
+                                    &session_key,
+                                    next_seq,
+                                    SessionMessage {
+                                        depth: 0,
+                                        source_agent: None,
+                                        message: stub,
+                                    },
+                                )
+                                .await?;
                                 next_seq += 1;
                             }
                             const INTERRUPT_NOTE: &str =
@@ -668,7 +741,12 @@ impl SessionsState {
                                 &channel,
                                 &session_key,
                                 next_seq,
-                                Message::new(Role::Assistant).with_contents([Part::text(note)]),
+                                SessionMessage {
+                                    depth: 0,
+                                    source_agent: None,
+                                    message: Message::new(Role::Assistant)
+                                        .with_contents([Part::text(note)]),
+                                },
                             )
                             .await?;
                             partial.lock().expect("partial lock poisoned").clear();
@@ -722,15 +800,16 @@ impl SessionsState {
     }
 }
 
-/// `INSERT` one message row for `session_key` at `seq` and publish it on the
-/// session's channel (a no-op when nobody is subscribed).
+/// `INSERT` one message row for `session_key` at `seq` (stored in the wrapped
+/// [`SessionMessage`] shape) and publish it on the session's channel (a no-op
+/// when nobody is subscribed).
 async fn persist_message(
     db: &SqlitePool,
     events: &EventQueue,
     channel: &str,
     session_key: &str,
     seq: i64,
-    message: Message,
+    stored: SessionMessage,
 ) -> anyhow::Result<()> {
     sqlx::query(
         "INSERT INTO messages (session_id, seq, content, created_at) \
@@ -738,13 +817,45 @@ async fn persist_message(
     )
     .bind(session_key)
     .bind(seq)
-    .bind(serde_json::to_string(&message)?)
+    .bind(serde_json::to_string(&stored)?)
     .bind(Utc::now().to_rfc3339())
     .execute(db)
     .await?;
     events.publish(
         channel,
-        serde_json::to_string(&SessionEvent::Message { seq, message })?,
+        serde_json::to_string(&SessionEvent::Message {
+            seq,
+            depth: stored.depth,
+            source_agent: stored.source_agent,
+            message: stored.message,
+        })?,
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rows written before provenance was recorded are a bare `Message`; they
+    /// must keep parsing (as depth-0, no source) alongside the wrapped shape,
+    /// or existing sessions break on upgrade.
+    #[test]
+    fn stored_message_parses_wrapped_and_legacy_rows() {
+        let wrapped = SessionMessage {
+            depth: 1,
+            source_agent: Some("researcher".into()),
+            message: Message::new(Role::Assistant).with_contents([Part::text("found it")]),
+        };
+        let parsed = parse_stored_message(&serde_json::to_string(&wrapped).unwrap()).unwrap();
+        assert_eq!(parsed.depth, 1);
+        assert_eq!(parsed.source_agent.as_deref(), Some("researcher"));
+        assert_eq!(parsed.message.contents[0].as_text(), Some("found it"));
+
+        let legacy = Message::new(Role::User).with_contents([Part::text("hi")]);
+        let parsed = parse_stored_message(&serde_json::to_string(&legacy).unwrap()).unwrap();
+        assert_eq!(parsed.depth, 0);
+        assert!(parsed.source_agent.is_none());
+        assert_eq!(parsed.message.role, Role::User);
+    }
 }

--- a/backend/src/state/session.rs
+++ b/backend/src/state/session.rs
@@ -1,19 +1,26 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, Mutex as StdMutex},
+};
 
 use ailoy::{
     agent::{Agent, AgentSpec, AgentState},
-    message::{Message, Part, Role},
+    message::{FinishReason, Message, Part, Role},
     runenv::{Machine as _, Sandbox, SandboxNetwork},
 };
 use chrono::{DateTime, Utc};
-use futures_util::StreamExt as _;
+use futures_util::{FutureExt as _, StreamExt as _};
 use sqlx::{Row as _, SqlitePool, sqlite::SqliteRow};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use super::{StateError, StateResult, parse_ts, parse_uuid};
-use crate::event::{EventQueue, MessageEvent, message_channel};
+use crate::{
+    agent_stream::{AgentStreamItem, MessageAssembler},
+    event::{EventQueue, RunStatus, SessionEvent, message_channel},
+};
 
 #[derive(Debug, Clone)]
 pub struct Session {
@@ -92,6 +99,19 @@ impl Session {
     }
 }
 
+/// Book-keeping for one in-flight run, held in [`SessionsState::runs`].
+struct ActiveRun {
+    /// Wakes the spawned task at its next safe point on
+    /// [`SessionsState::cancel`].
+    cancel: CancellationToken,
+
+    /// Exact snapshot of the in-progress assistant turn's streamed text,
+    /// mirrored from the run task on every delta. Lets a client that attaches
+    /// mid-turn catch up without a hole (the WS handler sends it as one
+    /// cumulative delta). A `std` mutex — only ever held for a clone/replace.
+    partial: Arc<StdMutex<String>>,
+}
+
 pub struct SessionsState {
     db: SqlitePool,
 
@@ -101,7 +121,7 @@ pub struct SessionsState {
     /// [`SessionsState::cancel`] can wake the spawned task; the entry's
     /// presence is also the "is this session running?" gate that rejects
     /// concurrent [`SessionsState::run`] calls.
-    runs: Arc<Mutex<HashMap<Uuid, CancellationToken>>>,
+    runs: Arc<Mutex<HashMap<Uuid, ActiveRun>>>,
 
     events: EventQueue,
 }
@@ -247,12 +267,25 @@ impl SessionsState {
     /// active. Non-blocking; the spawned task will clean up its own entry.
     pub async fn cancel(&self, id: Uuid) -> bool {
         match self.runs.lock().await.get(&id) {
-            Some(token) => {
-                token.cancel();
+            Some(run) => {
+                run.cancel.cancel();
                 true
             }
             None => false,
         }
+    }
+
+    /// The streamed-so-far text of the in-progress assistant turn, if a run is
+    /// in flight for `id`. `Some("")` means a run is active but hasn't
+    /// streamed top-level text yet; `None` means no active run. The WS
+    /// catch-up path uses this so a client attaching mid-turn starts from the
+    /// full partial answer instead of the next delta.
+    pub async fn live_partial(&self, id: Uuid) -> Option<String> {
+        self.runs
+            .lock()
+            .await
+            .get(&id)
+            .map(|run| run.partial.lock().expect("partial lock poisoned").clone())
     }
 
     /// Return all messages for `session_id`, ordered by `seq` ascending. Backs
@@ -291,19 +324,27 @@ impl SessionsState {
     /// Trigger an agent run for `id` with `query` as the user turn. Returns
     /// as soon as the run slot is reserved and the background task is
     /// spawned. Each persisted message is also published on the session's
-    /// `message/{id}` channel (no-op if no one is subscribed). Cancellation
-    /// is requested via [`SessionsState::cancel`].
+    /// `message/{id}` channel, along with ephemeral streaming deltas and run
+    /// lifecycle events (all no-ops if no one is subscribed). Cancellation is
+    /// requested via [`SessionsState::cancel`].
     ///
     /// Returns [`StateError::AlreadyRunning`] if a run is already in flight
     /// for this session.
     pub async fn run(&self, id: Uuid, query: Vec<Part>) -> StateResult<()> {
         let token = CancellationToken::new();
+        let partial = Arc::new(StdMutex::new(String::new()));
         {
             let mut runs = self.runs.lock().await;
             if runs.contains_key(&id) {
                 return Err(StateError::AlreadyRunning(id));
             }
-            runs.insert(id, token.clone());
+            runs.insert(
+                id,
+                ActiveRun {
+                    cancel: token.clone(),
+                    partial: partial.clone(),
+                },
+            );
         }
 
         let db = self.db.clone();
@@ -317,7 +358,16 @@ impl SessionsState {
             let archive_path = dir.join("sandbox.tar.zst");
             let channel = message_channel(id);
 
-            let result: anyhow::Result<()> = async {
+            // Ok(bool) is "was the run stopped?" — it picks the terminal
+            // lifecycle event published below.
+            let result: anyhow::Result<bool> = async {
+                events.publish(
+                    &channel,
+                    serde_json::to_string(&SessionEvent::Run {
+                        status: RunStatus::Started,
+                    })?,
+                );
+
                 // Setup — spec, history, sandbox.
                 let row =
                     sqlx::query("SELECT workspace_id, spec, runenv FROM sessions WHERE id = ?")
@@ -389,10 +439,12 @@ impl SessionsState {
                     .map(|r| serde_json::from_str::<Message>(&r.get::<String, _>("content")))
                     .collect::<Result<_, _>>()?;
 
-                // Drive — persist + publish each message. The sandbox archive
-                // below must run regardless of how this exits, so capture the
-                // drive's Result and propagate it after archiving.
-                let drive: anyhow::Result<()> = async {
+                // Drive — stream the model's raw deltas, publishing live text
+                // fragments as they arrive and persisting each message at its
+                // boundary. The sandbox archive below must run regardless of
+                // how this exits, so capture the drive's Result and propagate
+                // it after archiving.
+                let drive: anyhow::Result<bool> = async {
                     let mut next_seq = history.len() as i64;
                     let mut state = AgentState::new().with_history(history);
                     if let Some(ref r) = runenv {
@@ -401,55 +453,229 @@ impl SessionsState {
                     let mut agent = Agent::try_with_state(spec, state)?;
 
                     let user_msg = Message::new(Role::User).with_contents(query);
-                    sqlx::query(
-                        "INSERT INTO messages (session_id, seq, content, created_at) \
-                         VALUES (?, ?, ?, ?)",
-                    )
-                    .bind(&session_key)
-                    .bind(next_seq)
-                    .bind(serde_json::to_string(&user_msg)?)
-                    .bind(Utc::now().to_rfc3339())
-                    .execute(&db)
-                    .await?;
-                    events.publish(
-                        &channel,
-                        serde_json::to_string(&MessageEvent {
-                            seq: next_seq,
-                            message: user_msg.clone(),
-                        })?,
-                    );
+                    persist_message(&db, &events, &channel, &session_key, next_seq, user_msg.clone())
+                        .await?;
                     next_seq += 1;
 
-                    let mut stream = agent.run(user_msg);
+                    // `run_stream` yields raw `MessageDeltaOutput`s; the
+                    // assembler reassembles them into live assistant deltas +
+                    // completed messages (boundary detection and the
+                    // trailing-flush quirk live in `agent_stream`, unit-tested
+                    // there).
+                    let mut assembler = MessageAssembler::new();
+                    // Streamed text of the in-flight assistant turn. ailoy drops
+                    // its own accumulator when the stream is dropped, so if a
+                    // stop cuts a turn short before it commits a message, this
+                    // is the only copy of the partial answer. Cleared when a
+                    // top-level assistant message commits.
+                    let mut partial_text = String::new();
+                    // Tool-call ids still awaiting a Tool result, so a stop can
+                    // persist stub results — a replayed history with a tool
+                    // call but no result is rejected by most providers.
+                    let mut pending_calls: Vec<String> = Vec::new();
+                    // Whether the last committed top-level output ended the
+                    // turn (assistant + Stop) — a cancel landing at that exact
+                    // instant is a normal completion, not an interruption.
+                    let mut completed_naturally = false;
+                    let mut stopped = false;
+                    let mut run_error: Option<String> = None;
+
+                    let mut stream = agent.run_stream(user_msg);
                     loop {
-                        tokio::select! {
-                            biased;
-                            _ = token.cancelled() => break,
-                            next = stream.next() => {
-                                let Some(output) = next else { break };
-                                let output = output?;
-                                sqlx::query(
-                                    "INSERT INTO messages (session_id, seq, content, created_at) \
-                                     VALUES (?, ?, ?, ?)",
-                                )
-                                .bind(&session_key)
-                                .bind(next_seq)
-                                .bind(serde_json::to_string(&output.message)?)
-                                .bind(Utc::now().to_rfc3339())
-                                .execute(&db)
-                                .await?;
-                                events.publish(
-                                    &channel,
-                                    serde_json::to_string(&MessageEvent {
-                                        seq: next_seq,
-                                        message: output.message,
-                                    })?,
-                                );
-                                next_seq += 1;
+                        let item = if stopped {
+                            // Drain mode (entered on cancel). Take only what
+                            // ailoy has already produced, never awaiting new
+                            // output, so a turn that finished at the exact
+                            // cancel instant still commits its terminal message
+                            // instead of being mistagged as interrupted.
+                            // Nothing ready → break, dropping the stream (which
+                            // aborts the in-flight request), so stop stays
+                            // prompt.
+                            match stream.next().now_or_never() {
+                                Some(item) => item,
+                                None => break,
+                            }
+                        } else {
+                            tokio::select! {
+                                biased;
+                                _ = token.cancelled() => {
+                                    stopped = true;
+                                    continue;
+                                }
+                                item = stream.next() => item,
+                            }
+                        };
+                        // `last` marks the trailing-flush pseudo-item so the
+                        // loop exits after committing it.
+                        let (produced, last) = match item {
+                            Some(Ok(delta)) => match assembler.push(delta) {
+                                Ok(items) => (items, false),
+                                Err(e) => {
+                                    run_error = Some(e);
+                                    break;
+                                }
+                            },
+                            Some(Err(e)) => {
+                                run_error = Some(format!("{e:#}"));
+                                break;
+                            }
+                            // A stopped turn's pending partial is handled by
+                            // the interrupt path below, not flushed here.
+                            None if stopped => break,
+                            None => match assembler.finish() {
+                                // Defensive trailing flush: ailoy's contract
+                                // (every message ends with a finish_reason
+                                // delta) makes this a no-op for conforming
+                                // streams — a message here means an upstream
+                                // producer broke the contract. Still commit it
+                                // (losing a completed answer is worse) but warn
+                                // so the violation is visible.
+                                Ok(Some(output)) => {
+                                    tracing::warn!(
+                                        session = %id,
+                                        "stream ended mid-message (contract violation upstream); committing trailing message"
+                                    );
+                                    (vec![AgentStreamItem::Completed(Box::new(output))], true)
+                                }
+                                Ok(None) => break,
+                                Err(e) => {
+                                    tracing::warn!(session = %id, "failed to finalize trailing stream delta: {e}");
+                                    break;
+                                }
+                            },
+                        };
+                        for out in produced {
+                            match out {
+                                // Live assistant text. Published incrementally
+                                // with the running total so the client can dedup
+                                // at the catch-up↔live boundary; the shared
+                                // `partial` snapshot backs mid-turn
+                                // (re)subscribes.
+                                AgentStreamItem::Delta(fragment) => {
+                                    partial_text.push_str(&fragment);
+                                    // UTF-16 units so cum_len matches the
+                                    // client's String.length.
+                                    let cum_len = partial_text.encode_utf16().count() as u64;
+                                    *partial.lock().expect("partial lock poisoned") =
+                                        partial_text.clone();
+                                    events.publish(
+                                        &channel,
+                                        serde_json::to_string(&SessionEvent::Delta {
+                                            text: fragment,
+                                            cum_len,
+                                        })?,
+                                    );
+                                }
+                                // A message finalized at its boundary — persist
+                                // and publish it, and update the stop
+                                // book-keeping for top-level outputs.
+                                AgentStreamItem::Completed(output) => {
+                                    let output = *output;
+                                    if matches!(output.depth, None | Some(0)) {
+                                        match output.message.role {
+                                            Role::Assistant => {
+                                                partial_text.clear();
+                                                partial
+                                                    .lock()
+                                                    .expect("partial lock poisoned")
+                                                    .clear();
+                                                completed_naturally = matches!(
+                                                    output.finish_reason,
+                                                    FinishReason::Stop {}
+                                                );
+                                                for tc in output.message.tool_calls.iter().flatten()
+                                                {
+                                                    if let Some((call_id, _, _)) = tc.as_function()
+                                                    {
+                                                        pending_calls.push(call_id.to_string());
+                                                    }
+                                                }
+                                            }
+                                            Role::Tool => {
+                                                completed_naturally = false;
+                                                if let Some(call_id) = output.message.id.as_deref()
+                                                {
+                                                    pending_calls.retain(|c| c != call_id);
+                                                }
+                                            }
+                                            _ => completed_naturally = false,
+                                        }
+                                    }
+                                    persist_message(
+                                        &db,
+                                        &events,
+                                        &channel,
+                                        &session_key,
+                                        next_seq,
+                                        output.message,
+                                    )
+                                    .await?;
+                                    next_seq += 1;
+                                }
                             }
                         }
+                        if last {
+                            break;
+                        }
                     }
-                    Ok(())
+                    drop(stream);
+
+                    if let Some(err) = run_error {
+                        if stopped {
+                            // The error occurred during the grace period after a
+                            // stop request. Treat it as a clean stop rather than
+                            // a hard failure: keep the partial outputs already
+                            // committed instead of surfacing an error.
+                            tracing::warn!(
+                                session = %id,
+                                "agent error during stop grace period (treating as stop): {err}"
+                            );
+                        } else {
+                            anyhow::bail!("{err}");
+                        }
+                    }
+
+                    if stopped {
+                        if completed_naturally {
+                            // Cancel fired at the exact moment the turn
+                            // finished; report a normal completion so the
+                            // client doesn't see a spurious "stopped".
+                            stopped = false;
+                        } else {
+                            for call_id in std::mem::take(&mut pending_calls) {
+                                let stub = Message::new(Role::Tool)
+                                    .with_id(call_id)
+                                    .with_contents([Part::text(
+                                        "[Interrupted: the user stopped response generation before this tool call completed]",
+                                    )]);
+                                persist_message(&db, &events, &channel, &session_key, next_seq, stub)
+                                    .await?;
+                                next_seq += 1;
+                            }
+                            const INTERRUPT_NOTE: &str =
+                                "[Interrupted: the user manually stopped response generation here]";
+                            let note = if partial_text.is_empty() {
+                                INTERRUPT_NOTE.to_string()
+                            } else {
+                                // The interrupted turn streamed text but never
+                                // committed a message. Persist what accumulated
+                                // so the partial answer survives a refresh.
+                                format!("{partial_text}\n\n{INTERRUPT_NOTE}")
+                            };
+                            persist_message(
+                                &db,
+                                &events,
+                                &channel,
+                                &session_key,
+                                next_seq,
+                                Message::new(Role::Assistant).with_contents([Part::text(note)]),
+                            )
+                            .await?;
+                            partial.lock().expect("partial lock poisoned").clear();
+                        }
+                    }
+
+                    Ok(stopped)
                 }
                 .await;
 
@@ -473,12 +699,52 @@ impl SessionsState {
             }
             .await;
 
-            if let Err(e) = result {
-                tracing::error!(session = %id, "run failed: {e:#}");
+            let status = match &result {
+                Ok(false) => RunStatus::Done,
+                Ok(true) => RunStatus::Stopped,
+                Err(e) => {
+                    tracing::error!(session = %id, "run failed: {e:#}");
+                    RunStatus::Error {
+                        message: format!("{e:#}"),
+                    }
+                }
+            };
+            match serde_json::to_string(&SessionEvent::Run { status }) {
+                Ok(payload) => {
+                    events.publish(&channel, payload);
+                }
+                Err(e) => tracing::error!(session = %id, "failed to serialize run status: {e}"),
             }
             runs.lock().await.remove(&id);
         });
 
         Ok(())
     }
+}
+
+/// `INSERT` one message row for `session_key` at `seq` and publish it on the
+/// session's channel (a no-op when nobody is subscribed).
+async fn persist_message(
+    db: &SqlitePool,
+    events: &EventQueue,
+    channel: &str,
+    session_key: &str,
+    seq: i64,
+    message: Message,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO messages (session_id, seq, content, created_at) \
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(session_key)
+    .bind(seq)
+    .bind(serde_json::to_string(&message)?)
+    .bind(Utc::now().to_rfc3339())
+    .execute(db)
+    .await?;
+    events.publish(
+        channel,
+        serde_json::to_string(&SessionEvent::Message { seq, message })?,
+    );
+    Ok(())
 }

--- a/backend/src/state/workspace/mod.rs
+++ b/backend/src/state/workspace/mod.rs
@@ -145,7 +145,7 @@ impl WorkspacesState {
 
     /// Fetch `wid` only if it is owned by `user_id`. This is the single
     /// definition of the workspace access rule, reused by every caller (HTTP
-    /// routes, WebDAV, message WS). A workspace the user doesn't own is
+    /// routes, WebDAV, the message stream). A workspace the user doesn't own is
     /// indistinguishable from a missing one (`None`), so existence can't be
     /// probed.
     pub async fn get_for_user(&self, user_id: Uuid, wid: Uuid) -> StateResult<Option<Workspace>> {


### PR DESCRIPTION
Port the streaming backend from #200 onto backend v2. Backend only — the frontend from #200 predates the rewrite and is dropped.

Supersedes #200.

## What

- `agent.run()` → `agent.run_stream()` + `MessageAssembler` (ported from #200 with its unit tests): live assistant text is published as it streams, each message still persists at its boundary as before.
- Session stream (`GET /sessions/{id}/messages/stream`, SSE) carries a tagged `SessionEvent`:
  - `message` — persisted message with `seq` (same dedup/catch-up as before)
  - `delta` — ephemeral text fragment + `cum_len` (UTF-16, for client dedup across the catch-up↔live boundary)
  - `run` — lifecycle: `started` / `done` / `stopped` / `error` (errors were previously server-log only)
- SSE instead of WebSocket — the channel is strictly server→client. Auth goes through the standard `Authorization` header (no more token query param), and `message` events carry their `seq` as the SSE id, so `Last-Event-ID` auto-reconnect resumes from the persisted cursor.
- Attaching mid-turn replays the in-flight turn's partial text as one cumulative delta.
- Stop drains already-produced output (`now_or_never`), persists the partial answer with an interrupt note, and stubs unanswered tool calls so the next turn's history stays provider-valid.

No ailoy bump needed — main's rev already includes the stream contract #200 was built against.

## Verified

- Unit: assembler boundary/flush/sub-agent gating (7 tests).
- E2E against a live model: full stream round trip (delta concat == persisted message, contiguous seqs), auth gate (401 without header), `Last-Event-ID` resume with mid-turn snapshot, stop-mid-stream persistence, follow-up turn after stop, error propagation.
