### PR TITLE
feat(backend): record message depth and source agent

### DIFF
--- a/backend/src/event.rs
+++ b/backend/src/event.rs
@@ -77,7 +77,17 @@ pub enum SessionEvent {
     /// A message persisted to the session's history at sequence `seq`. Mirrors
     /// the HTTP `GET /sessions/{id}/messages` item shape so catch-up over
     /// either transport is interchangeable on the client.
-    Message { seq: i64, message: Message },
+    Message {
+        seq: i64,
+        /// Nesting level relative to the top-level agent turn: `0` is the
+        /// conversation the user sees; `>= 1` is a sub-agent's internal
+        /// output (render it indented/collapsed under the calling turn).
+        depth: u8,
+        /// Name of the agent that produced the message, when known. `None`
+        /// for user turns and synthetic (interrupt) messages.
+        source_agent: Option<String>,
+        message: Message,
+    },
 
     /// Newly streamed top-level assistant text for the in-progress turn.
     /// Ephemeral: not persisted, no seq. `text` is the newly produced

--- a/backend/src/router/message.rs
+++ b/backend/src/router/message.rs
@@ -31,6 +31,11 @@ use super::{
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct MessageResponse {
     pub seq: i64,
+    /// Nesting level: `0` is the top-level conversation, `>= 1` a sub-agent's
+    /// internal output.
+    pub depth: u8,
+    /// Name of the agent that produced the message, when known.
+    pub source_agent: Option<String>,
     pub message: Message,
 }
 
@@ -68,7 +73,12 @@ pub(super) async fn list_messages(
     Ok(Json(MessageListResponse {
         items: messages
             .into_iter()
-            .map(|(seq, message)| MessageResponse { seq, message })
+            .map(|(seq, stored)| MessageResponse {
+                seq,
+                depth: stored.depth,
+                source_agent: stored.source_agent,
+                message: stored.message,
+            })
             .collect(),
     }))
 }
@@ -142,9 +152,14 @@ pub(super) async fn stream_messages(
                     return;
                 }
             };
-            for (seq, message) in rows {
-                let payload = match serde_json::to_string(&SessionEvent::Message { seq, message })
-                {
+            for (seq, stored) in rows {
+                let event = SessionEvent::Message {
+                    seq,
+                    depth: stored.depth,
+                    source_agent: stored.source_agent,
+                    message: stored.message,
+                };
+                let payload = match serde_json::to_string(&event) {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::error!(session = %sid, "sse catch-up serialize error: {e}");

--- a/backend/src/state/session.rs
+++ b/backend/src/state/session.rs
@@ -99,6 +99,41 @@ impl Session {
     }
 }
 
+/// One persisted history row: the message plus the agent-loop provenance a
+/// bare [`Message`] can't carry. This is the JSON shape of `messages.content`;
+/// rows written before provenance was recorded are a bare `Message` and are
+/// read back as depth-0 with no source (see [`parse_stored_message`]).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SessionMessage {
+    /// Nesting level relative to the top-level agent turn: `0` is the
+    /// conversation the user sees; `>= 1` is a sub-agent's internal output.
+    /// Only depth-0 rows are replayed into the model's history on the next
+    /// run.
+    #[serde(default)]
+    pub depth: u8,
+
+    /// Name of the agent that produced the message, when known. `None` for
+    /// user turns and synthetic (interrupt) messages.
+    #[serde(default)]
+    pub source_agent: Option<String>,
+
+    pub message: Message,
+}
+
+/// Decode one `messages.content` value. New rows store the wrapped
+/// [`SessionMessage`] shape; legacy rows are a bare [`Message`] (which lacks
+/// the `message` field, so the first parse fails cleanly) and fall back to
+/// depth-0 with no source.
+fn parse_stored_message(content: &str) -> serde_json::Result<SessionMessage> {
+    serde_json::from_str::<SessionMessage>(content).or_else(|_| {
+        serde_json::from_str::<Message>(content).map(|message| SessionMessage {
+            depth: 0,
+            source_agent: None,
+            message,
+        })
+    })
+}
+
 /// Book-keeping for one in-flight run, held in [`SessionsState::runs`].
 struct ActiveRun {
     /// Wakes the spawned task at its next safe point on
@@ -277,7 +312,7 @@ impl SessionsState {
 
     /// The streamed-so-far text of the in-progress assistant turn, if a run is
     /// in flight for `id`. `Some("")` means a run is active but hasn't
-    /// streamed top-level text yet; `None` means no active run. The WS
+    /// streamed top-level text yet; `None` means no active run. The SSE
     /// catch-up path uses this so a client attaching mid-turn starts from the
     /// full partial answer instead of the next delta.
     pub async fn live_partial(&self, id: Uuid) -> Option<String> {
@@ -291,7 +326,7 @@ impl SessionsState {
     /// Return all messages for `session_id`, ordered by `seq` ascending. Backs
     /// the `GET /sessions/{id}/messages` endpoint; the SSE catch-up path uses
     /// [`SessionsState::list_messages_since`] instead.
-    pub async fn list_messages(&self, session_id: Uuid) -> StateResult<Vec<(i64, Message)>> {
+    pub async fn list_messages(&self, session_id: Uuid) -> StateResult<Vec<(i64, SessionMessage)>> {
         self.list_messages_since(session_id, -1).await
     }
 
@@ -302,7 +337,7 @@ impl SessionsState {
         &self,
         session_id: Uuid,
         since: i64,
-    ) -> StateResult<Vec<(i64, Message)>> {
+    ) -> StateResult<Vec<(i64, SessionMessage)>> {
         let rows = sqlx::query(
             "SELECT seq, content FROM messages \
              WHERE session_id = ? AND seq > ? ORDER BY seq ASC",
@@ -312,11 +347,10 @@ impl SessionsState {
         .fetch_all(&self.db)
         .await?;
         rows.into_iter()
-            .map(|r| -> StateResult<(i64, Message)> {
+            .map(|r| -> StateResult<(i64, SessionMessage)> {
                 let seq: i64 = r.get("seq");
                 let content: String = r.get("content");
-                let message: Message = serde_json::from_str(&content)?;
-                Ok((seq, message))
+                Ok((seq, parse_stored_message(&content)?))
             })
             .collect()
     }
@@ -429,15 +463,28 @@ impl SessionsState {
                 };
 
                 let rows = sqlx::query(
-                    "SELECT content FROM messages WHERE session_id = ? ORDER BY seq ASC",
+                    "SELECT seq, content FROM messages WHERE session_id = ? ORDER BY seq ASC",
                 )
                 .bind(&session_key)
                 .fetch_all(&db)
                 .await?;
+                // Sequence numbers continue from the last persisted row — not
+                // from the replayed-history length, which is shorter once
+                // sub-agent rows are filtered out below.
+                let next_seq_start = rows.last().map(|r| r.get::<i64, _>("seq") + 1).unwrap_or(0);
+                // Replay only the top-level conversation (depth 0). A
+                // sub-agent's work reaches the model through its capped
+                // depth-0 tool result, never its internal transcript —
+                // mirroring ailoy's own in-memory history, which only ever
+                // holds depth-0 messages.
                 let history: Vec<Message> = rows
                     .iter()
-                    .map(|r| serde_json::from_str::<Message>(&r.get::<String, _>("content")))
-                    .collect::<Result<_, _>>()?;
+                    .map(|r| parse_stored_message(&r.get::<String, _>("content")))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .filter(|stored| stored.depth == 0)
+                    .map(|stored| stored.message)
+                    .collect();
 
                 // Drive — stream the model's raw deltas, publishing live text
                 // fragments as they arrive and persisting each message at its
@@ -445,7 +492,7 @@ impl SessionsState {
                 // how this exits, so capture the drive's Result and propagate
                 // it after archiving.
                 let drive: anyhow::Result<bool> = async {
-                    let mut next_seq = history.len() as i64;
+                    let mut next_seq = next_seq_start;
                     let mut state = AgentState::new().with_history(history);
                     if let Some(ref r) = runenv {
                         state = state.with_runenv(r.clone());
@@ -453,8 +500,19 @@ impl SessionsState {
                     let mut agent = Agent::try_with_state(spec, state)?;
 
                     let user_msg = Message::new(Role::User).with_contents(query);
-                    persist_message(&db, &events, &channel, &session_key, next_seq, user_msg.clone())
-                        .await?;
+                    persist_message(
+                        &db,
+                        &events,
+                        &channel,
+                        &session_key,
+                        next_seq,
+                        SessionMessage {
+                            depth: 0,
+                            source_agent: None,
+                            message: user_msg.clone(),
+                        },
+                    )
+                    .await?;
                     next_seq += 1;
 
                     // `run_stream` yields raw `MessageDeltaOutput`s; the
@@ -607,7 +665,11 @@ impl SessionsState {
                                         &channel,
                                         &session_key,
                                         next_seq,
-                                        output.message,
+                                        SessionMessage {
+                                            depth: output.depth.unwrap_or(0),
+                                            source_agent: output.source_agent,
+                                            message: output.message,
+                                        },
                                     )
                                     .await?;
                                     next_seq += 1;
@@ -648,8 +710,19 @@ impl SessionsState {
                                     .with_contents([Part::text(
                                         "[Interrupted: the user stopped response generation before this tool call completed]",
                                     )]);
-                                persist_message(&db, &events, &channel, &session_key, next_seq, stub)
-                                    .await?;
+                                persist_message(
+                                    &db,
+                                    &events,
+                                    &channel,
+                                    &session_key,
+                                    next_seq,
+                                    SessionMessage {
+                                        depth: 0,
+                                        source_agent: None,
+                                        message: stub,
+                                    },
+                                )
+                                .await?;
                                 next_seq += 1;
                             }
                             const INTERRUPT_NOTE: &str =
@@ -668,7 +741,12 @@ impl SessionsState {
                                 &channel,
                                 &session_key,
                                 next_seq,
-                                Message::new(Role::Assistant).with_contents([Part::text(note)]),
+                                SessionMessage {
+                                    depth: 0,
+                                    source_agent: None,
+                                    message: Message::new(Role::Assistant)
+                                        .with_contents([Part::text(note)]),
+                                },
                             )
                             .await?;
                             partial.lock().expect("partial lock poisoned").clear();
@@ -722,15 +800,16 @@ impl SessionsState {
     }
 }
 
-/// `INSERT` one message row for `session_key` at `seq` and publish it on the
-/// session's channel (a no-op when nobody is subscribed).
+/// `INSERT` one message row for `session_key` at `seq` (stored in the wrapped
+/// [`SessionMessage`] shape) and publish it on the session's channel (a no-op
+/// when nobody is subscribed).
 async fn persist_message(
     db: &SqlitePool,
     events: &EventQueue,
     channel: &str,
     session_key: &str,
     seq: i64,
-    message: Message,
+    stored: SessionMessage,
 ) -> anyhow::Result<()> {
     sqlx::query(
         "INSERT INTO messages (session_id, seq, content, created_at) \
@@ -738,13 +817,45 @@ async fn persist_message(
     )
     .bind(session_key)
     .bind(seq)
-    .bind(serde_json::to_string(&message)?)
+    .bind(serde_json::to_string(&stored)?)
     .bind(Utc::now().to_rfc3339())
     .execute(db)
     .await?;
     events.publish(
         channel,
-        serde_json::to_string(&SessionEvent::Message { seq, message })?,
+        serde_json::to_string(&SessionEvent::Message {
+            seq,
+            depth: stored.depth,
+            source_agent: stored.source_agent,
+            message: stored.message,
+        })?,
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rows written before provenance was recorded are a bare `Message`; they
+    /// must keep parsing (as depth-0, no source) alongside the wrapped shape,
+    /// or existing sessions break on upgrade.
+    #[test]
+    fn stored_message_parses_wrapped_and_legacy_rows() {
+        let wrapped = SessionMessage {
+            depth: 1,
+            source_agent: Some("researcher".into()),
+            message: Message::new(Role::Assistant).with_contents([Part::text("found it")]),
+        };
+        let parsed = parse_stored_message(&serde_json::to_string(&wrapped).unwrap()).unwrap();
+        assert_eq!(parsed.depth, 1);
+        assert_eq!(parsed.source_agent.as_deref(), Some("researcher"));
+        assert_eq!(parsed.message.contents[0].as_text(), Some("found it"));
+
+        let legacy = Message::new(Role::User).with_contents([Part::text("hi")]);
+        let parsed = parse_stored_message(&serde_json::to_string(&legacy).unwrap()).unwrap();
+        assert_eq!(parsed.depth, 0);
+        assert!(parsed.source_agent.is_none());
+        assert_eq!(parsed.message.role, Role::User);
+    }
 }


### PR DESCRIPTION
Record each message's agent-loop provenance so clients can tell sub-agent output apart from the top-level conversation.

## What

- `messages.content` now stores `{depth, source_agent, message}`; legacy bare-`Message` rows still parse (read as depth 0, no source), so no migration.
- `depth` / `source_agent` are exposed on `GET /sessions/{id}/messages` and the SSE `message` event — depth 0 is the conversation, depth ≥ 1 is sub-agent internals for the frontend to render indented/collapsed.
- History replay now feeds only depth-0 rows to the model, matching ailoy's in-memory semantics — a sub-agent's work reaches the model through its capped depth-0 tool result, not its transcript.
- Seq allocation follows the last persisted row (`MAX(seq)+1`) since the filtered history length no longer tracks the row count.

| | Persisted in DB | Model context (replay) |
|---|---|---|
| v1 | depth 0 only | depth 0 only |
| v2 (main) | everything, depth dropped | everything (pollutes context) |
| this PR | everything, depth preserved | depth 0 only |

## Verified

- Unit: stored-format round trip + legacy fallback.
- E2E with a real sub-agent: depth/source stamped on persisted rows and events (depth: count`{0: 4, 1: 1}`) , follow-up turn accepted by the provider, seq continues past filtered rows; old-format DB reads back as depth 0.
