### PR TITLE
Automation events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ Thumbs.db
 .env.*
 !.env.example
 
+# Local automation dev DB + local API test console (not committed)
+/data/
+backend/automation-console.html
+
 # Logs
 *.log
 

--- a/backend/migrations/0003_automations.sql
+++ b/backend/migrations/0003_automations.sql
@@ -1,0 +1,79 @@
+-- Automations: a named, workspace-scoped agent job. Single prompt (v1's
+-- multi-step `prompts` array is intentionally collapsed to one prompt here —
+-- there is no cross-step progress to track, so a re-claimed run just re-runs
+-- the one prompt on a fresh session).
+CREATE TABLE automations (
+    id           TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    name         TEXT NOT NULL,
+    description  TEXT,
+    prompt       TEXT NOT NULL,
+    -- Agent surface for triggered runs: preset name + optional model pin. Built
+    -- into an AgentSpec at run time (see state/automation.rs `build_spec`).
+    agent_type   TEXT NOT NULL DEFAULT 'coworker',
+    model        TEXT,
+    enabled      INTEGER NOT NULL DEFAULT 1,
+    created_by   TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+CREATE INDEX idx_automations_workspace ON automations(workspace_id, created_at DESC);
+
+-- Cron triggers (webhook out of scope). `spec_json` holds the untagged variant
+-- fields ({expr, tz}); `next_fire_at` is the next scheduled UTC instant, NULL
+-- when the trigger is disabled.
+CREATE TABLE automation_triggers (
+    id            TEXT PRIMARY KEY,
+    automation_id TEXT NOT NULL REFERENCES automations(id) ON DELETE CASCADE,
+    kind          TEXT NOT NULL,
+    spec_json     TEXT NOT NULL,
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    next_fire_at  TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+CREATE INDEX idx_triggers_automation ON automation_triggers(automation_id);
+-- Partial index for the cron ticker's "due" scan.
+CREATE INDEX idx_triggers_due ON automation_triggers(next_fire_at)
+    WHERE enabled = 1 AND next_fire_at IS NOT NULL;
+
+-- Runs: one session per run. Lease/reaper columns support crash-safe execution.
+-- A run is self-describing: it snapshots the rendered prompt + agent surface it
+-- executes, so it depends on no automation at run time and its audit trail
+-- survives later edits/deletion of the automation.
+CREATE TABLE automation_runs (
+    id              TEXT PRIMARY KEY,
+    -- NULL for ad-hoc one-time runs (they depend on no automation). ON DELETE
+    -- SET NULL so deleting an automation preserves its runs as an audit record.
+    automation_id   TEXT REFERENCES automations(id) ON DELETE SET NULL,
+    trigger_id      TEXT REFERENCES automation_triggers(id) ON DELETE SET NULL,
+    session_id      TEXT NOT NULL UNIQUE REFERENCES sessions(id) ON DELETE CASCADE,
+    workspace_id    TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    -- Rendered prompt actually executed + agent surface, snapshotted at creation.
+    prompt          TEXT NOT NULL,
+    agent_type      TEXT NOT NULL DEFAULT 'coworker',
+    model           TEXT,
+    status          TEXT NOT NULL,            -- queued | running | succeeded | failed | cancelled
+    scheduled_for   TEXT NOT NULL,            -- earliest pickup time
+    lease_until     TEXT,                     -- NULL when not leased; reaper uses this
+    previous_run_id TEXT REFERENCES automation_runs(id) ON DELETE SET NULL,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+CREATE INDEX idx_runs_workspace ON automation_runs(workspace_id, created_at DESC);
+CREATE INDEX idx_runs_automation_created ON automation_runs(automation_id, created_at DESC);
+CREATE INDEX idx_runs_status_scheduled   ON automation_runs(status, scheduled_for);
+CREATE INDEX idx_runs_lease              ON automation_runs(lease_until)
+    WHERE status = 'running';
+
+-- Append-only run event log. `ts` is both event time and row insertion time.
+-- Full lifecycle set minus step_started/step_finished (single-prompt runs have
+-- no per-step cursor).
+CREATE TABLE automation_run_logs (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id   TEXT NOT NULL REFERENCES automation_runs(id) ON DELETE CASCADE,
+    ts       TEXT NOT NULL,
+    kind     TEXT NOT NULL,
+    payload  TEXT
+);
+CREATE INDEX idx_run_logs_run_ts ON automation_run_logs(run_id, ts);

--- a/backend/migrations/0003_automations.sql
+++ b/backend/migrations/0003_automations.sql
@@ -19,9 +19,9 @@ CREATE TABLE automations (
 );
 CREATE INDEX idx_automations_workspace ON automations(workspace_id, created_at DESC);
 
--- Cron triggers (webhook out of scope). `spec_json` holds the untagged variant
--- fields ({expr, tz}); `next_fire_at` is the next scheduled UTC instant, NULL
--- when the trigger is disabled.
+-- Triggers. Cron: `spec_json` holds {expr, tz}, `next_fire_at` the next UTC
+-- instant (NULL when disabled). Event: `spec_json` holds the OR-combined
+-- conditions ([{source, filter}]); the dispatcher matches events to these.
 CREATE TABLE automation_triggers (
     id            TEXT PRIMARY KEY,
     automation_id TEXT NOT NULL REFERENCES automations(id) ON DELETE CASCADE,
@@ -41,6 +41,23 @@ CREATE INDEX idx_triggers_automation ON automation_triggers(automation_id);
 -- Partial index for the cron ticker's "due" scan.
 CREATE INDEX idx_triggers_due ON automation_triggers(next_fire_at)
     WHERE enabled = 1 AND next_fire_at IS NOT NULL;
+
+-- Durable event outbox. Producers append domain events (run.succeeded,
+-- workspace.created, knowledge.indexed, …); the dispatcher scans undispatched
+-- rows, matches them to event triggers (source + filter), and fires runs.
+-- Distinct from the in-process, ephemeral EventQueue (event.rs), which only
+-- powers live WS streaming. Declared before automation_runs so the run's
+-- event_id FK below resolves.
+CREATE TABLE events (
+    id             TEXT PRIMARY KEY,
+    type           TEXT NOT NULL,
+    workspace_id   TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+    payload        TEXT,
+    created_at     TEXT NOT NULL,
+    dispatched_at  TEXT
+);
+CREATE INDEX idx_events_undispatched ON events(created_at) WHERE dispatched_at IS NULL;
+CREATE INDEX idx_events_type ON events(type, workspace_id);
 
 -- Runs: one session per run. Lease/reaper columns support crash-safe execution.
 -- A run is self-describing: it snapshots the rendered prompt + agent surface it
@@ -62,6 +79,14 @@ CREATE TABLE automation_runs (
     scheduled_for   TEXT NOT NULL,            -- earliest pickup time
     lease_until     TEXT,                     -- NULL when not leased; reaper uses this
     previous_run_id TEXT REFERENCES automation_runs(id) ON DELETE SET NULL,
+    -- Event-triggered runs carry the triggering event's payload as input
+    -- (rendered into the prompt template) and record the event that fired them.
+    input           TEXT,
+    event_id        TEXT REFERENCES events(id) ON DELETE SET NULL,
+    -- Causal chain depth: 0 for roots (cron/ad-hoc/non-run events), parent+1
+    -- for runs triggered by a `run.succeeded` event. Capped at dispatch to break
+    -- run→run trigger loops (see worker.rs MAX_CHAIN_DEPTH).
+    chain_depth     INTEGER NOT NULL DEFAULT 0,
     created_at      TEXT NOT NULL,
     updated_at      TEXT NOT NULL
 );
@@ -70,10 +95,16 @@ CREATE INDEX idx_runs_automation_created ON automation_runs(automation_id, creat
 CREATE INDEX idx_runs_status_scheduled   ON automation_runs(status, scheduled_for);
 CREATE INDEX idx_runs_lease              ON automation_runs(lease_until)
     WHERE status = 'running';
+-- One run per (trigger, event): guards against duplicate runs if an event is
+-- re-processed after a crash mid-dispatch.
+CREATE UNIQUE INDEX idx_runs_trigger_event
+    ON automation_runs(trigger_id, event_id)
+    WHERE trigger_id IS NOT NULL AND event_id IS NOT NULL;
 
--- Append-only run event log. `ts` is both event time and row insertion time.
--- Full lifecycle set minus step_started/step_finished (single-prompt runs have
--- no per-step cursor).
+-- Append-only run log (lifecycle entries: triggered/queued/started/…). Distinct
+-- from the `events` outbox above — this is the per-run audit trail, that is the
+-- trigger event bus. Full lifecycle set minus step_started/step_finished
+-- (single-prompt runs have no per-step cursor).
 CREATE TABLE automation_run_logs (
     id       INTEGER PRIMARY KEY AUTOINCREMENT,
     run_id   TEXT NOT NULL REFERENCES automation_runs(id) ON DELETE CASCADE,

--- a/backend/migrations/0003_automations.sql
+++ b/backend/migrations/0003_automations.sql
@@ -101,6 +101,17 @@ CREATE UNIQUE INDEX idx_runs_trigger_event
     ON automation_runs(trigger_id, event_id)
     WHERE trigger_id IS NOT NULL AND event_id IS NOT NULL;
 
+-- Per-mount snapshot for external-source polling: `snapshot` is a JSON map of
+-- workspace-relative path → change signature (modified:size). The poller diffs a
+-- fresh scan against this to synthesize s3.*/notion.* events, then overwrites it.
+CREATE TABLE source_poll_state (
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    prefix       TEXT NOT NULL,            -- mount prefix, e.g. /s3-prod
+    snapshot     TEXT NOT NULL,            -- JSON: { path: signature }
+    updated_at   TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, prefix)
+);
+
 -- Append-only run log (lifecycle entries: triggered/queued/started/…). Distinct
 -- from the `events` outbox above — this is the per-run audit trail, that is the
 -- trigger event bus. Full lifecycle set minus step_started/step_finished

--- a/backend/migrations/0003_automations.sql
+++ b/backend/migrations/0003_automations.sql
@@ -29,9 +29,14 @@ CREATE TABLE automation_triggers (
     spec_json     TEXT NOT NULL,
     enabled       INTEGER NOT NULL DEFAULT 1,
     next_fire_at  TEXT,
+    webhook_token_hash TEXT,                     -- webhook only; sha256 hex of the issued token
     created_at    TEXT NOT NULL,
     updated_at    TEXT NOT NULL
 );
+-- A webhook token identifies its trigger globally; the hash is the lookup key.
+CREATE UNIQUE INDEX idx_triggers_webhook_token
+    ON automation_triggers(webhook_token_hash)
+    WHERE webhook_token_hash IS NOT NULL;
 CREATE INDEX idx_triggers_automation ON automation_triggers(automation_id);
 -- Partial index for the cron ticker's "due" scan.
 CREATE INDEX idx_triggers_due ON automation_triggers(next_fire_at)

--- a/backend/src/cron.rs
+++ b/backend/src/cron.rs
@@ -1,0 +1,118 @@
+//! Cron expression parsing + timezone-aware "next fire" calculation.
+//! Callers pass `now` explicitly so cron-driven code can be tested by
+//! invoking the tick function with a fixed timestamp.
+
+use std::sync::OnceLock;
+
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+use croner::Cron;
+
+/// Default IANA timezone used when a Cron trigger's spec omits `tz`. Reads
+/// `AGENT_K_DEFAULT_TZ` at first call and caches the result; invalid or
+/// missing values fall back to `"UTC"` (with a warning logged for an invalid
+/// value).
+pub fn default_tz_name() -> &'static str {
+    static CACHE: OnceLock<String> = OnceLock::new();
+    CACHE
+        .get_or_init(|| match std::env::var("AGENT_K_DEFAULT_TZ") {
+            Ok(name) => match name.parse::<Tz>() {
+                Ok(_) => name,
+                Err(e) => {
+                    tracing::warn!("invalid AGENT_K_DEFAULT_TZ '{name}': {e}; falling back to UTC");
+                    "UTC".to_string()
+                }
+            },
+            Err(_) => "UTC".to_string(),
+        })
+        .as_str()
+}
+
+/// Parse `expr` in `tz_name` and compute the first occurrence strictly after
+/// `after`. Only Linux-style 5-field POSIX cron (`min hour dom mon dow`) is
+/// accepted — sub-minute precision is rejected because the worker's tick
+/// interval and per-run execution latency make sub-minute cron meaningless
+/// for automation use.
+pub fn next_fire_after(
+    expr: &str,
+    tz_name: &str,
+    after: DateTime<Utc>,
+) -> Result<DateTime<Utc>, String> {
+    let tz: Tz = tz_name
+        .parse()
+        .map_err(|e: chrono_tz::ParseError| format!("invalid timezone '{tz_name}': {e}"))?;
+    validate_five_field(expr)?;
+    let cron = Cron::new(expr)
+        .parse()
+        .map_err(|e| format!("invalid cron expression '{expr}': {e}"))?;
+    let after_in_tz = after.with_timezone(&tz);
+    cron.find_next_occurrence(&after_in_tz, false)
+        .map(|t| t.with_timezone(&Utc))
+        .map_err(|e| format!("no future occurrence for '{expr}': {e}"))
+}
+
+fn validate_five_field(expr: &str) -> Result<(), String> {
+    let n = expr.split_whitespace().count();
+    if n == 5 {
+        Ok(())
+    } else {
+        Err(format!(
+            "only 5-field POSIX cron is supported (got {n} fields); sub-minute precision not allowed"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn at(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn five_field_expr_resolves_next_fire() {
+        let now = at("2026-06-01T08:30:00Z");
+        // every day at 09:00 UTC
+        let next = next_fire_after("0 9 * * *", "UTC", now).unwrap();
+        assert_eq!(next, at("2026-06-01T09:00:00Z"));
+    }
+
+    #[test]
+    fn next_fire_in_explicit_timezone() {
+        // 9 AM Seoul on 2026-06-01 = 2026-06-01T00:00:00Z
+        let before = Utc.with_ymd_and_hms(2026, 5, 31, 23, 0, 0).unwrap();
+        let next = next_fire_after("0 9 * * *", "Asia/Seoul", before).unwrap();
+        assert_eq!(next, at("2026-06-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn six_field_expr_is_rejected() {
+        let now = at("2026-06-01T08:30:00Z");
+        // sub-minute precision not allowed — automation uses Linux cron only.
+        let err = next_fire_after("30 * * * * *", "UTC", now).unwrap_err();
+        assert!(err.contains("5-field"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn last_day_of_month_resolves_next_fire() {
+        // "0 9 L * *" → 09:00 on the last day of the month (croner `L`).
+        let now = at("2026-06-10T00:00:00Z");
+        let next = next_fire_after("0 9 L * *", "UTC", now).unwrap();
+        assert_eq!(next, at("2026-06-30T09:00:00Z"));
+    }
+
+    #[test]
+    fn invalid_cron_returns_error() {
+        let now = at("2026-06-01T08:30:00Z");
+        assert!(next_fire_after("not a cron", "UTC", now).is_err());
+    }
+
+    #[test]
+    fn invalid_timezone_returns_error() {
+        let now = at("2026-06-01T08:30:00Z");
+        assert!(next_fire_after("0 9 * * *", "Mars/Olympus", now).is_err());
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod agent_stream;
 pub mod auth;
+mod cron;
 pub mod event;
 pub mod model;
 pub mod router;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,6 +10,7 @@ pub mod model;
 pub mod router;
 pub mod sandbox_tunnel;
 pub mod state;
+mod worker;
 
 use std::{path::PathBuf, sync::Arc};
 
@@ -73,6 +74,14 @@ pub async fn run() -> std::io::Result<()> {
     );
 
     bootstrap_admin_if_needed(&app_state.users, &app_state.workspaces).await;
+
+    // Automation runtime: claim/execute workers + reaper + cron ticker + event
+    // dispatcher + external-source poller.
+    let worker_count = std::env::var("AGENT_K_AUTOMATION_WORKERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2);
+    worker::spawn_runtime(app_state.clone(), worker_count);
 
     // Optional periodic knowledge resync: picks up provider-side changes to
     // referenced external targets, which produce no local write event. Disabled

--- a/backend/src/router/automation.rs
+++ b/backend/src/router/automation.rs
@@ -122,6 +122,17 @@ impl TriggerResponse {
     }
 }
 
+/// Create response: for a webhook trigger, `webhook_token` carries the raw token
+/// ONCE (only its hash is stored). Present POSTs to `POST /webhooks/automations`
+/// with `Authorization: Bearer <token>`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CreatedTriggerResponse {
+    #[serde(flatten)]
+    pub trigger: TriggerResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook_token: Option<String>,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct TriggerListResponse {
     pub items: Vec<TriggerResponse>,
@@ -354,10 +365,12 @@ pub(super) async fn create_trigger(
     Extension(auth): Extension<AuthUser>,
     Path(automation_id): Path<Uuid>,
     Json(payload): Json<CreateTriggerRequest>,
-) -> Result<(StatusCode, Json<TriggerResponse>), ApiError> {
+) -> Result<(StatusCode, Json<CreatedTriggerResponse>), ApiError> {
     require_owned_automation(&state, &auth, automation_id).await?;
 
-    // Validate the cron expression up front + compute the first fire instant.
+    // Cron: validate the expression + compute the first fire instant. Webhook:
+    // issue a token (client never provides it) and store only its hash.
+    let (mut token_hash, mut webhook_token) = (None, None);
     let next_fire_at = match &payload.spec {
         TriggerSpec::Cron { expr, tz } => {
             let tz_name = tz.as_deref().unwrap_or(default_tz_name());
@@ -365,13 +378,25 @@ pub(super) async fn create_trigger(
                 .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
             payload.enabled.then_some(fire)
         }
+        TriggerSpec::Webhook {} => {
+            let (token, hash) = crate::state::AutomationsState::new_webhook_token();
+            token_hash = Some(hash);
+            webhook_token = Some(token);
+            None
+        }
     };
 
     let trigger = state
         .automations
-        .create_trigger(automation_id, &payload.spec, payload.enabled, next_fire_at)
+        .create_trigger(automation_id, &payload.spec, payload.enabled, next_fire_at, token_hash)
         .await?;
-    Ok((StatusCode::CREATED, Json(TriggerResponse::from_db(trigger)?)))
+    Ok((
+        StatusCode::CREATED,
+        Json(CreatedTriggerResponse {
+            trigger: TriggerResponse::from_db(trigger)?,
+            webhook_token,
+        }),
+    ))
 }
 
 pub(super) async fn list_triggers(
@@ -404,6 +429,39 @@ pub(super) async fn delete_trigger(
     }
     state.automations.delete_trigger(trigger_id).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Public webhook receiver (no auth middleware): fires the automation whose
+/// webhook trigger matches the `Authorization: Bearer <token>` header. The token
+/// hashes to a globally-unique `webhook_token_hash`, so it alone identifies the
+/// trigger. The request body is accepted but not yet used (body → render input
+/// arrives with the event infrastructure). A generic 401 masks unknown tokens.
+pub(super) async fn fire_webhook_trigger(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    _body: axum::body::Bytes,
+) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .ok_or_else(|| err(StatusCode::UNAUTHORIZED, "invalid token"))?;
+    let hash = crate::state::AutomationsState::webhook_token_hash(token);
+    let trigger = state
+        .automations
+        .find_trigger_by_webhook_token_hash(&hash)
+        .await?
+        .filter(|t| t.enabled)
+        .ok_or_else(|| err(StatusCode::UNAUTHORIZED, "invalid token"))?;
+    let automation = state
+        .automations
+        .get_automation(trigger.automation_id)
+        .await?
+        .ok_or_else(|| err(StatusCode::INTERNAL_SERVER_ERROR, "trigger's automation missing"))?;
+    match state.automations.create_webhook_run(&automation, trigger.id).await? {
+        Some(run) => Ok((StatusCode::ACCEPTED, Json(serde_json::json!({ "run_id": run.id })))),
+        None => Err(err(StatusCode::CONFLICT, "automation is disabled")),
+    }
 }
 
 // ── runs (top-level resource: /automation-runs) ─────────────────────────────

--- a/backend/src/router/automation.rs
+++ b/backend/src/router/automation.rs
@@ -1,4 +1,4 @@
-//! Automation HTTP surface: automations CRUD, cron triggers, runs, run events.
+//! Automation HTTP surface: automations CRUD, cron triggers, runs, run logs.
 //! Ownership is workspace-scoped (an automation belongs to a workspace the
 //! caller owns); missing and foreign resources both report `404`.
 
@@ -166,6 +166,10 @@ pub struct RunResponse {
     pub scheduled_for: DateTime<Utc>,
     pub lease_until: Option<DateTime<Utc>>,
     pub previous_run_id: Option<Uuid>,
+    /// The triggering event's payload (the run's render input), if event-triggered.
+    pub input: Option<serde_json::Value>,
+    /// The event that triggered this run, if any.
+    pub event_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -185,6 +189,8 @@ impl From<AutomationRun> for RunResponse {
             scheduled_for: r.scheduled_for,
             lease_until: r.lease_until,
             previous_run_id: r.previous_run_id,
+            input: r.input,
+            event_id: r.event_id,
             created_at: r.created_at,
             updated_at: r.updated_at,
         }
@@ -368,7 +374,8 @@ pub(super) async fn create_trigger(
 ) -> Result<(StatusCode, Json<CreatedTriggerResponse>), ApiError> {
     require_owned_automation(&state, &auth, automation_id).await?;
 
-    // Cron: validate the expression + compute the first fire instant. Webhook:
+    // Cron: validate the expression + compute the first fire instant. Event
+    // triggers have no scheduled fire time (the dispatcher fires them). Webhook:
     // issue a token (client never provides it) and store only its hash.
     let (mut token_hash, mut webhook_token) = (None, None);
     let next_fire_at = match &payload.spec {
@@ -378,7 +385,13 @@ pub(super) async fn create_trigger(
                 .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
             payload.enabled.then_some(fire)
         }
-        TriggerSpec::Webhook {} => {
+        TriggerSpec::Event { conditions } => {
+            if conditions.is_empty() {
+                return Err(err(StatusCode::BAD_REQUEST, "event trigger needs at least one condition"));
+            }
+            None
+        }
+        TriggerSpec::Webhook { .. } => {
             let (token, hash) = crate::state::AutomationsState::new_webhook_token();
             token_hash = Some(hash);
             webhook_token = Some(token);
@@ -434,12 +447,13 @@ pub(super) async fn delete_trigger(
 /// Public webhook receiver (no auth middleware): fires the automation whose
 /// webhook trigger matches the `Authorization: Bearer <token>` header. The token
 /// hashes to a globally-unique `webhook_token_hash`, so it alone identifies the
-/// trigger. The request body is accepted but not yet used (body → render input
-/// arrives with the event infrastructure). A generic 401 masks unknown tokens.
+/// trigger (automation-direct — no outbox event). The request body (JSON, else
+/// wrapped raw text) becomes the run's render input; an optional filter gates
+/// firing on it. A generic 401 masks unknown tokens.
 pub(super) async fn fire_webhook_trigger(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
-    _body: axum::body::Bytes,
+    body: axum::body::Bytes,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
     let token = headers
         .get(axum::http::header::AUTHORIZATION)
@@ -458,7 +472,25 @@ pub(super) async fn fire_webhook_trigger(
         .get_automation(trigger.automation_id)
         .await?
         .ok_or_else(|| err(StatusCode::INTERNAL_SERVER_ERROR, "trigger's automation missing"))?;
-    match state.automations.create_webhook_run(&automation, trigger.id).await? {
+    let input = if body.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_slice::<serde_json::Value>(&body)
+            .unwrap_or_else(|_| serde_json::json!({ "raw": String::from_utf8_lossy(&body) }))
+    };
+    // Optional filter gates firing on the body: a non-matching POST is accepted
+    // but fires no run.
+    if let Ok(TriggerSpec::Webhook { filter: Some(f), .. }) =
+        TriggerSpec::from_db(trigger.kind, &trigger.spec_json)
+        && !crate::state::event_filter_matches(Some(&f), Some(&input))
+    {
+        return Ok((StatusCode::ACCEPTED, Json(serde_json::json!({ "matched": false }))));
+    }
+    match state
+        .automations
+        .create_webhook_run(&automation, trigger.id, input)
+        .await?
+    {
         Some(run) => Ok((StatusCode::ACCEPTED, Json(serde_json::json!({ "run_id": run.id })))),
         None => Err(err(StatusCode::CONFLICT, "automation is disabled")),
     }
@@ -579,15 +611,15 @@ pub(super) async fn cancel_run(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// `GET /automation-runs/{id}/events` — audit event log.
+/// `GET /automation-runs/{id}/logs` — per-run audit log.
 pub(super) async fn list_run_logs(
     State(state): State<Arc<AppState>>,
     Extension(auth): Extension<AuthUser>,
     Path(run_id): Path<Uuid>,
 ) -> Result<Json<RunLogListResponse>, ApiError> {
     require_owned_run(&state, &auth, run_id).await?;
-    let events = state.automations.list_logs_for_run(run_id).await?;
+    let logs = state.automations.list_logs_for_run(run_id).await?;
     Ok(Json(RunLogListResponse {
-        items: events.into_iter().map(RunLogResponse::from).collect(),
+        items: logs.into_iter().map(RunLogResponse::from).collect(),
     }))
 }

--- a/backend/src/router/automation.rs
+++ b/backend/src/router/automation.rs
@@ -1,0 +1,535 @@
+//! Automation HTTP surface: automations CRUD, cron triggers, runs, run events.
+//! Ownership is workspace-scoped (an automation belongs to a workspace the
+//! caller owns); missing and foreign resources both report `404`.
+
+use std::sync::Arc;
+
+use axum::{
+    Extension, Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    auth::AuthUser,
+    cron::{default_tz_name, next_fire_after},
+    state::{
+        AppState, Automation, AutomationRun, AutomationTrigger, RunLogKind, RunLog, RunStatus,
+        TriggerKind, TriggerSpec,
+    },
+};
+
+use super::{
+    error::{ApiError, err},
+    workspace::require_owned_workspace,
+};
+
+// ── DTOs ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AutomationResponse {
+    pub id: Uuid,
+    pub workspace_id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub prompt: String,
+    pub agent_type: String,
+    pub model: Option<String>,
+    pub enabled: bool,
+    pub created_by: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<Automation> for AutomationResponse {
+    fn from(a: Automation) -> Self {
+        Self {
+            id: a.id,
+            workspace_id: a.workspace_id,
+            name: a.name,
+            description: a.description,
+            prompt: a.prompt,
+            agent_type: a.agent_type,
+            model: a.model,
+            enabled: a.enabled,
+            created_by: a.created_by,
+            created_at: a.created_at,
+            updated_at: a.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AutomationListResponse {
+    pub items: Vec<AutomationResponse>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateAutomationRequest {
+    pub workspace_id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub prompt: String,
+    /// `coworker` (default) or `deep_research`.
+    #[serde(default)]
+    pub agent_type: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateAutomationRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub prompt: Option<String>,
+    pub agent_type: Option<String>,
+    pub model: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TriggerResponse {
+    pub id: Uuid,
+    pub automation_id: Uuid,
+    pub kind: TriggerKind,
+    pub spec: TriggerSpec,
+    pub enabled: bool,
+    pub next_fire_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl TriggerResponse {
+    fn from_db(t: AutomationTrigger) -> Result<Self, ApiError> {
+        let spec = TriggerSpec::from_db(t.kind, &t.spec_json)
+            .map_err(|e| err(StatusCode::INTERNAL_SERVER_ERROR, format!("spec decode: {e}")))?;
+        Ok(Self {
+            id: t.id,
+            automation_id: t.automation_id,
+            kind: t.kind,
+            spec,
+            enabled: t.enabled,
+            next_fire_at: t.next_fire_at,
+            created_at: t.created_at,
+            updated_at: t.updated_at,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TriggerListResponse {
+    pub items: Vec<TriggerResponse>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateTriggerRequest {
+    #[serde(flatten)]
+    pub spec: TriggerSpec,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RunResponse {
+    pub id: Uuid,
+    /// `null` for ad-hoc one-time runs (no owning automation).
+    pub automation_id: Option<Uuid>,
+    pub trigger_id: Option<Uuid>,
+    pub session_id: Uuid,
+    pub workspace_id: Uuid,
+    /// The rendered prompt this run executes.
+    pub prompt: String,
+    pub agent_type: String,
+    pub model: Option<String>,
+    pub status: RunStatus,
+    pub scheduled_for: DateTime<Utc>,
+    pub lease_until: Option<DateTime<Utc>>,
+    pub previous_run_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<AutomationRun> for RunResponse {
+    fn from(r: AutomationRun) -> Self {
+        Self {
+            id: r.id,
+            automation_id: r.automation_id,
+            trigger_id: r.trigger_id,
+            session_id: r.session_id,
+            workspace_id: r.workspace_id,
+            prompt: r.prompt,
+            agent_type: r.agent_type,
+            model: r.model,
+            status: r.status,
+            scheduled_for: r.scheduled_for,
+            lease_until: r.lease_until,
+            previous_run_id: r.previous_run_id,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RunListResponse {
+    pub items: Vec<RunResponse>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RunLogResponse {
+    pub id: i64,
+    pub run_id: Uuid,
+    pub ts: DateTime<Utc>,
+    pub kind: RunLogKind,
+    pub payload: Option<serde_json::Value>,
+}
+
+impl From<RunLog> for RunLogResponse {
+    fn from(e: RunLog) -> Self {
+        Self {
+            id: e.id,
+            run_id: e.run_id,
+            ts: e.ts,
+            kind: e.kind,
+            payload: e.payload,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RunLogListResponse {
+    pub items: Vec<RunLogResponse>,
+}
+
+// ── ownership helpers ──────────────────────────────────────────────────────
+
+/// Fetch an automation the caller owns (via its workspace). Missing and foreign
+/// automations both report `404`.
+async fn require_owned_automation(
+    state: &AppState,
+    auth: &AuthUser,
+    id: Uuid,
+) -> Result<Automation, ApiError> {
+    let automation = state
+        .automations
+        .get_automation(id)
+        .await?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "automation not found"))?;
+    if state
+        .workspaces
+        .get_for_user(auth.id, automation.workspace_id)
+        .await?
+        .is_none()
+    {
+        return Err(err(StatusCode::NOT_FOUND, "automation not found"));
+    }
+    Ok(automation)
+}
+
+/// An owned run, addressed directly by id. Runs are a top-level resource
+/// (independent of automations), so ownership is via the run's workspace —
+/// this works for ad-hoc runs and automation-linked runs alike. Missing and
+/// foreign runs both report `404`.
+async fn require_owned_run(
+    state: &AppState,
+    auth: &AuthUser,
+    run_id: Uuid,
+) -> Result<AutomationRun, ApiError> {
+    let run = state
+        .automations
+        .get_run(run_id)
+        .await?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "run not found"))?;
+    if state
+        .workspaces
+        .get_for_user(auth.id, run.workspace_id)
+        .await?
+        .is_none()
+    {
+        return Err(err(StatusCode::NOT_FOUND, "run not found"));
+    }
+    Ok(run)
+}
+
+// ── automations ────────────────────────────────────────────────────────────
+
+pub(super) async fn create_automation(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Json(payload): Json<CreateAutomationRequest>,
+) -> Result<(StatusCode, Json<AutomationResponse>), ApiError> {
+    require_owned_workspace(&state, &auth, payload.workspace_id).await?;
+    if payload.name.trim().is_empty() {
+        return Err(err(StatusCode::BAD_REQUEST, "name must not be empty"));
+    }
+    if payload.prompt.trim().is_empty() {
+        return Err(err(StatusCode::BAD_REQUEST, "prompt must not be empty"));
+    }
+    let automation = state
+        .automations
+        .create_automation(
+            payload.workspace_id,
+            payload.name,
+            payload.description,
+            payload.prompt,
+            payload.agent_type.unwrap_or_else(|| "coworker".to_string()),
+            payload.model,
+            auth.id,
+        )
+        .await?;
+    Ok((StatusCode::CREATED, Json(automation.into())))
+}
+
+pub(super) async fn list_automations(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+) -> Result<Json<AutomationListResponse>, ApiError> {
+    // Default workspace id == user id (see auth bootstrap).
+    let automations = state.automations.list_automations_by_workspace(auth.id).await?;
+    Ok(Json(AutomationListResponse {
+        items: automations.into_iter().map(AutomationResponse::from).collect(),
+    }))
+}
+
+pub(super) async fn get_automation(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<AutomationResponse>, ApiError> {
+    let automation = require_owned_automation(&state, &auth, id).await?;
+    Ok(Json(automation.into()))
+}
+
+pub(super) async fn update_automation(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+    Json(payload): Json<UpdateAutomationRequest>,
+) -> Result<Json<AutomationResponse>, ApiError> {
+    require_owned_automation(&state, &auth, id).await?;
+    if let Some(ref name) = payload.name
+        && name.trim().is_empty()
+    {
+        return Err(err(StatusCode::BAD_REQUEST, "name must not be empty"));
+    }
+    let updated = state
+        .automations
+        .update_automation(
+            id,
+            payload.name,
+            payload.description.map(Some),
+            payload.prompt,
+            payload.agent_type,
+            payload.model.map(Some),
+            payload.enabled,
+        )
+        .await?;
+    Ok(Json(updated.into()))
+}
+
+pub(super) async fn delete_automation(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    require_owned_automation(&state, &auth, id).await?;
+    state.automations.delete_automation(id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── triggers ───────────────────────────────────────────────────────────────
+
+pub(super) async fn create_trigger(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(automation_id): Path<Uuid>,
+    Json(payload): Json<CreateTriggerRequest>,
+) -> Result<(StatusCode, Json<TriggerResponse>), ApiError> {
+    require_owned_automation(&state, &auth, automation_id).await?;
+
+    // Validate the cron expression up front + compute the first fire instant.
+    let next_fire_at = match &payload.spec {
+        TriggerSpec::Cron { expr, tz } => {
+            let tz_name = tz.as_deref().unwrap_or(default_tz_name());
+            let fire = next_fire_after(expr, tz_name, Utc::now())
+                .map_err(|e| err(StatusCode::BAD_REQUEST, e))?;
+            payload.enabled.then_some(fire)
+        }
+    };
+
+    let trigger = state
+        .automations
+        .create_trigger(automation_id, &payload.spec, payload.enabled, next_fire_at)
+        .await?;
+    Ok((StatusCode::CREATED, Json(TriggerResponse::from_db(trigger)?)))
+}
+
+pub(super) async fn list_triggers(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(automation_id): Path<Uuid>,
+) -> Result<Json<TriggerListResponse>, ApiError> {
+    require_owned_automation(&state, &auth, automation_id).await?;
+    let triggers = state.automations.list_triggers(automation_id).await?;
+    let items = triggers
+        .into_iter()
+        .map(TriggerResponse::from_db)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Json(TriggerListResponse { items }))
+}
+
+pub(super) async fn delete_trigger(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path((automation_id, trigger_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, ApiError> {
+    require_owned_automation(&state, &auth, automation_id).await?;
+    let trigger = state
+        .automations
+        .get_trigger(trigger_id)
+        .await?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "trigger not found"))?;
+    if trigger.automation_id != automation_id {
+        return Err(err(StatusCode::NOT_FOUND, "trigger not found"));
+    }
+    state.automations.delete_trigger(trigger_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── runs (top-level resource: /automation-runs) ─────────────────────────────
+
+/// Create body: `automation_id` runs an existing automation; otherwise
+/// `workspace_id` + `prompt` make an ad-hoc run. `scheduled_for` defers pickup.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, default)]
+pub struct CreateRunRequest {
+    pub automation_id: Option<Uuid>,
+    pub workspace_id: Option<Uuid>,
+    pub prompt: Option<String>,
+    pub agent_type: Option<String>,
+    pub model: Option<String>,
+    pub scheduled_for: Option<DateTime<Utc>>,
+    pub title: Option<String>,
+}
+
+/// `POST /automation-runs`
+pub(super) async fn create_run(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Json(payload): Json<CreateRunRequest>,
+) -> Result<(StatusCode, Json<RunResponse>), ApiError> {
+    let (at, source) = match payload.scheduled_for {
+        Some(t) => (t, "one_time"),
+        None => (Utc::now(), "manual"),
+    };
+    let run = if let Some(aid) = payload.automation_id {
+        let automation = require_owned_automation(&state, &auth, aid).await?;
+        if !automation.enabled {
+            return Err(err(StatusCode::CONFLICT, "automation is disabled"));
+        }
+        state
+            .automations
+            .create_scheduled_run(&automation, at, source)
+            .await?
+    } else {
+        let ws = payload.workspace_id.ok_or_else(|| {
+            err(StatusCode::BAD_REQUEST, "automation_id or workspace_id is required")
+        })?;
+        let prompt = payload
+            .prompt
+            .ok_or_else(|| err(StatusCode::BAD_REQUEST, "prompt is required for ad-hoc runs"))?;
+        require_owned_workspace(&state, &auth, ws).await?;
+        if prompt.trim().is_empty() {
+            return Err(err(StatusCode::BAD_REQUEST, "prompt must not be empty"));
+        }
+        let title = payload.title.unwrap_or_else(|| prompt.chars().take(60).collect());
+        state
+            .automations
+            .create_adhoc_run(
+                ws,
+                title,
+                prompt,
+                payload.agent_type.unwrap_or_else(|| "coworker".to_string()),
+                payload.model,
+                at,
+                auth.id,
+            )
+            .await?
+    };
+    Ok((StatusCode::CREATED, Json(run.into())))
+}
+
+/// `GET /automation-runs` filter: by automation, else by workspace.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, default)]
+pub struct ListRunsQuery {
+    pub automation_id: Option<Uuid>,
+    pub workspace_id: Option<Uuid>,
+}
+
+/// `GET /automation-runs?automation_id=&workspace_id=`
+pub(super) async fn list_runs(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Query(q): Query<ListRunsQuery>,
+) -> Result<Json<RunListResponse>, ApiError> {
+    let runs = if let Some(aid) = q.automation_id {
+        require_owned_automation(&state, &auth, aid).await?;
+        state.automations.list_runs(aid).await?
+    } else {
+        let ws = q.workspace_id.unwrap_or(auth.id);
+        require_owned_workspace(&state, &auth, ws).await?;
+        state.automations.list_runs_by_workspace(ws).await?
+    };
+    Ok(Json(RunListResponse {
+        items: runs.into_iter().map(RunResponse::from).collect(),
+    }))
+}
+
+/// `GET /automation-runs/{id}`
+pub(super) async fn get_run(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(run_id): Path<Uuid>,
+) -> Result<Json<RunResponse>, ApiError> {
+    let run = require_owned_run(&state, &auth, run_id).await?;
+    Ok(Json(run.into()))
+}
+
+/// `POST /automation-runs/{id}/cancel`
+pub(super) async fn cancel_run(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(run_id): Path<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    require_owned_run(&state, &auth, run_id).await?;
+    let payload = serde_json::json!({ "source": "manual", "by": auth.id.to_string() });
+    let cancelled = state.automations.cancel_run(run_id, &payload).await?;
+    if !cancelled {
+        return Err(err(StatusCode::CONFLICT, "run is already terminal"));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /automation-runs/{id}/events` — audit event log.
+pub(super) async fn list_run_logs(
+    State(state): State<Arc<AppState>>,
+    Extension(auth): Extension<AuthUser>,
+    Path(run_id): Path<Uuid>,
+) -> Result<Json<RunLogListResponse>, ApiError> {
+    require_owned_run(&state, &auth, run_id).await?;
+    let events = state.automations.list_logs_for_run(run_id).await?;
+    Ok(Json(RunLogListResponse {
+        items: events.into_iter().map(RunLogResponse::from).collect(),
+    }))
+}

--- a/backend/src/router/mod.rs
+++ b/backend/src/router/mod.rs
@@ -152,6 +152,14 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
         ))
         .api_route("/auth/signup", post(auth::signup))
         .api_route("/auth/login", post(auth::login))
+        // Public webhook receiver: gated only by the Bearer token (its hash
+        // identifies the trigger), so it sits outside `auth_required`. Cap the
+        // body (public + unauthenticated) to bound memory per request.
+        .api_route(
+            "/webhooks/automations",
+            post(automation::fire_webhook_trigger)
+                .layer(axum::extract::DefaultBodyLimit::max(1024 * 1024)),
+        )
         // WebDAV serves the unified workspace tree (local under `files/`, each
         // provider mount as a sibling) at `/sources`. Two routes: matchit's
         // `{*rest}` wildcard needs one-or-more segments, so the bare collection

--- a/backend/src/router/mod.rs
+++ b/backend/src/router/mod.rs
@@ -13,6 +13,7 @@ use crate::{
 pub(crate) mod error;
 
 mod agent;
+mod automation;
 mod auth;
 mod knowledge;
 mod message;
@@ -112,6 +113,38 @@ pub fn get_router(state: Arc<AppState>) -> ApiRouter {
         .route(
             "/sessions/{id}/messages/stream",
             axum::routing::get(message::stream_messages),
+        )
+        .api_route(
+            "/automations",
+            get(automation::list_automations).post(automation::create_automation),
+        )
+        .api_route(
+            "/automations/{id}",
+            get(automation::get_automation)
+                .patch(automation::update_automation)
+                .delete(automation::delete_automation),
+        )
+        .api_route(
+            "/automations/{id}/triggers",
+            get(automation::list_triggers).post(automation::create_trigger),
+        )
+        .api_route(
+            "/automations/{id}/triggers/{trigger_id}",
+            delete(automation::delete_trigger),
+        )
+        // Runs are a top-level resource, independent of automations.
+        .api_route(
+            "/automation-runs",
+            get(automation::list_runs).post(automation::create_run),
+        )
+        .api_route("/automation-runs/{run_id}", get(automation::get_run))
+        .api_route(
+            "/automation-runs/{run_id}/cancel",
+            post(automation::cancel_run),
+        )
+        .api_route(
+            "/automation-runs/{run_id}/logs",
+            get(automation::list_run_logs),
         )
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/backend/src/state/automation.rs
+++ b/backend/src/state/automation.rs
@@ -973,6 +973,33 @@ impl AutomationsState {
         self.insert_run_with_session(spec, Utc::now(), Some(&payload)).await
     }
 
+    /// `(workspace_id, sources)` for every enabled event trigger of an enabled
+    /// automation. The source poller uses this to poll only subscribed provider
+    /// mounts (lazy activation).
+    pub async fn list_enabled_event_trigger_sources(
+        &self,
+    ) -> StateResult<Vec<(Uuid, Vec<String>)>> {
+        let rows = sqlx::query(
+            "SELECT a.workspace_id AS workspace_id, t.spec_json AS spec_json \
+             FROM automation_triggers t JOIN automations a ON a.id = t.automation_id \
+             WHERE t.kind = 'event' AND t.enabled = 1 AND a.enabled = 1",
+        )
+        .fetch_all(&self.db)
+        .await?;
+        let mut out = Vec::new();
+        for r in rows {
+            let workspace_id = parse_uuid(r.get::<String, _>("workspace_id"), "automations.workspace_id")?;
+            let spec_json: String = r.get("spec_json");
+            if let Ok(TriggerSpec::Event { conditions }) =
+                TriggerSpec::from_db(TriggerKind::Event, &spec_json)
+            {
+                let sources = conditions.into_iter().map(|c| c.source).collect();
+                out.push((workspace_id, sources));
+            }
+        }
+        Ok(out)
+    }
+
     // ── runs ────────────────────────────────────────────────────────────
 
     /// Enqueue a run + its session, emitting `triggered` + `queued` atomically.
@@ -1715,6 +1742,32 @@ mod tests {
             .await
             .unwrap();
         assert!(state.create_webhook_run(&a, t.id, serde_json::json!({})).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn lazy_poll_sources_from_enabled_event_triggers() {
+        let pool = fresh_db().await;
+        let (uid, wid) = seed(&pool).await;
+        let state = AutomationsState::new(pool);
+
+        let a = state
+            .create_automation(wid, "on s3".into(), None, "go".into(), "coworker".into(), None, uid)
+            .await
+            .unwrap();
+        let spec = TriggerSpec::Event {
+            conditions: vec![Condition { source: "s3.object_created".into(), filter: None }],
+        };
+        state.create_trigger(a.id, &spec, true, None, None).await.unwrap();
+
+        let subs = state.list_enabled_event_trigger_sources().await.unwrap();
+        assert_eq!(subs, vec![(wid, vec!["s3.object_created".to_string()])]);
+
+        // A disabled automation drops out of the poll-activation set.
+        state
+            .update_automation(a.id, None, None, None, None, None, Some(false))
+            .await
+            .unwrap();
+        assert!(state.list_enabled_event_trigger_sources().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/backend/src/state/automation.rs
+++ b/backend/src/state/automation.rs
@@ -1,0 +1,1360 @@
+//! Automation persistence + lifecycle. Ported from backend-v1's
+//! `repository/automation.rs`, adapted to v2 conventions (workspace-scoped,
+//! `SqlitePool` store, `StateError`) and **single-prompt**: an automation runs
+//! exactly one prompt, so there is no per-step cursor and the multi-step
+//! machinery (StepStarted/StepFinished, resume) is gone. Cron is the only
+//! trigger kind (webhook is out of scope).
+
+use ailoy::agent::AgentSpec;
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sqlx::{Row as _, SqlitePool, sqlite::SqliteRow};
+use uuid::Uuid;
+
+use super::{StateError, StateResult, parse_ts, parse_uuid};
+
+/// Identity passed to agent-k's spec builders (mirrors router/session.rs).
+const SESSION_AGENT_NAME: &str = "agent-k";
+const DEFAULT_MODEL_COWORKER: &str = "anthropic/claude-sonnet-4-5";
+const DEFAULT_MODEL_DEEP_RESEARCH: &str = "anthropic/claude-sonnet-4-5";
+
+/// Total attempts including the first; RETRY_BACKOFFS has MAX_ATTEMPTS-1 gaps.
+pub const MAX_ATTEMPTS: i64 = 3;
+
+/// Build a session [`AgentSpec`] from an automation's stored agent surface.
+/// Unknown `agent_type` falls back to the coworker preset.
+pub fn build_spec(agent_type: &str, model: Option<&str>) -> AgentSpec {
+    use agent_k::agents::{get_coworker_agent_spec, get_deep_research_agent_spec};
+    match agent_type {
+        "deep_research" => get_deep_research_agent_spec(
+            SESSION_AGENT_NAME,
+            model.unwrap_or(DEFAULT_MODEL_DEEP_RESEARCH),
+        ),
+        _ => get_coworker_agent_spec(
+            SESSION_AGENT_NAME,
+            model.unwrap_or(DEFAULT_MODEL_COWORKER),
+            true,
+        ),
+    }
+}
+
+// ── enums ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl RunStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RunStatus::Queued => "queued",
+            RunStatus::Running => "running",
+            RunStatus::Succeeded => "succeeded",
+            RunStatus::Failed => "failed",
+            RunStatus::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "queued" => Some(RunStatus::Queued),
+            "running" => Some(RunStatus::Running),
+            "succeeded" => Some(RunStatus::Succeeded),
+            "failed" => Some(RunStatus::Failed),
+            "cancelled" => Some(RunStatus::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TriggerKind {
+    Cron,
+}
+
+impl TriggerKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TriggerKind::Cron => "cron",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "cron" => Some(TriggerKind::Cron),
+            _ => None,
+        }
+    }
+}
+
+/// API-shape: internally tagged by `kind`. DB-shape: `kind` column + untagged
+/// variant fields in `spec_json`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TriggerSpec {
+    Cron {
+        expr: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tz: Option<String>,
+    },
+}
+
+impl TriggerSpec {
+    pub fn kind(&self) -> TriggerKind {
+        match self {
+            TriggerSpec::Cron { .. } => TriggerKind::Cron,
+        }
+    }
+
+    pub fn to_db_spec_json(&self) -> serde_json::Result<String> {
+        match self {
+            TriggerSpec::Cron { expr, tz } => {
+                serde_json::to_string(&serde_json::json!({ "expr": expr, "tz": tz }))
+            }
+        }
+    }
+
+    pub fn from_db(kind: TriggerKind, spec_json: &str) -> serde_json::Result<Self> {
+        match kind {
+            TriggerKind::Cron => {
+                #[derive(Deserialize)]
+                struct CronFields {
+                    expr: String,
+                    #[serde(default)]
+                    tz: Option<String>,
+                }
+                let CronFields { expr, tz } = serde_json::from_str(spec_json)?;
+                Ok(TriggerSpec::Cron { expr, tz })
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RunLogKind {
+    Triggered,
+    Queued,
+    Started,
+    Succeeded,
+    Failed,
+    RetryScheduled,
+    RetrySkipped,
+    LeaseLost,
+    Cancelled,
+}
+
+impl RunLogKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RunLogKind::Triggered => "triggered",
+            RunLogKind::Queued => "queued",
+            RunLogKind::Started => "started",
+            RunLogKind::Succeeded => "succeeded",
+            RunLogKind::Failed => "failed",
+            RunLogKind::RetryScheduled => "retry_scheduled",
+            RunLogKind::RetrySkipped => "retry_skipped",
+            RunLogKind::LeaseLost => "lease_lost",
+            RunLogKind::Cancelled => "cancelled",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "triggered" => Some(RunLogKind::Triggered),
+            "queued" => Some(RunLogKind::Queued),
+            "started" => Some(RunLogKind::Started),
+            "succeeded" => Some(RunLogKind::Succeeded),
+            "failed" => Some(RunLogKind::Failed),
+            "retry_scheduled" => Some(RunLogKind::RetryScheduled),
+            "retry_skipped" => Some(RunLogKind::RetrySkipped),
+            "lease_lost" => Some(RunLogKind::LeaseLost),
+            "cancelled" => Some(RunLogKind::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+// ── row structs ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct Automation {
+    pub id: Uuid,
+    pub workspace_id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub prompt: String,
+    pub agent_type: String,
+    pub model: Option<String>,
+    pub enabled: bool,
+    pub created_by: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Automation {
+    fn from_row(row: &SqliteRow) -> StateResult<Self> {
+        Ok(Self {
+            id: parse_uuid(row.get::<String, _>("id"), "automations.id")?,
+            workspace_id: parse_uuid(
+                row.get::<String, _>("workspace_id"),
+                "automations.workspace_id",
+            )?,
+            name: row.get("name"),
+            description: row.get("description"),
+            prompt: row.get("prompt"),
+            agent_type: row.get("agent_type"),
+            model: row.get("model"),
+            enabled: row.get("enabled"),
+            created_by: parse_uuid(row.get::<String, _>("created_by"), "automations.created_by")?,
+            created_at: parse_ts(&row.get::<String, _>("created_at"), "automations.created_at")?,
+            updated_at: parse_ts(&row.get::<String, _>("updated_at"), "automations.updated_at")?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AutomationTrigger {
+    pub id: Uuid,
+    pub automation_id: Uuid,
+    pub kind: TriggerKind,
+    pub spec_json: String,
+    pub enabled: bool,
+    pub next_fire_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl AutomationTrigger {
+    fn from_row(row: &SqliteRow) -> StateResult<Self> {
+        let kind_s: String = row.get("kind");
+        let kind = TriggerKind::from_str(&kind_s)
+            .ok_or_else(|| StateError::InvalidData(format!("invalid trigger kind '{kind_s}'")))?;
+        let next_fire_at = row
+            .get::<Option<String>, _>("next_fire_at")
+            .map(|s| parse_ts(&s, "automation_triggers.next_fire_at"))
+            .transpose()?;
+        Ok(Self {
+            id: parse_uuid(row.get::<String, _>("id"), "automation_triggers.id")?,
+            automation_id: parse_uuid(
+                row.get::<String, _>("automation_id"),
+                "automation_triggers.automation_id",
+            )?,
+            kind,
+            spec_json: row.get("spec_json"),
+            enabled: row.get("enabled"),
+            next_fire_at,
+            created_at: parse_ts(
+                &row.get::<String, _>("created_at"),
+                "automation_triggers.created_at",
+            )?,
+            updated_at: parse_ts(
+                &row.get::<String, _>("updated_at"),
+                "automation_triggers.updated_at",
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AutomationRun {
+    pub id: Uuid,
+    /// `None` for ad-hoc one-time runs (no owning automation).
+    pub automation_id: Option<Uuid>,
+    pub trigger_id: Option<Uuid>,
+    pub session_id: Uuid,
+    pub workspace_id: Uuid,
+    /// Rendered prompt actually executed (snapshot).
+    pub prompt: String,
+    pub agent_type: String,
+    pub model: Option<String>,
+    pub status: RunStatus,
+    pub scheduled_for: DateTime<Utc>,
+    pub lease_until: Option<DateTime<Utc>>,
+    pub previous_run_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl AutomationRun {
+    fn from_row(row: &SqliteRow) -> StateResult<Self> {
+        let status_s: String = row.get("status");
+        let status = RunStatus::from_str(&status_s)
+            .ok_or_else(|| StateError::InvalidData(format!("invalid run status '{status_s}'")))?;
+        let opt_uuid = |col: &str| -> StateResult<Option<Uuid>> {
+            row.get::<Option<String>, _>(col)
+                .map(|s| parse_uuid(s, "automation_runs"))
+                .transpose()
+        };
+        let lease_until = row
+            .get::<Option<String>, _>("lease_until")
+            .map(|s| parse_ts(&s, "automation_runs.lease_until"))
+            .transpose()?;
+        Ok(Self {
+            id: parse_uuid(row.get::<String, _>("id"), "automation_runs.id")?,
+            automation_id: opt_uuid("automation_id")?,
+            trigger_id: opt_uuid("trigger_id")?,
+            session_id: parse_uuid(row.get::<String, _>("session_id"), "automation_runs.session_id")?,
+            workspace_id: parse_uuid(
+                row.get::<String, _>("workspace_id"),
+                "automation_runs.workspace_id",
+            )?,
+            prompt: row.get("prompt"),
+            agent_type: row.get("agent_type"),
+            model: row.get("model"),
+            status,
+            scheduled_for: parse_ts(
+                &row.get::<String, _>("scheduled_for"),
+                "automation_runs.scheduled_for",
+            )?,
+            lease_until,
+            previous_run_id: opt_uuid("previous_run_id")?,
+            created_at: parse_ts(
+                &row.get::<String, _>("created_at"),
+                "automation_runs.created_at",
+            )?,
+            updated_at: parse_ts(
+                &row.get::<String, _>("updated_at"),
+                "automation_runs.updated_at",
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RunLog {
+    pub id: i64,
+    pub run_id: Uuid,
+    pub ts: DateTime<Utc>,
+    pub kind: RunLogKind,
+    pub payload: Option<serde_json::Value>,
+}
+
+impl RunLog {
+    fn from_row(row: &SqliteRow) -> StateResult<Self> {
+        let kind_s: String = row.get("kind");
+        let kind = RunLogKind::from_str(&kind_s)
+            .ok_or_else(|| StateError::InvalidData(format!("invalid event kind '{kind_s}'")))?;
+        let payload = row
+            .get::<Option<String>, _>("payload")
+            .map(|s| serde_json::from_str(&s))
+            .transpose()?;
+        Ok(Self {
+            id: row.get("id"),
+            run_id: parse_uuid(row.get::<String, _>("run_id"), "automation_run_logs.run_id")?,
+            ts: parse_ts(&row.get::<String, _>("ts"), "automation_run_logs.ts")?,
+            kind,
+            payload,
+        })
+    }
+}
+
+const AUTOMATION_COLS: &str =
+    "id, workspace_id, name, description, prompt, agent_type, model, enabled, created_by, created_at, updated_at";
+const TRIGGER_COLS: &str =
+    "id, automation_id, kind, spec_json, enabled, next_fire_at, created_at, updated_at";
+const RUN_COLS: &str =
+    "id, automation_id, trigger_id, session_id, workspace_id, prompt, agent_type, model, status, scheduled_for, lease_until, previous_run_id, created_at, updated_at";
+
+/// Everything needed to enqueue a run + its session. `automation_id = None` for
+/// ad-hoc one-time runs that depend on no automation.
+struct NewRun {
+    automation_id: Option<Uuid>,
+    trigger_id: Option<Uuid>,
+    workspace_id: Uuid,
+    title: String,
+    prompt: String,
+    agent_type: String,
+    model: Option<String>,
+    previous_run_id: Option<Uuid>,
+}
+
+impl NewRun {
+    /// Snapshot an automation's prompt + agent surface into a new run.
+    fn from_automation(
+        a: &Automation,
+        trigger_id: Option<Uuid>,
+        previous_run_id: Option<Uuid>,
+    ) -> Self {
+        Self {
+            automation_id: Some(a.id),
+            trigger_id,
+            workspace_id: a.workspace_id,
+            title: a.name.clone(),
+            prompt: a.prompt.clone(),
+            agent_type: a.agent_type.clone(),
+            model: a.model.clone(),
+            previous_run_id,
+        }
+    }
+
+    /// Re-run the same snapshot as a prior run (for retries). Preserves the
+    /// executed prompt rather than re-reading a possibly-changed template.
+    fn retry_of(prev: &AutomationRun) -> Self {
+        Self {
+            automation_id: prev.automation_id,
+            trigger_id: prev.trigger_id,
+            workspace_id: prev.workspace_id,
+            title: prev.prompt.chars().take(60).collect(),
+            prompt: prev.prompt.clone(),
+            agent_type: prev.agent_type.clone(),
+            model: prev.model.clone(),
+            previous_run_id: Some(prev.id),
+        }
+    }
+}
+
+// ── store ─────────────────────────────────────────────────────────────────
+
+pub struct AutomationsState {
+    db: SqlitePool,
+}
+
+impl AutomationsState {
+    pub fn new(db: SqlitePool) -> Self {
+        Self { db }
+    }
+
+    fn now() -> String {
+        Utc::now().to_rfc3339()
+    }
+
+    // ── automations ─────────────────────────────────────────────────────
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_automation(
+        &self,
+        workspace_id: Uuid,
+        name: String,
+        description: Option<String>,
+        prompt: String,
+        agent_type: String,
+        model: Option<String>,
+        created_by: Uuid,
+    ) -> StateResult<Automation> {
+        let id = Uuid::new_v4();
+        let now = Self::now();
+        sqlx::query(
+            "INSERT INTO automations (id, workspace_id, name, description, prompt, agent_type, model, enabled, created_by, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)",
+        )
+        .bind(id.to_string())
+        .bind(workspace_id.to_string())
+        .bind(&name)
+        .bind(&description)
+        .bind(&prompt)
+        .bind(&agent_type)
+        .bind(&model)
+        .bind(created_by.to_string())
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.db)
+        .await?;
+
+        Ok(Automation {
+            id,
+            workspace_id,
+            name,
+            description,
+            prompt,
+            agent_type,
+            model,
+            enabled: true,
+            created_by,
+            created_at: parse_ts(&now, "automations.created_at")?,
+            updated_at: parse_ts(&now, "automations.updated_at")?,
+        })
+    }
+
+    pub async fn get_automation(&self, id: Uuid) -> StateResult<Option<Automation>> {
+        let sql = format!("SELECT {AUTOMATION_COLS} FROM automations WHERE id = ?");
+        let row = sqlx::query(&sql)
+            .bind(id.to_string())
+            .fetch_optional(&self.db)
+            .await?;
+        row.as_ref().map(Automation::from_row).transpose()
+    }
+
+    pub async fn list_automations_by_workspace(
+        &self,
+        workspace_id: Uuid,
+    ) -> StateResult<Vec<Automation>> {
+        let sql = format!(
+            "SELECT {AUTOMATION_COLS} FROM automations WHERE workspace_id = ? ORDER BY created_at DESC"
+        );
+        let rows = sqlx::query(&sql)
+            .bind(workspace_id.to_string())
+            .fetch_all(&self.db)
+            .await?;
+        rows.iter().map(Automation::from_row).collect()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_automation(
+        &self,
+        id: Uuid,
+        name: Option<String>,
+        description: Option<Option<String>>,
+        prompt: Option<String>,
+        agent_type: Option<String>,
+        model: Option<Option<String>>,
+        enabled: Option<bool>,
+    ) -> StateResult<Automation> {
+        let current = self.get_automation(id).await?.ok_or(StateError::NotFound)?;
+        let name = name.unwrap_or(current.name);
+        let description = description.unwrap_or(current.description);
+        let prompt = prompt.unwrap_or(current.prompt);
+        let agent_type = agent_type.unwrap_or(current.agent_type);
+        let model = model.unwrap_or(current.model);
+        let enabled = enabled.unwrap_or(current.enabled);
+        let now = Self::now();
+
+        let mut tx = self.db.begin().await?;
+        sqlx::query(
+            "UPDATE automations SET name = ?, description = ?, prompt = ?, agent_type = ?, model = ?, enabled = ?, updated_at = ? \
+             WHERE id = ?",
+        )
+        .bind(&name)
+        .bind(&description)
+        .bind(&prompt)
+        .bind(&agent_type)
+        .bind(&model)
+        .bind(enabled)
+        .bind(&now)
+        .bind(id.to_string())
+        .execute(&mut *tx)
+        .await?;
+
+        // Disabling cancels queued runs so nothing new starts under the old config.
+        if current.enabled && !enabled {
+            sqlx::query(
+                "UPDATE automation_runs SET status = 'cancelled', lease_until = NULL, updated_at = ? \
+                 WHERE automation_id = ? AND status = 'queued'",
+            )
+            .bind(&now)
+            .bind(id.to_string())
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+
+        Ok(Automation {
+            id,
+            workspace_id: current.workspace_id,
+            name,
+            description,
+            prompt,
+            agent_type,
+            model,
+            enabled,
+            created_by: current.created_by,
+            created_at: current.created_at,
+            updated_at: parse_ts(&now, "automations.updated_at")?,
+        })
+    }
+
+    /// Delete the automation. Its triggers cascade away, but its runs are
+    /// preserved as an audit record — `automation_runs.automation_id` is
+    /// `ON DELETE SET NULL`, and each run already snapshots the prompt + agent
+    /// surface it executed, so the run + its events + session stay intact and
+    /// self-describing. Returns `false` if no automation row existed.
+    pub async fn delete_automation(&self, id: Uuid) -> StateResult<bool> {
+        let res = sqlx::query("DELETE FROM automations WHERE id = ?")
+            .bind(id.to_string())
+            .execute(&self.db)
+            .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    // ── triggers ────────────────────────────────────────────────────────
+
+    /// Create a trigger; for cron, `next_fire_at` is computed from the expr.
+    pub async fn create_trigger(
+        &self,
+        automation_id: Uuid,
+        spec: &TriggerSpec,
+        enabled: bool,
+        next_fire_at: Option<DateTime<Utc>>,
+    ) -> StateResult<AutomationTrigger> {
+        let id = Uuid::new_v4();
+        let now = Self::now();
+        let spec_json = spec.to_db_spec_json()?;
+        let next_s = next_fire_at.map(|t| t.to_rfc3339());
+        sqlx::query(
+            "INSERT INTO automation_triggers (id, automation_id, kind, spec_json, enabled, next_fire_at, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(id.to_string())
+        .bind(automation_id.to_string())
+        .bind(spec.kind().as_str())
+        .bind(&spec_json)
+        .bind(enabled)
+        .bind(&next_s)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.db)
+        .await?;
+
+        Ok(AutomationTrigger {
+            id,
+            automation_id,
+            kind: spec.kind(),
+            spec_json,
+            enabled,
+            next_fire_at,
+            created_at: parse_ts(&now, "automation_triggers.created_at")?,
+            updated_at: parse_ts(&now, "automation_triggers.updated_at")?,
+        })
+    }
+
+    pub async fn get_trigger(&self, id: Uuid) -> StateResult<Option<AutomationTrigger>> {
+        let sql = format!("SELECT {TRIGGER_COLS} FROM automation_triggers WHERE id = ?");
+        let row = sqlx::query(&sql)
+            .bind(id.to_string())
+            .fetch_optional(&self.db)
+            .await?;
+        row.as_ref().map(AutomationTrigger::from_row).transpose()
+    }
+
+    pub async fn list_triggers(
+        &self,
+        automation_id: Uuid,
+    ) -> StateResult<Vec<AutomationTrigger>> {
+        let sql = format!(
+            "SELECT {TRIGGER_COLS} FROM automation_triggers WHERE automation_id = ? ORDER BY created_at ASC"
+        );
+        let rows = sqlx::query(&sql)
+            .bind(automation_id.to_string())
+            .fetch_all(&self.db)
+            .await?;
+        rows.iter().map(AutomationTrigger::from_row).collect()
+    }
+
+    pub async fn delete_trigger(&self, id: Uuid) -> StateResult<bool> {
+        let res = sqlx::query("DELETE FROM automation_triggers WHERE id = ?")
+            .bind(id.to_string())
+            .execute(&self.db)
+            .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Cron triggers whose `next_fire_at` has elapsed (enabled only).
+    pub async fn list_due_cron_triggers(
+        &self,
+        now: DateTime<Utc>,
+    ) -> StateResult<Vec<AutomationTrigger>> {
+        let sql = format!(
+            "SELECT {TRIGGER_COLS} FROM automation_triggers \
+             WHERE kind = 'cron' AND enabled = 1 AND next_fire_at IS NOT NULL AND next_fire_at <= ? \
+             ORDER BY next_fire_at ASC"
+        );
+        let rows = sqlx::query(&sql)
+            .bind(now.to_rfc3339())
+            .fetch_all(&self.db)
+            .await?;
+        rows.iter().map(AutomationTrigger::from_row).collect()
+    }
+
+    // ── runs ────────────────────────────────────────────────────────────
+
+    /// Enqueue a run + its session, emitting `triggered` + `queued` atomically.
+    /// When `spec.automation_id` is set, the insert is gated on that automation
+    /// still being enabled (returns `None` if disabled); ad-hoc runs
+    /// (`automation_id = None`) are never gated.
+    async fn insert_run_with_session(
+        &self,
+        spec: NewRun,
+        scheduled_for: DateTime<Utc>,
+        triggered_payload: Option<&serde_json::Value>,
+    ) -> StateResult<Option<AutomationRun>> {
+        let now = Self::now();
+        let scheduled_s = scheduled_for.to_rfc3339();
+        let agent_spec = build_spec(&spec.agent_type, spec.model.as_deref());
+        let spec_json = serde_json::to_string(&agent_spec)?;
+        let session_id = Uuid::new_v4();
+        let run_id = Uuid::new_v4();
+
+        let mut tx = self.db.begin().await?;
+
+        // Session for this run (no runenv/sandbox — automation runs are simple).
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, agent_id, title, spec, runenv, created_at, updated_at) \
+             VALUES (?, ?, NULL, ?, ?, 0, ?, ?)",
+        )
+        .bind(session_id.to_string())
+        .bind(spec.workspace_id.to_string())
+        .bind(&spec.title)
+        .bind(&spec_json)
+        .bind(&now)
+        .bind(&now)
+        .execute(&mut *tx)
+        .await?;
+
+        // Run row. Automation-linked runs are gated on the automation still being
+        // enabled (atomic against a concurrent disable); ad-hoc runs insert plainly.
+        let run_cols = "INSERT INTO automation_runs \
+             (id, automation_id, trigger_id, session_id, workspace_id, prompt, agent_type, model, status, scheduled_for, lease_until, previous_run_id, created_at, updated_at)";
+        let res = if let Some(aid) = spec.automation_id {
+            sqlx::query(&format!(
+                "{run_cols} SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, NULL, ?, ?, ? \
+                  WHERE EXISTS (SELECT 1 FROM automations WHERE id = ? AND enabled = 1)"
+            ))
+            .bind(run_id.to_string())
+            .bind(aid.to_string())
+            .bind(spec.trigger_id.map(|u| u.to_string()))
+            .bind(session_id.to_string())
+            .bind(spec.workspace_id.to_string())
+            .bind(&spec.prompt)
+            .bind(&spec.agent_type)
+            .bind(&spec.model)
+            .bind(&scheduled_s)
+            .bind(spec.previous_run_id.map(|u| u.to_string()))
+            .bind(&now)
+            .bind(&now)
+            .bind(aid.to_string())
+            .execute(&mut *tx)
+            .await?
+        } else {
+            sqlx::query(&format!(
+                "{run_cols} VALUES (?, NULL, ?, ?, ?, ?, ?, ?, 'queued', ?, NULL, ?, ?, ?)"
+            ))
+            .bind(run_id.to_string())
+            .bind(spec.trigger_id.map(|u| u.to_string()))
+            .bind(session_id.to_string())
+            .bind(spec.workspace_id.to_string())
+            .bind(&spec.prompt)
+            .bind(&spec.agent_type)
+            .bind(&spec.model)
+            .bind(&scheduled_s)
+            .bind(spec.previous_run_id.map(|u| u.to_string()))
+            .bind(&now)
+            .bind(&now)
+            .execute(&mut *tx)
+            .await?
+        };
+
+        if res.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        Self::insert_log(&mut tx, run_id, RunLogKind::Triggered, triggered_payload, &now).await?;
+        Self::insert_log(&mut tx, run_id, RunLogKind::Queued, None, &now).await?;
+        tx.commit().await?;
+
+        Ok(Some(AutomationRun {
+            id: run_id,
+            automation_id: spec.automation_id,
+            trigger_id: spec.trigger_id,
+            session_id,
+            workspace_id: spec.workspace_id,
+            prompt: spec.prompt,
+            agent_type: spec.agent_type,
+            model: spec.model,
+            status: RunStatus::Queued,
+            scheduled_for,
+            lease_until: None,
+            previous_run_id: spec.previous_run_id,
+            created_at: parse_ts(&now, "automation_runs.created_at")?,
+            updated_at: parse_ts(&now, "automation_runs.updated_at")?,
+        }))
+    }
+
+    /// A run of `automation` scheduled for `at` (snapshotting its prompt + agent
+    /// surface). `at = now` for an immediate manual run. Errors if disabled.
+    pub async fn create_scheduled_run(
+        &self,
+        automation: &Automation,
+        at: DateTime<Utc>,
+        source: &str,
+    ) -> StateResult<AutomationRun> {
+        let payload = serde_json::json!({ "source": source, "scheduled_for": at.to_rfc3339() });
+        self.insert_run_with_session(NewRun::from_automation(automation, None, None), at, Some(&payload))
+            .await?
+            .ok_or_else(|| StateError::InvalidData("automation is disabled".into()))
+    }
+
+    /// Ad-hoc one-time run: no automation, the run carries its own (rendered)
+    /// prompt and agent surface. `at = now` runs immediately; a future `at`
+    /// defers pickup until then. Never gated (there is no automation to disable).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_adhoc_run(
+        &self,
+        workspace_id: Uuid,
+        title: String,
+        prompt: String,
+        agent_type: String,
+        model: Option<String>,
+        at: DateTime<Utc>,
+        scheduled_by: Uuid,
+    ) -> StateResult<AutomationRun> {
+        let payload = serde_json::json!({
+            "source": "one_time",
+            "scheduled_by": scheduled_by.to_string(),
+            "scheduled_for": at.to_rfc3339(),
+        });
+        let spec = NewRun {
+            automation_id: None,
+            trigger_id: None,
+            workspace_id,
+            title,
+            prompt,
+            agent_type,
+            model,
+            previous_run_id: None,
+        };
+        self.insert_run_with_session(spec, at, Some(&payload))
+            .await?
+            .ok_or_else(|| StateError::InvalidData("failed to create run".into()))
+    }
+
+    /// Cron fire: create a run and advance the trigger's `next_fire_at` in one tx.
+    pub async fn fire_cron_trigger(
+        &self,
+        automation: &Automation,
+        trigger_id: Uuid,
+        scheduled_for: DateTime<Utc>,
+        next_fire_at: DateTime<Utc>,
+        triggered_payload: &serde_json::Value,
+    ) -> StateResult<Option<AutomationRun>> {
+        let run = self
+            .insert_run_with_session(
+                NewRun::from_automation(automation, Some(trigger_id), None),
+                scheduled_for,
+                Some(triggered_payload),
+            )
+            .await?;
+        // Advance next_fire_at regardless of whether the run was created (a
+        // disabled automation still shouldn't re-fire the same instant forever).
+        sqlx::query("UPDATE automation_triggers SET next_fire_at = ?, updated_at = ? WHERE id = ?")
+            .bind(next_fire_at.to_rfc3339())
+            .bind(Self::now())
+            .bind(trigger_id.to_string())
+            .execute(&self.db)
+            .await?;
+        Ok(run)
+    }
+
+    pub async fn get_run(&self, id: Uuid) -> StateResult<Option<AutomationRun>> {
+        let sql = format!("SELECT {RUN_COLS} FROM automation_runs WHERE id = ?");
+        let row = sqlx::query(&sql)
+            .bind(id.to_string())
+            .fetch_optional(&self.db)
+            .await?;
+        row.as_ref().map(AutomationRun::from_row).transpose()
+    }
+
+    pub async fn list_runs(&self, automation_id: Uuid) -> StateResult<Vec<AutomationRun>> {
+        let sql = format!(
+            "SELECT {RUN_COLS} FROM automation_runs WHERE automation_id = ? ORDER BY created_at DESC"
+        );
+        let rows = sqlx::query(&sql)
+            .bind(automation_id.to_string())
+            .fetch_all(&self.db)
+            .await?;
+        rows.iter().map(AutomationRun::from_row).collect()
+    }
+
+    pub async fn list_runs_by_workspace(&self, workspace_id: Uuid) -> StateResult<Vec<AutomationRun>> {
+        let sql = format!(
+            "SELECT {RUN_COLS} FROM automation_runs WHERE workspace_id = ? ORDER BY created_at DESC"
+        );
+        let rows = sqlx::query(&sql)
+            .bind(workspace_id.to_string())
+            .fetch_all(&self.db)
+            .await?;
+        rows.iter().map(AutomationRun::from_row).collect()
+    }
+
+    /// Atomically claim the oldest due `queued` run: flip to `running` with a
+    /// lease. Returns the claimed run, or `None` if nothing is due.
+    pub async fn claim_due_run(
+        &self,
+        now: DateTime<Utc>,
+        lease_until: DateTime<Utc>,
+    ) -> StateResult<Option<AutomationRun>> {
+        let now_s = now.to_rfc3339();
+        let mut tx = self.db.begin().await?;
+        let sql = format!(
+            "SELECT {RUN_COLS} FROM automation_runs \
+             WHERE status = 'queued' AND scheduled_for <= ? ORDER BY scheduled_for ASC LIMIT 1"
+        );
+        let Some(row) = sqlx::query(&sql)
+            .bind(&now_s)
+            .fetch_optional(&mut *tx)
+            .await?
+        else {
+            tx.rollback().await?;
+            return Ok(None);
+        };
+        let run = AutomationRun::from_row(&row)?;
+        let res = sqlx::query(
+            "UPDATE automation_runs SET status = 'running', lease_until = ?, updated_at = ? \
+             WHERE id = ? AND status = 'queued'",
+        )
+        .bind(lease_until.to_rfc3339())
+        .bind(&now_s)
+        .bind(run.id.to_string())
+        .execute(&mut *tx)
+        .await?;
+        if res.rows_affected() != 1 {
+            // Lost the race to another worker; treat as nothing claimed.
+            tx.rollback().await?;
+            return Ok(None);
+        }
+        tx.commit().await?;
+        Ok(Some(AutomationRun {
+            status: RunStatus::Running,
+            lease_until: Some(lease_until),
+            ..run
+        }))
+    }
+
+    /// Renew the lease on an owned `running` run. `false` if it is no longer ours.
+    pub async fn renew_lease(&self, run_id: Uuid, new_lease: DateTime<Utc>) -> StateResult<bool> {
+        let res = sqlx::query(
+            "UPDATE automation_runs SET lease_until = ?, updated_at = ? \
+             WHERE id = ? AND status = 'running'",
+        )
+        .bind(new_lease.to_rfc3339())
+        .bind(Self::now())
+        .bind(run_id.to_string())
+        .execute(&self.db)
+        .await?;
+        Ok(res.rows_affected() == 1)
+    }
+
+    /// Atomically write the terminal event + status (clearing the lease). The
+    /// UPDATE is guarded by `status='running'`; `Ok(false)` if reaped from under us.
+    pub async fn finalize_run(
+        &self,
+        run_id: Uuid,
+        status: RunStatus,
+        event_kind: RunLogKind,
+        event_payload: Option<&serde_json::Value>,
+    ) -> StateResult<bool> {
+        let now = Self::now();
+        let mut tx = self.db.begin().await?;
+        let res = sqlx::query(
+            "UPDATE automation_runs SET status = ?, lease_until = NULL, updated_at = ? \
+             WHERE id = ? AND status = 'running'",
+        )
+        .bind(status.as_str())
+        .bind(&now)
+        .bind(run_id.to_string())
+        .execute(&mut *tx)
+        .await?;
+        if res.rows_affected() != 1 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+        Self::insert_log(&mut tx, run_id, event_kind, event_payload, &now).await?;
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    /// Cancel a queued/running run + emit `cancelled`. `false` if already terminal.
+    pub async fn cancel_run(
+        &self,
+        run_id: Uuid,
+        payload: &serde_json::Value,
+    ) -> StateResult<bool> {
+        let now = Self::now();
+        let mut tx = self.db.begin().await?;
+        let res = sqlx::query(
+            "UPDATE automation_runs SET status = 'cancelled', lease_until = NULL, updated_at = ? \
+             WHERE id = ? AND status IN ('queued', 'running')",
+        )
+        .bind(&now)
+        .bind(run_id.to_string())
+        .execute(&mut *tx)
+        .await?;
+        if res.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+        Self::insert_log(&mut tx, run_id, RunLogKind::Cancelled, Some(payload), &now).await?;
+        tx.commit().await?;
+        Ok(true)
+    }
+
+    /// Attempt number of `run_id` = depth of the `previous_run_id` chain (1-based).
+    pub async fn compute_run_attempt(&self, run_id: Uuid) -> StateResult<i64> {
+        let row = sqlx::query(
+            "WITH RECURSIVE chain(id, prev, depth) AS ( \
+               SELECT id, previous_run_id, 1 FROM automation_runs WHERE id = ? \
+               UNION ALL \
+               SELECT r.id, r.previous_run_id, c.depth + 1 \
+                 FROM automation_runs r JOIN chain c ON c.prev = r.id \
+             ) \
+             SELECT MAX(depth) AS d FROM chain",
+        )
+        .bind(run_id.to_string())
+        .fetch_one(&self.db)
+        .await?;
+        Ok(row.get::<i64, _>("d"))
+    }
+
+    /// Create a retry run chained to a failed one, emitting `retry_scheduled` on
+    /// the previous run and `queued` on the new one. `None` if disabled (also
+    /// emits `retry_skipped`).
+    pub async fn schedule_retry(
+        &self,
+        previous_run: &AutomationRun,
+        scheduled_for: DateTime<Utc>,
+        next_attempt: i64,
+    ) -> StateResult<Option<AutomationRun>> {
+        // Enabled gate applies only to automation-linked runs; ad-hoc one-time
+        // runs (no automation) always retry.
+        if let Some(aid) = previous_run.automation_id {
+            let enabled = matches!(self.get_automation(aid).await?, Some(a) if a.enabled);
+            if !enabled {
+                let payload = serde_json::json!({
+                    "reason": "automation_disabled",
+                    "attempt": next_attempt,
+                });
+                let now = Self::now();
+                let mut tx = self.db.begin().await?;
+                Self::insert_log(
+                    &mut tx,
+                    previous_run.id,
+                    RunLogKind::RetrySkipped,
+                    Some(&payload),
+                    &now,
+                )
+                .await?;
+                tx.commit().await?;
+                return Ok(None);
+            }
+        }
+
+        let run = self
+            .insert_run_with_session(NewRun::retry_of(previous_run), scheduled_for, None)
+            .await?;
+
+        if let Some(ref retry) = run {
+            let payload = serde_json::json!({
+                "next_run_id": retry.id.to_string(),
+                "scheduled_for": scheduled_for.to_rfc3339(),
+                "attempt": next_attempt,
+            });
+            let now = Self::now();
+            let mut tx = self.db.begin().await?;
+            Self::insert_log(
+                &mut tx,
+                previous_run.id,
+                RunLogKind::RetryScheduled,
+                Some(&payload),
+                &now,
+            )
+            .await?;
+            tx.commit().await?;
+        }
+        Ok(run)
+    }
+
+    /// Requeue expired-lease `running` rows, emitting `lease_lost` per row. Boot
+    /// recovery passes `None` to requeue *all* running rows unconditionally.
+    pub async fn reap_expired_leases(
+        &self,
+        now: Option<DateTime<Utc>>,
+    ) -> StateResult<Vec<Uuid>> {
+        let now_s = now.map(|t| t.to_rfc3339());
+        let rows = match &now_s {
+            Some(ts) => {
+                sqlx::query(
+                    "SELECT id FROM automation_runs \
+                     WHERE status = 'running' AND lease_until IS NOT NULL AND lease_until < ?",
+                )
+                .bind(ts)
+                .fetch_all(&self.db)
+                .await?
+            }
+            None => {
+                sqlx::query("SELECT id FROM automation_runs WHERE status = 'running'")
+                    .fetch_all(&self.db)
+                    .await?
+            }
+        };
+        if rows.is_empty() {
+            return Ok(vec![]);
+        }
+        let updated_at = Self::now();
+        let mut reaped = Vec::with_capacity(rows.len());
+        for r in &rows {
+            let id_s: String = r.get("id");
+            let mut tx = self.db.begin().await?;
+            let res = sqlx::query(
+                "UPDATE automation_runs SET status = 'queued', lease_until = NULL, updated_at = ? \
+                 WHERE id = ? AND status = 'running'",
+            )
+            .bind(&updated_at)
+            .bind(&id_s)
+            .execute(&mut *tx)
+            .await?;
+            if res.rows_affected() == 1 {
+                let run_id = parse_uuid(id_s.clone(), "automation_runs.id")?;
+                Self::insert_log(&mut tx, run_id, RunLogKind::LeaseLost, None, &updated_at).await?;
+                tx.commit().await?;
+                reaped.push(run_id);
+            } else {
+                tx.rollback().await?;
+            }
+        }
+        Ok(reaped)
+    }
+
+    // ── events ──────────────────────────────────────────────────────────
+
+    pub async fn append_log(
+        &self,
+        run_id: Uuid,
+        kind: RunLogKind,
+        payload: Option<&serde_json::Value>,
+    ) -> StateResult<()> {
+        let now = Self::now();
+        let mut tx = self.db.begin().await?;
+        Self::insert_log(&mut tx, run_id, kind, payload, &now).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn list_logs_for_run(&self, run_id: Uuid) -> StateResult<Vec<RunLog>> {
+        let rows = sqlx::query(
+            "SELECT id, run_id, ts, kind, payload FROM automation_run_logs \
+             WHERE run_id = ? ORDER BY ts ASC, id ASC",
+        )
+        .bind(run_id.to_string())
+        .fetch_all(&self.db)
+        .await?;
+        rows.iter().map(RunLog::from_row).collect()
+    }
+
+    /// Shared INSERT used inside the lifecycle transactions.
+    async fn insert_log(
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        run_id: Uuid,
+        kind: RunLogKind,
+        payload: Option<&serde_json::Value>,
+        ts: &str,
+    ) -> StateResult<()> {
+        let payload_str = payload.map(serde_json::to_string).transpose()?;
+        sqlx::query(
+            "INSERT INTO automation_run_logs (run_id, ts, kind, payload) VALUES (?, ?, ?, ?)",
+        )
+        .bind(run_id.to_string())
+        .bind(ts)
+        .bind(kind.as_str())
+        .bind(&payload_str)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    async fn fresh_db() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    /// Seed a user + its default workspace; returns `(user_id, workspace_id)`.
+    async fn seed(pool: &SqlitePool) -> (Uuid, Uuid) {
+        let uid = Uuid::new_v4();
+        let wid = Uuid::new_v4();
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO users \
+                 (id, username, password_hash, role, is_active, preferred_language, created_at, updated_at) \
+             VALUES (?, ?, 'x', 'user', 1, 'en', ?, ?)",
+        )
+        .bind(uid.to_string())
+        .bind(format!("u-{uid}"))
+        .bind(&now)
+        .bind(&now)
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO workspaces (id, user_id, title, created_at, updated_at) VALUES (?, ?, 'W', ?, ?)",
+        )
+        .bind(wid.to_string())
+        .bind(uid.to_string())
+        .bind(&now)
+        .bind(&now)
+        .execute(pool)
+        .await
+        .unwrap();
+        (uid, wid)
+    }
+
+    #[tokio::test]
+    async fn automation_crud_and_trigger() {
+        let pool = fresh_db().await;
+        let (uid, wid) = seed(&pool).await;
+        let state = AutomationsState::new(pool);
+
+        let a = state
+            .create_automation(
+                wid,
+                "daily digest".into(),
+                Some("desc".into()),
+                "summarize today".into(),
+                "coworker".into(),
+                None,
+                uid,
+            )
+            .await
+            .unwrap();
+        assert_eq!(a.prompt, "summarize today");
+        assert!(a.enabled);
+        assert_eq!(state.list_automations_by_workspace(wid).await.unwrap().len(), 1);
+
+        // Cron trigger with a computed next_fire_at.
+        let spec = TriggerSpec::Cron { expr: "0 9 * * *".into(), tz: None };
+        let next = crate::cron::next_fire_after("0 9 * * *", "UTC", Utc::now()).unwrap();
+        let t = state
+            .create_trigger(a.id, &spec, true, Some(next))
+            .await
+            .unwrap();
+        assert_eq!(t.kind, TriggerKind::Cron);
+        assert_eq!(state.list_triggers(a.id).await.unwrap().len(), 1);
+
+        // Update: disable, which cancels queued runs.
+        let updated = state
+            .update_automation(a.id, None, None, None, None, None, Some(false))
+            .await
+            .unwrap();
+        assert!(!updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn run_lifecycle_claim_finalize() {
+        let pool = fresh_db().await;
+        let (uid, wid) = seed(&pool).await;
+        let state = AutomationsState::new(pool);
+
+        let a = state
+            .create_automation(wid, "job".into(), None, "do it".into(), "coworker".into(), None, uid)
+            .await
+            .unwrap();
+
+        // Manual run → queued, with triggered + queued events.
+        let run = state.create_scheduled_run(&a, Utc::now(), "manual").await.unwrap();
+        assert_eq!(run.status, RunStatus::Queued);
+        let events = state.list_logs_for_run(run.id).await.unwrap();
+        let kinds: Vec<_> = events.iter().map(|e| e.kind).collect();
+        assert_eq!(kinds, vec![RunLogKind::Triggered, RunLogKind::Queued]);
+
+        // Claim → running.
+        let now = Utc::now() + chrono::Duration::seconds(1);
+        let lease = now + chrono::Duration::minutes(3);
+        let claimed = state.claim_due_run(now, lease).await.unwrap().expect("claimable");
+        assert_eq!(claimed.id, run.id);
+        assert_eq!(claimed.status, RunStatus::Running);
+        // Nothing left to claim.
+        assert!(state.claim_due_run(now, lease).await.unwrap().is_none());
+
+        // Finalize succeeded.
+        assert!(state
+            .finalize_run(run.id, RunStatus::Succeeded, RunLogKind::Succeeded, None)
+            .await
+            .unwrap());
+        assert_eq!(state.get_run(run.id).await.unwrap().unwrap().status, RunStatus::Succeeded);
+        assert!(state
+            .list_logs_for_run(run.id)
+            .await
+            .unwrap()
+            .iter()
+            .any(|e| e.kind == RunLogKind::Succeeded));
+
+        // A second finalize finds no running row.
+        assert!(!state
+            .finalize_run(run.id, RunStatus::Failed, RunLogKind::Failed, None)
+            .await
+            .unwrap());
+
+        // Deleting the automation preserves the run as an audit record: its
+        // automation_id is SET NULL, and its snapshot (prompt) stays intact.
+        assert!(state.delete_automation(a.id).await.unwrap());
+        let preserved = state.get_run(run.id).await.unwrap().expect("run preserved");
+        assert!(preserved.automation_id.is_none(), "automation_id should be NULL");
+        assert_eq!(preserved.prompt, "do it");
+    }
+
+    #[tokio::test]
+    async fn adhoc_one_time_run() {
+        let pool = fresh_db().await;
+        let (uid, wid) = seed(&pool).await;
+        let state = AutomationsState::new(pool);
+
+        // Schedule one hour out — self-contained, no automation.
+        let future = Utc::now() + chrono::Duration::hours(1);
+        let run = state
+            .create_adhoc_run(wid, "t".into(), "hello".into(), "coworker".into(), None, future, uid)
+            .await
+            .unwrap();
+        assert!(run.automation_id.is_none());
+        assert_eq!(run.prompt, "hello");
+        assert_eq!(run.status, RunStatus::Queued);
+
+        // Not due yet; becomes claimable only once the scheduled instant passes.
+        let lease = Utc::now() + chrono::Duration::minutes(3);
+        assert!(state.claim_due_run(Utc::now(), lease).await.unwrap().is_none());
+        let claimed = state
+            .claim_due_run(future + chrono::Duration::seconds(1), lease)
+            .await
+            .unwrap()
+            .expect("claimable once due");
+        assert_eq!(claimed.id, run.id);
+        assert_eq!(claimed.prompt, "hello");
+
+        // Full audit trail exists without any automation.
+        let kinds: Vec<_> = state
+            .list_logs_for_run(run.id)
+            .await
+            .unwrap()
+            .iter()
+            .map(|e| e.kind)
+            .collect();
+        assert_eq!(kinds, vec![RunLogKind::Triggered, RunLogKind::Queued]);
+    }
+
+    #[tokio::test]
+    async fn reap_requeues_expired_lease() {
+        let pool = fresh_db().await;
+        let (uid, wid) = seed(&pool).await;
+        let state = AutomationsState::new(pool);
+        let a = state
+            .create_automation(wid, "j".into(), None, "p".into(), "coworker".into(), None, uid)
+            .await
+            .unwrap();
+        let run = state.create_scheduled_run(&a, Utc::now(), "manual").await.unwrap();
+
+        // Claim with an already-expired lease, then reap.
+        let past = Utc::now() - chrono::Duration::minutes(10);
+        state.claim_due_run(Utc::now(), past).await.unwrap().unwrap();
+        let reaped = state.reap_expired_leases(Some(Utc::now())).await.unwrap();
+        assert_eq!(reaped, vec![run.id]);
+        assert_eq!(state.get_run(run.id).await.unwrap().unwrap().status, RunStatus::Queued);
+        assert!(state
+            .list_logs_for_run(run.id)
+            .await
+            .unwrap()
+            .iter()
+            .any(|e| e.kind == RunLogKind::LeaseLost));
+    }
+}

--- a/backend/src/state/automation.rs
+++ b/backend/src/state/automation.rs
@@ -78,18 +78,21 @@ impl RunStatus {
 #[serde(rename_all = "snake_case")]
 pub enum TriggerKind {
     Cron,
+    Webhook,
 }
 
 impl TriggerKind {
     pub fn as_str(&self) -> &'static str {
         match self {
             TriggerKind::Cron => "cron",
+            TriggerKind::Webhook => "webhook",
         }
     }
 
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "cron" => Some(TriggerKind::Cron),
+            "webhook" => Some(TriggerKind::Webhook),
             _ => None,
         }
     }
@@ -105,12 +108,17 @@ pub enum TriggerSpec {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tz: Option<String>,
     },
+    /// Fired directly by an authenticated HTTP POST (automation-direct). The
+    /// token isn't in the spec — its sha256 hash lives in the
+    /// `webhook_token_hash` column and the raw token is shown once on create.
+    Webhook {},
 }
 
 impl TriggerSpec {
     pub fn kind(&self) -> TriggerKind {
         match self {
             TriggerSpec::Cron { .. } => TriggerKind::Cron,
+            TriggerSpec::Webhook {} => TriggerKind::Webhook,
         }
     }
 
@@ -119,6 +127,7 @@ impl TriggerSpec {
             TriggerSpec::Cron { expr, tz } => {
                 serde_json::to_string(&serde_json::json!({ "expr": expr, "tz": tz }))
             }
+            TriggerSpec::Webhook {} => serde_json::to_string(&serde_json::json!({})),
         }
     }
 
@@ -134,8 +143,23 @@ impl TriggerSpec {
                 let CronFields { expr, tz } = serde_json::from_str(spec_json)?;
                 Ok(TriggerSpec::Cron { expr, tz })
             }
+            TriggerKind::Webhook => Ok(TriggerSpec::Webhook {}),
         }
     }
+}
+
+/// sha256 hex of a webhook token — the lookup key stored in
+/// `automation_triggers.webhook_token_hash`.
+fn sha256_hex(s: impl AsRef<[u8]>) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_ref());
+    hasher.finalize().iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// 256 bits of entropy from two UUID v4s (OS-RNG backed).
+fn generate_webhook_token() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -229,6 +253,8 @@ pub struct AutomationTrigger {
     pub spec_json: String,
     pub enabled: bool,
     pub next_fire_at: Option<DateTime<Utc>>,
+    /// sha256 hex of the issued webhook token (webhook triggers only; else `None`).
+    pub webhook_token_hash: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -252,6 +278,7 @@ impl AutomationTrigger {
             spec_json: row.get("spec_json"),
             enabled: row.get("enabled"),
             next_fire_at,
+            webhook_token_hash: row.get("webhook_token_hash"),
             created_at: parse_ts(
                 &row.get::<String, _>("created_at"),
                 "automation_triggers.created_at",
@@ -360,7 +387,7 @@ impl RunLog {
 const AUTOMATION_COLS: &str =
     "id, workspace_id, name, description, prompt, agent_type, model, enabled, created_by, created_at, updated_at";
 const TRIGGER_COLS: &str =
-    "id, automation_id, kind, spec_json, enabled, next_fire_at, created_at, updated_at";
+    "id, automation_id, kind, spec_json, enabled, next_fire_at, webhook_token_hash, created_at, updated_at";
 const RUN_COLS: &str =
     "id, automation_id, trigger_id, session_id, workspace_id, prompt, agent_type, model, status, scheduled_for, lease_until, previous_run_id, created_at, updated_at";
 
@@ -583,14 +610,15 @@ impl AutomationsState {
         spec: &TriggerSpec,
         enabled: bool,
         next_fire_at: Option<DateTime<Utc>>,
+        webhook_token_hash: Option<String>,
     ) -> StateResult<AutomationTrigger> {
         let id = Uuid::new_v4();
         let now = Self::now();
         let spec_json = spec.to_db_spec_json()?;
         let next_s = next_fire_at.map(|t| t.to_rfc3339());
         sqlx::query(
-            "INSERT INTO automation_triggers (id, automation_id, kind, spec_json, enabled, next_fire_at, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO automation_triggers (id, automation_id, kind, spec_json, enabled, next_fire_at, webhook_token_hash, created_at, updated_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(id.to_string())
         .bind(automation_id.to_string())
@@ -598,6 +626,7 @@ impl AutomationsState {
         .bind(&spec_json)
         .bind(enabled)
         .bind(&next_s)
+        .bind(&webhook_token_hash)
         .bind(&now)
         .bind(&now)
         .execute(&self.db)
@@ -610,6 +639,7 @@ impl AutomationsState {
             spec_json,
             enabled,
             next_fire_at,
+            webhook_token_hash,
             created_at: parse_ts(&now, "automation_triggers.created_at")?,
             updated_at: parse_ts(&now, "automation_triggers.updated_at")?,
         })
@@ -644,6 +674,52 @@ impl AutomationsState {
             .execute(&self.db)
             .await?;
         Ok(res.rows_affected() == 1)
+    }
+
+    /// The enabled webhook trigger of `automation_id` whose secret matches
+    /// `token`, or `None`. Used by the public webhook receive endpoint.
+    /// The webhook trigger whose token hashes to `token_hash`, or `None`. The
+    /// hash is globally unique, so the token alone identifies its trigger.
+    pub async fn find_trigger_by_webhook_token_hash(
+        &self,
+        token_hash: &str,
+    ) -> StateResult<Option<AutomationTrigger>> {
+        let sql = format!(
+            "SELECT {TRIGGER_COLS} FROM automation_triggers WHERE webhook_token_hash = ?"
+        );
+        let row = sqlx::query(&sql)
+            .bind(token_hash)
+            .fetch_optional(&self.db)
+            .await?;
+        row.as_ref().map(AutomationTrigger::from_row).transpose()
+    }
+
+    /// sha256 hex of a webhook token — for the caller to hash a presented token
+    /// before looking it up.
+    pub fn webhook_token_hash(token: &str) -> String {
+        sha256_hex(token)
+    }
+
+    /// Generate a fresh webhook token; returns `(token, hash)`. Store the hash,
+    /// return the token to the client once.
+    pub fn new_webhook_token() -> (String, String) {
+        let token = generate_webhook_token();
+        let hash = sha256_hex(&token);
+        (token, hash)
+    }
+
+    /// Create a queued run fired directly by a webhook (automation-direct). The
+    /// automation's stored prompt runs as-is — the POST body is not yet used as
+    /// render input (that arrives with the event infrastructure). `None` if the
+    /// automation is disabled.
+    pub async fn create_webhook_run(
+        &self,
+        automation: &Automation,
+        trigger_id: Uuid,
+    ) -> StateResult<Option<AutomationRun>> {
+        let spec = NewRun::from_automation(automation, Some(trigger_id), None);
+        let payload = serde_json::json!({ "source": "webhook" });
+        self.insert_run_with_session(spec, Utc::now(), Some(&payload)).await
     }
 
     /// Cron triggers whose `next_fire_at` has elapsed (enabled only).
@@ -1227,7 +1303,7 @@ mod tests {
         let spec = TriggerSpec::Cron { expr: "0 9 * * *".into(), tz: None };
         let next = crate::cron::next_fire_after("0 9 * * *", "UTC", Utc::now()).unwrap();
         let t = state
-            .create_trigger(a.id, &spec, true, Some(next))
+            .create_trigger(a.id, &spec, true, Some(next), None)
             .await
             .unwrap();
         assert_eq!(t.kind, TriggerKind::Cron);
@@ -1239,6 +1315,53 @@ mod tests {
             .await
             .unwrap();
         assert!(!updated.enabled);
+    }
+
+    #[tokio::test]
+    async fn webhook_trigger_lookup_and_run() {
+        let pool = fresh_db().await;
+        let (uid, wid) = seed(&pool).await;
+        let state = AutomationsState::new(pool);
+
+        let a = state
+            .create_automation(wid, "hooked".into(), None, "go".into(), "coworker".into(), None, uid)
+            .await
+            .unwrap();
+        let (token, hash) = AutomationsState::new_webhook_token();
+        let t = state
+            .create_trigger(a.id, &TriggerSpec::Webhook {}, true, None, Some(hash))
+            .await
+            .unwrap();
+        assert_eq!(t.kind, TriggerKind::Webhook);
+
+        // Lookup by token hash: correct → Some(trigger); wrong → None.
+        assert_eq!(
+            state
+                .find_trigger_by_webhook_token_hash(&AutomationsState::webhook_token_hash(&token))
+                .await
+                .unwrap()
+                .map(|f| f.id),
+            Some(t.id)
+        );
+        assert!(
+            state
+                .find_trigger_by_webhook_token_hash(&AutomationsState::webhook_token_hash("wrong"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Fire it: a run is created for the automation.
+        let run = state.create_webhook_run(&a, t.id).await.unwrap().unwrap();
+        assert_eq!(run.trigger_id, Some(t.id));
+        assert_eq!(run.automation_id, Some(a.id));
+
+        // Disabled automation gates run creation.
+        state
+            .update_automation(a.id, None, None, None, None, None, Some(false))
+            .await
+            .unwrap();
+        assert!(state.create_webhook_run(&a, t.id).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/backend/src/state/automation.rs
+++ b/backend/src/state/automation.rs
@@ -2,8 +2,8 @@
 //! `repository/automation.rs`, adapted to v2 conventions (workspace-scoped,
 //! `SqlitePool` store, `StateError`) and **single-prompt**: an automation runs
 //! exactly one prompt, so there is no per-step cursor and the multi-step
-//! machinery (StepStarted/StepFinished, resume) is gone. Cron is the only
-//! trigger kind (webhook is out of scope).
+//! machinery (StepStarted/StepFinished, resume) is gone. Trigger kinds: `cron`
+//! (schedule), `event` (durable outbox), and `webhook` (automation-direct HTTP).
 
 use ailoy::agent::AgentSpec;
 use chrono::{DateTime, Utc};
@@ -22,6 +22,11 @@ const DEFAULT_MODEL_DEEP_RESEARCH: &str = "anthropic/claude-sonnet-4-5";
 /// Total attempts including the first; RETRY_BACKOFFS has MAX_ATTEMPTS-1 gaps.
 pub const MAX_ATTEMPTS: i64 = 3;
 
+/// Max causal chain depth for `run.succeeded`-triggered runs. A run at this
+/// depth still runs, but the run it would spawn is suppressed at dispatch — this
+/// breaks run→run trigger loops (self or cyclic). Roots start at 0.
+pub const MAX_CHAIN_DEPTH: i64 = 5;
+
 /// Build a session [`AgentSpec`] from an automation's stored agent surface.
 /// Unknown `agent_type` falls back to the coworker preset.
 pub fn build_spec(agent_type: &str, model: Option<&str>) -> AgentSpec {
@@ -36,6 +41,45 @@ pub fn build_spec(agent_type: &str, model: Option<&str>) -> AgentSpec {
             model.unwrap_or(DEFAULT_MODEL_COWORKER),
             true,
         ),
+    }
+}
+
+/// Render a `{{ ... }}` template against an event input context. Supports
+/// `{{now}}`, `{{today}}`, and `{{event.<field>}}` (one level of the input
+/// JSON object). Unknown or missing variables error (fail-closed).
+pub fn render(template: &str, input: Option<&serde_json::Value>) -> Result<String, String> {
+    let now = Utc::now();
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let Some(end) = after.find("}}") else {
+            return Err("unterminated '{{' in template".into());
+        };
+        out.push_str(&resolve_var(after[..end].trim(), input, now)?);
+        rest = &after[end + 2..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+fn resolve_var(
+    key: &str,
+    input: Option<&serde_json::Value>,
+    now: DateTime<Utc>,
+) -> Result<String, String> {
+    match key {
+        "now" => Ok(now.to_rfc3339()),
+        "today" => Ok(now.format("%Y-%m-%d").to_string()),
+        _ => match key.strip_prefix("event.") {
+            Some(field) => match input.and_then(|v| v.as_object()).and_then(|m| m.get(field)) {
+                Some(serde_json::Value::String(s)) => Ok(s.clone()),
+                Some(v) => Ok(v.to_string()),
+                None => Err(format!("undefined template variable '{{{{{key}}}}}'")),
+            },
+            None => Err(format!("unknown template variable '{{{{{key}}}}}'")),
+        },
     }
 }
 
@@ -78,6 +122,7 @@ impl RunStatus {
 #[serde(rename_all = "snake_case")]
 pub enum TriggerKind {
     Cron,
+    Event,
     Webhook,
 }
 
@@ -85,6 +130,7 @@ impl TriggerKind {
     pub fn as_str(&self) -> &'static str {
         match self {
             TriggerKind::Cron => "cron",
+            TriggerKind::Event => "event",
             TriggerKind::Webhook => "webhook",
         }
     }
@@ -92,9 +138,28 @@ impl TriggerKind {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "cron" => Some(TriggerKind::Cron),
+            "event" => Some(TriggerKind::Event),
             "webhook" => Some(TriggerKind::Webhook),
             _ => None,
         }
+    }
+}
+
+/// One event condition of an event trigger: a source type + optional payload
+/// filter.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Condition {
+    /// Dotted event type, e.g. `file.added`, `run.succeeded`.
+    pub source: String,
+    /// Predicate over the event payload (see [`event_filter_matches`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<serde_json::Value>,
+}
+
+impl Condition {
+    /// True when an event of `kind`/`payload` satisfies this condition.
+    pub fn matches(&self, kind: &str, payload: Option<&serde_json::Value>) -> bool {
+        self.source == kind && event_filter_matches(self.filter.as_ref(), payload)
     }
 }
 
@@ -108,17 +173,26 @@ pub enum TriggerSpec {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tz: Option<String>,
     },
-    /// Fired directly by an authenticated HTTP POST (automation-direct). The
-    /// token isn't in the spec — its sha256 hash lives in the
-    /// `webhook_token_hash` column and the raw token is shown once on create.
-    Webhook {},
+    /// Fire when ANY condition matches (OR); each condition has its own source +
+    /// filter. Multi-step work is the triggered agent's job. (AND/fan-in later.)
+    Event { conditions: Vec<Condition> },
+    /// Fired directly by an authenticated HTTP POST (automation-direct: bypasses
+    /// the event outbox). The token isn't in the spec — its sha256 hash lives in
+    /// the `webhook_token_hash` column and the raw token is shown once on create.
+    /// `filter` (optional) gates firing on the POST body — same predicate shape as
+    /// an event condition's filter; a non-matching POST is accepted but fires no run.
+    Webhook {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filter: Option<serde_json::Value>,
+    },
 }
 
 impl TriggerSpec {
     pub fn kind(&self) -> TriggerKind {
         match self {
             TriggerSpec::Cron { .. } => TriggerKind::Cron,
-            TriggerSpec::Webhook {} => TriggerKind::Webhook,
+            TriggerSpec::Event { .. } => TriggerKind::Event,
+            TriggerSpec::Webhook { .. } => TriggerKind::Webhook,
         }
     }
 
@@ -127,7 +201,12 @@ impl TriggerSpec {
             TriggerSpec::Cron { expr, tz } => {
                 serde_json::to_string(&serde_json::json!({ "expr": expr, "tz": tz }))
             }
-            TriggerSpec::Webhook {} => serde_json::to_string(&serde_json::json!({})),
+            TriggerSpec::Event { conditions } => {
+                serde_json::to_string(&serde_json::json!({ "conditions": conditions }))
+            }
+            TriggerSpec::Webhook { filter } => {
+                serde_json::to_string(&serde_json::json!({ "filter": filter }))
+            }
         }
     }
 
@@ -143,7 +222,24 @@ impl TriggerSpec {
                 let CronFields { expr, tz } = serde_json::from_str(spec_json)?;
                 Ok(TriggerSpec::Cron { expr, tz })
             }
-            TriggerKind::Webhook => Ok(TriggerSpec::Webhook {}),
+            TriggerKind::Event => {
+                #[derive(Deserialize)]
+                struct EventFields {
+                    conditions: Vec<Condition>,
+                }
+                let EventFields { conditions } = serde_json::from_str(spec_json)?;
+                Ok(TriggerSpec::Event { conditions })
+            }
+            TriggerKind::Webhook => {
+                #[derive(Deserialize)]
+                struct WebhookFields {
+                    #[serde(default)]
+                    filter: Option<serde_json::Value>,
+                }
+                // Webhooks created before the `filter` field stored `{}`; default covers it.
+                let WebhookFields { filter } = serde_json::from_str(spec_json)?;
+                Ok(TriggerSpec::Webhook { filter })
+            }
         }
     }
 }
@@ -160,6 +256,64 @@ fn sha256_hex(s: impl AsRef<[u8]>) -> String {
 /// 256 bits of entropy from two UUID v4s (OS-RNG backed).
 fn generate_webhook_token() -> String {
     format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+/// Match an event trigger's `filter` against the event `payload`. Each key in
+/// `filter` is a predicate on `payload[key]`: a scalar means equality; an
+/// object means operator(s) — `eq`, `glob`, `contains`, `gte`, `lte`. All keys
+/// must hold. `None`/empty filter matches any event of the right source.
+pub fn event_filter_matches(
+    filter: Option<&serde_json::Value>,
+    payload: Option<&serde_json::Value>,
+) -> bool {
+    let Some(filter) = filter.and_then(|f| f.as_object()) else {
+        return true;
+    };
+    let pl = payload.and_then(|p| p.as_object());
+    filter.iter().all(|(key, cond)| {
+        let actual = pl.and_then(|m| m.get(key));
+        match cond {
+            serde_json::Value::Object(ops) => ops.iter().all(|(op, want)| eval_op(op, want, actual)),
+            scalar => actual == Some(scalar),
+        }
+    })
+}
+
+fn eval_op(op: &str, want: &serde_json::Value, actual: Option<&serde_json::Value>) -> bool {
+    let Some(actual) = actual else { return false };
+    match op {
+        "eq" => actual == want,
+        "glob" => matches!((actual.as_str(), want.as_str()), (Some(s), Some(p)) if glob_match(p, s)),
+        "contains" => matches!((actual.as_str(), want.as_str()), (Some(s), Some(sub)) if s.contains(sub)),
+        "gte" => json_cmp(actual, want).map(|o| o.is_ge()).unwrap_or(false),
+        "lte" => json_cmp(actual, want).map(|o| o.is_le()).unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// Compare two JSON scalars: numerically if both numbers, else lexicographically
+/// as strings (so ISO dates order correctly). `None` if incomparable.
+fn json_cmp(a: &serde_json::Value, b: &serde_json::Value) -> Option<std::cmp::Ordering> {
+    if let (Some(x), Some(y)) = (a.as_f64(), b.as_f64()) {
+        return x.partial_cmp(&y);
+    }
+    match (a.as_str(), b.as_str()) {
+        (Some(x), Some(y)) => Some(x.cmp(y)),
+        _ => None,
+    }
+}
+
+/// Minimal glob matcher supporting `*` (any run) and `?` (one char).
+fn glob_match(pattern: &str, s: &str) -> bool {
+    fn m(p: &[u8], s: &[u8]) -> bool {
+        match p.first() {
+            None => s.is_empty(),
+            Some(b'*') => m(&p[1..], s) || (!s.is_empty() && m(p, &s[1..])),
+            Some(b'?') => !s.is_empty() && m(&p[1..], &s[1..]),
+            Some(&c) => !s.is_empty() && s[0] == c && m(&p[1..], &s[1..]),
+        }
+    }
+    m(pattern.as_bytes(), s.as_bytes())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -307,6 +461,12 @@ pub struct AutomationRun {
     pub scheduled_for: DateTime<Utc>,
     pub lease_until: Option<DateTime<Utc>>,
     pub previous_run_id: Option<Uuid>,
+    /// Triggering event payload(s) as render input context, if event-triggered.
+    pub input: Option<serde_json::Value>,
+    /// The event that triggered this run, if any.
+    pub event_id: Option<Uuid>,
+    /// Causal chain depth (0 for roots; parent+1 for run.succeeded-triggered).
+    pub chain_depth: i64,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -344,6 +504,12 @@ impl AutomationRun {
             )?,
             lease_until,
             previous_run_id: opt_uuid("previous_run_id")?,
+            input: row
+                .get::<Option<String>, _>("input")
+                .map(|s| serde_json::from_str(&s))
+                .transpose()?,
+            event_id: opt_uuid("event_id")?,
+            chain_depth: row.get("chain_depth"),
             created_at: parse_ts(
                 &row.get::<String, _>("created_at"),
                 "automation_runs.created_at",
@@ -389,7 +555,7 @@ const AUTOMATION_COLS: &str =
 const TRIGGER_COLS: &str =
     "id, automation_id, kind, spec_json, enabled, next_fire_at, webhook_token_hash, created_at, updated_at";
 const RUN_COLS: &str =
-    "id, automation_id, trigger_id, session_id, workspace_id, prompt, agent_type, model, status, scheduled_for, lease_until, previous_run_id, created_at, updated_at";
+    "id, automation_id, trigger_id, session_id, workspace_id, prompt, agent_type, model, status, scheduled_for, lease_until, previous_run_id, input, event_id, chain_depth, created_at, updated_at";
 
 /// Everything needed to enqueue a run + its session. `automation_id = None` for
 /// ad-hoc one-time runs that depend on no automation.
@@ -402,6 +568,9 @@ struct NewRun {
     agent_type: String,
     model: Option<String>,
     previous_run_id: Option<Uuid>,
+    input: Option<serde_json::Value>,
+    event_id: Option<Uuid>,
+    chain_depth: i64,
 }
 
 impl NewRun {
@@ -420,11 +589,15 @@ impl NewRun {
             agent_type: a.agent_type.clone(),
             model: a.model.clone(),
             previous_run_id,
+            input: None,
+            event_id: None,
+            chain_depth: 0,
         }
     }
 
     /// Re-run the same snapshot as a prior run (for retries). Preserves the
-    /// executed prompt rather than re-reading a possibly-changed template.
+    /// executed prompt + input + event rather than re-reading a
+    /// possibly-changed template.
     fn retry_of(prev: &AutomationRun) -> Self {
         Self {
             automation_id: prev.automation_id,
@@ -435,6 +608,10 @@ impl NewRun {
             agent_type: prev.agent_type.clone(),
             model: prev.model.clone(),
             previous_run_id: Some(prev.id),
+            input: prev.input.clone(),
+            event_id: prev.event_id,
+            // Retries re-run the same node; they don't deepen the causal chain.
+            chain_depth: prev.chain_depth,
         }
     }
 }
@@ -676,8 +853,6 @@ impl AutomationsState {
         Ok(res.rows_affected() == 1)
     }
 
-    /// The enabled webhook trigger of `automation_id` whose secret matches
-    /// `token`, or `None`. Used by the public webhook receive endpoint.
     /// The webhook trigger whose token hashes to `token_hash`, or `None`. The
     /// hash is globally unique, so the token alone identifies its trigger.
     pub async fn find_trigger_by_webhook_token_hash(
@@ -708,20 +883,6 @@ impl AutomationsState {
         (token, hash)
     }
 
-    /// Create a queued run fired directly by a webhook (automation-direct). The
-    /// automation's stored prompt runs as-is — the POST body is not yet used as
-    /// render input (that arrives with the event infrastructure). `None` if the
-    /// automation is disabled.
-    pub async fn create_webhook_run(
-        &self,
-        automation: &Automation,
-        trigger_id: Uuid,
-    ) -> StateResult<Option<AutomationRun>> {
-        let spec = NewRun::from_automation(automation, Some(trigger_id), None);
-        let payload = serde_json::json!({ "source": "webhook" });
-        self.insert_run_with_session(spec, Utc::now(), Some(&payload)).await
-    }
-
     /// Cron triggers whose `next_fire_at` has elapsed (enabled only).
     pub async fn list_due_cron_triggers(
         &self,
@@ -737,6 +898,79 @@ impl AutomationsState {
             .fetch_all(&self.db)
             .await?;
         rows.iter().map(AutomationTrigger::from_row).collect()
+    }
+
+    /// All enabled `event` triggers (the dispatcher matches events against these).
+    pub async fn list_event_triggers(&self) -> StateResult<Vec<AutomationTrigger>> {
+        let sql = format!(
+            "SELECT {TRIGGER_COLS} FROM automation_triggers WHERE kind = 'event' AND enabled = 1"
+        );
+        let rows = sqlx::query(&sql).fetch_all(&self.db).await?;
+        rows.iter().map(AutomationTrigger::from_row).collect()
+    }
+
+    /// True if a run already exists for this (trigger, event) — the dispatcher's
+    /// idempotency check against re-processing an event after a crash.
+    pub async fn run_exists_for_event(
+        &self,
+        trigger_id: Uuid,
+        event_id: Uuid,
+    ) -> StateResult<bool> {
+        let row = sqlx::query(
+            "SELECT 1 FROM automation_runs WHERE trigger_id = ? AND event_id = ? LIMIT 1",
+        )
+        .bind(trigger_id.to_string())
+        .bind(event_id.to_string())
+        .fetch_optional(&self.db)
+        .await?;
+        Ok(row.is_some())
+    }
+
+    /// Causal chain depth of a run, or `None` if the run is gone. Used by the
+    /// dispatcher to compute a `run.succeeded`-triggered run's depth (parent+1).
+    pub async fn run_chain_depth(&self, run_id: Uuid) -> StateResult<Option<i64>> {
+        let row = sqlx::query("SELECT chain_depth FROM automation_runs WHERE id = ?")
+            .bind(run_id.to_string())
+            .fetch_optional(&self.db)
+            .await?;
+        Ok(row.map(|r| r.get::<i64, _>("chain_depth")))
+    }
+
+    /// Create a queued run from an event trigger: snapshots the automation's
+    /// prompt/agent surface, carries the event `input` + `event_id`.
+    /// `None` if the automation is disabled.
+    pub async fn create_event_run(
+        &self,
+        automation: &Automation,
+        trigger_id: Uuid,
+        event_id: Uuid,
+        input: serde_json::Value,
+        chain_depth: i64,
+    ) -> StateResult<Option<AutomationRun>> {
+        let mut spec = NewRun::from_automation(automation, Some(trigger_id), None);
+        spec.input = Some(input);
+        spec.event_id = Some(event_id);
+        spec.chain_depth = chain_depth;
+        let payload = serde_json::json!({
+            "source": "event",
+            "event_id": event_id.to_string(),
+        });
+        self.insert_run_with_session(spec, Utc::now(), Some(&payload)).await
+    }
+
+    /// Create a queued run fired directly by a webhook (automation-direct: no
+    /// outbox event). The POST body becomes the run's render `input`; chain depth
+    /// is 0 (external root). `None` if the automation is disabled.
+    pub async fn create_webhook_run(
+        &self,
+        automation: &Automation,
+        trigger_id: Uuid,
+        input: serde_json::Value,
+    ) -> StateResult<Option<AutomationRun>> {
+        let mut spec = NewRun::from_automation(automation, Some(trigger_id), None);
+        spec.input = Some(input);
+        let payload = serde_json::json!({ "source": "webhook" });
+        self.insert_run_with_session(spec, Utc::now(), Some(&payload)).await
     }
 
     // ── runs ────────────────────────────────────────────────────────────
@@ -774,13 +1008,16 @@ impl AutomationsState {
         .execute(&mut *tx)
         .await?;
 
+        let input_str = spec.input.as_ref().map(serde_json::to_string).transpose()?;
+        let event_id_s = spec.event_id.map(|c| c.to_string());
+
         // Run row. Automation-linked runs are gated on the automation still being
         // enabled (atomic against a concurrent disable); ad-hoc runs insert plainly.
         let run_cols = "INSERT INTO automation_runs \
-             (id, automation_id, trigger_id, session_id, workspace_id, prompt, agent_type, model, status, scheduled_for, lease_until, previous_run_id, created_at, updated_at)";
+             (id, automation_id, trigger_id, session_id, workspace_id, prompt, agent_type, model, status, scheduled_for, lease_until, previous_run_id, input, event_id, chain_depth, created_at, updated_at)";
         let res = if let Some(aid) = spec.automation_id {
             sqlx::query(&format!(
-                "{run_cols} SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, NULL, ?, ?, ? \
+                "{run_cols} SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, NULL, ?, ?, ?, ?, ?, ? \
                   WHERE EXISTS (SELECT 1 FROM automations WHERE id = ? AND enabled = 1)"
             ))
             .bind(run_id.to_string())
@@ -793,6 +1030,9 @@ impl AutomationsState {
             .bind(&spec.model)
             .bind(&scheduled_s)
             .bind(spec.previous_run_id.map(|u| u.to_string()))
+            .bind(&input_str)
+            .bind(&event_id_s)
+            .bind(spec.chain_depth)
             .bind(&now)
             .bind(&now)
             .bind(aid.to_string())
@@ -800,7 +1040,7 @@ impl AutomationsState {
             .await?
         } else {
             sqlx::query(&format!(
-                "{run_cols} VALUES (?, NULL, ?, ?, ?, ?, ?, ?, 'queued', ?, NULL, ?, ?, ?)"
+                "{run_cols} VALUES (?, NULL, ?, ?, ?, ?, ?, ?, 'queued', ?, NULL, ?, ?, ?, ?, ?, ?)"
             ))
             .bind(run_id.to_string())
             .bind(spec.trigger_id.map(|u| u.to_string()))
@@ -811,6 +1051,9 @@ impl AutomationsState {
             .bind(&spec.model)
             .bind(&scheduled_s)
             .bind(spec.previous_run_id.map(|u| u.to_string()))
+            .bind(&input_str)
+            .bind(&event_id_s)
+            .bind(spec.chain_depth)
             .bind(&now)
             .bind(&now)
             .execute(&mut *tx)
@@ -839,6 +1082,9 @@ impl AutomationsState {
             scheduled_for,
             lease_until: None,
             previous_run_id: spec.previous_run_id,
+            input: spec.input,
+            event_id: spec.event_id,
+            chain_depth: spec.chain_depth,
             created_at: parse_ts(&now, "automation_runs.created_at")?,
             updated_at: parse_ts(&now, "automation_runs.updated_at")?,
         }))
@@ -886,6 +1132,9 @@ impl AutomationsState {
             agent_type,
             model,
             previous_run_id: None,
+            input: None,
+            event_id: None,
+            chain_depth: 0,
         };
         self.insert_run_with_session(spec, at, Some(&payload))
             .await?
@@ -1241,6 +1490,53 @@ mod tests {
     use super::*;
     use sqlx::SqlitePool;
 
+    #[test]
+    fn render_fills_and_fails_closed() {
+        let input = serde_json::json!({ "path": "knowledge/report.md" });
+        assert_eq!(
+            render("indexed {{event.path}}", Some(&input)).unwrap(),
+            "indexed knowledge/report.md"
+        );
+        assert!(render("{{today}}", None).is_ok());
+        assert!(render("{{event.missing}}", Some(&input)).is_err());
+        assert!(render("{{bogus}}", None).is_err());
+    }
+
+    #[test]
+    fn condition_matching_with_equality() {
+        let c = Condition {
+            source: "run.succeeded".into(),
+            filter: Some(serde_json::json!({ "automation_id": "A" })),
+        };
+        assert!(c.matches("run.succeeded", Some(&serde_json::json!({ "automation_id": "A" }))));
+        assert!(!c.matches("run.succeeded", Some(&serde_json::json!({ "automation_id": "B" }))));
+        assert!(!c.matches("run.failed", Some(&serde_json::json!({ "automation_id": "A" }))));
+        let c2 = Condition { source: "file.added".into(), filter: None };
+        assert!(c2.matches("file.added", None));
+    }
+
+    #[test]
+    fn filter_operators() {
+        // "after 2026-07-01 AND a new PDF" — predicates on one event.
+        let filter = serde_json::json!({
+            "path": { "glob": "*.pdf" },
+            "created_at": { "gte": "2026-07-01" },
+        });
+        let f = Some(&filter);
+        assert!(event_filter_matches(
+            f,
+            Some(&serde_json::json!({ "path": "report.pdf", "created_at": "2026-08-10" }))
+        ));
+        assert!(!event_filter_matches(
+            f,
+            Some(&serde_json::json!({ "path": "notes.md", "created_at": "2026-08-10" }))
+        )); // wrong extension
+        assert!(!event_filter_matches(
+            f,
+            Some(&serde_json::json!({ "path": "old.pdf", "created_at": "2026-06-01" }))
+        )); // before date
+    }
+
     async fn fresh_db() -> SqlitePool {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
@@ -1318,18 +1614,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn event_run_carries_and_reads_chain_depth() {
+        let pool = fresh_db().await;
+        let (uid, wid) = seed(&pool).await;
+        let state = AutomationsState::new(pool.clone());
+
+        let a = state
+            .create_automation(wid, "chained".into(), None, "go".into(), "coworker".into(), None, uid)
+            .await
+            .unwrap();
+        let spec = TriggerSpec::Event {
+            conditions: vec![Condition { source: "run.succeeded".into(), filter: None }],
+        };
+        let t = state.create_trigger(a.id, &spec, true, None, None).await.unwrap();
+
+        // Event row is the FK target for the run's event_id.
+        let ev = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO events (id, type, workspace_id, payload, created_at) \
+             VALUES (?, 'run.succeeded', ?, NULL, ?)",
+        )
+        .bind(ev.to_string())
+        .bind(wid.to_string())
+        .bind(Utc::now().to_rfc3339())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let run = state
+            .create_event_run(&a, t.id, ev, serde_json::json!({ "x": 1 }), 3)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.chain_depth, 3);
+        // Reads back through the dispatcher's lookup and through from_row.
+        assert_eq!(state.run_chain_depth(run.id).await.unwrap(), Some(3));
+        assert_eq!(state.get_run(run.id).await.unwrap().unwrap().chain_depth, 3);
+        assert_eq!(state.run_chain_depth(Uuid::new_v4()).await.unwrap(), None);
+    }
+
+    #[tokio::test]
     async fn webhook_trigger_lookup_and_run() {
         let pool = fresh_db().await;
         let (uid, wid) = seed(&pool).await;
         let state = AutomationsState::new(pool);
 
         let a = state
-            .create_automation(wid, "hooked".into(), None, "go".into(), "coworker".into(), None, uid)
+            .create_automation(wid, "hooked".into(), None, "run {{event.x}}".into(), "coworker".into(), None, uid)
             .await
             .unwrap();
         let (token, hash) = AutomationsState::new_webhook_token();
         let t = state
-            .create_trigger(a.id, &TriggerSpec::Webhook {}, true, None, Some(hash))
+            .create_trigger(a.id, &TriggerSpec::Webhook { filter: None }, true, None, Some(hash))
             .await
             .unwrap();
         assert_eq!(t.kind, TriggerKind::Webhook);
@@ -1351,17 +1687,34 @@ mod tests {
                 .is_none()
         );
 
-        // Fire it: a run is created for the automation.
-        let run = state.create_webhook_run(&a, t.id).await.unwrap().unwrap();
+        // Fire it: run carries the body as input, is chain root, no event.
+        let run = state
+            .create_webhook_run(&a, t.id, serde_json::json!({ "x": 1 }))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.input.as_ref().unwrap()["x"], 1);
+        assert_eq!(run.chain_depth, 0);
+        assert!(run.event_id.is_none());
         assert_eq!(run.trigger_id, Some(t.id));
-        assert_eq!(run.automation_id, Some(a.id));
+
+        // Webhook filter roundtrips through spec_json and gates on the body.
+        let wf = TriggerSpec::Webhook {
+            filter: Some(serde_json::json!({ "action": { "eq": "opened" } })),
+        };
+        let back = TriggerSpec::from_db(TriggerKind::Webhook, &wf.to_db_spec_json().unwrap()).unwrap();
+        let TriggerSpec::Webhook { filter: Some(f), .. } = back else {
+            panic!("expected webhook filter");
+        };
+        assert!(event_filter_matches(Some(&f), Some(&serde_json::json!({ "action": "opened" }))));
+        assert!(!event_filter_matches(Some(&f), Some(&serde_json::json!({ "action": "closed" }))));
 
         // Disabled automation gates run creation.
         state
             .update_automation(a.id, None, None, None, None, None, Some(false))
             .await
             .unwrap();
-        assert!(state.create_webhook_run(&a, t.id).await.unwrap().is_none());
+        assert!(state.create_webhook_run(&a, t.id, serde_json::json!({})).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/backend/src/state/events.rs
+++ b/backend/src/state/events.rs
@@ -1,0 +1,151 @@
+//! Durable event outbox. Producers append domain events; the automation
+//! dispatcher (worker.rs) consumes undispatched rows, matches them to event
+//! triggers, and fires runs. Separate from the ephemeral in-process
+//! [`EventQueue`](crate::event::EventQueue), which only powers live WS streaming.
+
+use chrono::{DateTime, Utc};
+use sqlx::{Row as _, Sqlite, SqlitePool, Transaction, sqlite::SqliteRow};
+use uuid::Uuid;
+
+use super::{StateResult, parse_ts, parse_uuid};
+
+// `workspace_id`/`created_at`/`dispatched_at` are stored audit fields not all
+// consumed by the dispatcher yet (workspace scoping arrives with more sources).
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub id: Uuid,
+    /// Dotted domain type, e.g. `run.succeeded`, `file.added`, `knowledge.indexed`.
+    pub kind: String,
+    pub workspace_id: Option<Uuid>,
+    pub payload: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub dispatched_at: Option<DateTime<Utc>>,
+}
+
+impl Event {
+    fn from_row(row: &SqliteRow) -> StateResult<Self> {
+        let payload = row
+            .get::<Option<String>, _>("payload")
+            .map(|s| serde_json::from_str(&s))
+            .transpose()?;
+        let workspace_id = row
+            .get::<Option<String>, _>("workspace_id")
+            .map(|s| parse_uuid(s, "events.workspace_id"))
+            .transpose()?;
+        let dispatched_at = row
+            .get::<Option<String>, _>("dispatched_at")
+            .map(|s| parse_ts(&s, "events.dispatched_at"))
+            .transpose()?;
+        Ok(Self {
+            id: parse_uuid(row.get::<String, _>("id"), "events.id")?,
+            kind: row.get("type"),
+            workspace_id,
+            payload,
+            created_at: parse_ts(&row.get::<String, _>("created_at"), "events.created_at")?,
+            dispatched_at,
+        })
+    }
+}
+
+const EVENT_COLS: &str = "id, type, workspace_id, payload, created_at, dispatched_at";
+
+/// A domain event to append.
+pub struct NewEvent {
+    pub kind: String,
+    pub workspace_id: Option<Uuid>,
+    pub payload: Option<serde_json::Value>,
+}
+
+#[derive(Clone)]
+pub struct EventsState {
+    db: SqlitePool,
+}
+
+impl EventsState {
+    pub fn new(db: SqlitePool) -> Self {
+        Self { db }
+    }
+
+    /// Append an event. Best-effort producers use this; producers that mutate
+    /// the DB in the same logical step should prefer [`Self::emit_tx`].
+    pub async fn emit(&self, new: NewEvent) -> StateResult<Event> {
+        let mut tx = self.db.begin().await?;
+        let ev = Self::emit_tx(&mut tx, new).await?;
+        tx.commit().await?;
+        Ok(ev)
+    }
+
+    /// Append an event inside an existing transaction (transactional outbox):
+    /// the event is durable iff the surrounding domain change commits.
+    pub async fn emit_tx(tx: &mut Transaction<'_, Sqlite>, new: NewEvent) -> StateResult<Event> {
+        let id = Uuid::new_v4();
+        let now = Utc::now().to_rfc3339();
+        let payload_str = new.payload.as_ref().map(serde_json::to_string).transpose()?;
+        sqlx::query(
+            "INSERT INTO events (id, type, workspace_id, payload, created_at, dispatched_at) \
+             VALUES (?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(id.to_string())
+        .bind(&new.kind)
+        .bind(new.workspace_id.map(|w| w.to_string()))
+        .bind(&payload_str)
+        .bind(&now)
+        .execute(&mut **tx)
+        .await?;
+        Ok(Event {
+            id,
+            kind: new.kind,
+            workspace_id: new.workspace_id,
+            payload: new.payload,
+            created_at: parse_ts(&now, "events.created_at")?,
+            dispatched_at: None,
+        })
+    }
+
+    /// Oldest undispatched events, up to `limit`.
+    pub async fn list_undispatched(&self, limit: i64) -> StateResult<Vec<Event>> {
+        let sql = format!(
+            "SELECT {EVENT_COLS} FROM events WHERE dispatched_at IS NULL ORDER BY created_at ASC LIMIT ?"
+        );
+        let rows = sqlx::query(&sql).bind(limit).fetch_all(&self.db).await?;
+        rows.iter().map(Event::from_row).collect()
+    }
+
+    /// Mark an event dispatched (idempotent — only flips a still-NULL row).
+    pub async fn mark_dispatched(&self, id: Uuid) -> StateResult<()> {
+        sqlx::query("UPDATE events SET dispatched_at = ? WHERE id = ? AND dispatched_at IS NULL")
+            .bind(Utc::now().to_rfc3339())
+            .bind(id.to_string())
+            .execute(&self.db)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn db() -> SqlitePool {
+        let p = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&p).await.unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn outbox_round_trip() {
+        let store = EventsState::new(db().await);
+        let ev = store
+            .emit(NewEvent {
+                kind: "run.succeeded".into(),
+                workspace_id: None,
+                payload: Some(serde_json::json!({ "x": 1 })),
+            })
+            .await
+            .unwrap();
+        assert_eq!(store.list_undispatched(10).await.unwrap().len(), 1);
+        store.mark_dispatched(ev.id).await.unwrap();
+        assert!(store.list_undispatched(10).await.unwrap().is_empty());
+    }
+}

--- a/backend/src/state/mod.rs
+++ b/backend/src/state/mod.rs
@@ -9,6 +9,7 @@ use crate::{auth::JwtConfig, event::EventQueue};
 
 mod agent;
 mod automation;
+mod events;
 mod knowledge;
 mod session;
 mod user;
@@ -16,6 +17,7 @@ mod workspace;
 
 pub use agent::*;
 pub use automation::*;
+pub use events::*;
 pub use knowledge::*;
 pub use session::*;
 pub use user::*;
@@ -69,6 +71,7 @@ pub struct AppState {
     pub sessions: SessionsState,
     pub users: UsersState,
     pub automations: AutomationsState,
+    pub event_store: EventsState,
     pub events: EventQueue,
     pub jwt: JwtConfig,
 }
@@ -98,6 +101,7 @@ impl AppState {
             agents: AgentsState::new(db.clone()),
             sessions: SessionsState::new(db.clone(), data_root, events.clone()),
             automations: AutomationsState::new(db.clone()),
+            event_store: EventsState::new(db.clone()),
             users: UsersState::new(db),
             events,
             jwt,

--- a/backend/src/state/mod.rs
+++ b/backend/src/state/mod.rs
@@ -12,6 +12,7 @@ mod automation;
 mod events;
 mod knowledge;
 mod session;
+mod source_poll;
 mod user;
 mod workspace;
 
@@ -20,6 +21,7 @@ pub use automation::*;
 pub use events::*;
 pub use knowledge::*;
 pub use session::*;
+pub use source_poll::*;
 pub use user::*;
 pub use workspace::*;
 
@@ -72,6 +74,7 @@ pub struct AppState {
     pub users: UsersState,
     pub automations: AutomationsState,
     pub event_store: EventsState,
+    pub source_poll: SourcePollState,
     pub events: EventQueue,
     pub jwt: JwtConfig,
 }
@@ -102,6 +105,7 @@ impl AppState {
             sessions: SessionsState::new(db.clone(), data_root, events.clone()),
             automations: AutomationsState::new(db.clone()),
             event_store: EventsState::new(db.clone()),
+            source_poll: SourcePollState::new(db.clone()),
             users: UsersState::new(db),
             events,
             jwt,

--- a/backend/src/state/mod.rs
+++ b/backend/src/state/mod.rs
@@ -8,12 +8,14 @@ use uuid::Uuid;
 use crate::{auth::JwtConfig, event::EventQueue};
 
 mod agent;
+mod automation;
 mod knowledge;
 mod session;
 mod user;
 mod workspace;
 
 pub use agent::*;
+pub use automation::*;
 pub use knowledge::*;
 pub use session::*;
 pub use user::*;
@@ -66,6 +68,7 @@ pub struct AppState {
     pub agents: AgentsState,
     pub sessions: SessionsState,
     pub users: UsersState,
+    pub automations: AutomationsState,
     pub events: EventQueue,
     pub jwt: JwtConfig,
 }
@@ -94,6 +97,7 @@ impl AppState {
             workspaces: WorkspacesState::new(db.clone(), data_root.clone()),
             agents: AgentsState::new(db.clone()),
             sessions: SessionsState::new(db.clone(), data_root, events.clone()),
+            automations: AutomationsState::new(db.clone()),
             users: UsersState::new(db),
             events,
             jwt,

--- a/backend/src/state/session.rs
+++ b/backend/src/state/session.rs
@@ -839,12 +839,14 @@ impl SessionsState {
     /// (fire-and-forget, gated by the runs map) this awaits and returns the
     /// result, so a caller like the automation worker can finalize the run.
     /// Errors (including cancellation) surface as [`StateError`].
+    /// Drives one turn and returns the final agent message text (the run's
+    /// "output", used for event chaining), or `None` if there was none.
     pub async fn drive_prompt(
         &self,
         id: Uuid,
         query: Vec<Part>,
         cancel: CancellationToken,
-    ) -> StateResult<()> {
+    ) -> StateResult<Option<String>> {
         let session_key = id.to_string();
         let channel = message_channel(id);
 
@@ -896,6 +898,7 @@ impl SessionsState {
             .await?;
         next_seq += 1;
 
+        let mut last_text: Option<String> = None;
         let drive: StateResult<()> = async {
             let mut stream = agent.run(user_msg);
             loop {
@@ -908,6 +911,9 @@ impl SessionsState {
                         let Some(output) = next else { break };
                         let output = output
                             .map_err(|e| StateError::InvalidData(format!("agent run: {e:#}")))?;
+                        if let Some(t) = message_text(&output.message) {
+                            last_text = Some(t);
+                        }
                         self.persist_message(&session_key, next_seq, &output.message, &channel)
                             .await?;
                         next_seq += 1;
@@ -934,7 +940,7 @@ impl SessionsState {
             }
         }
 
-        drive
+        drive.map(|()| last_text)
     }
 }
 
@@ -969,6 +975,19 @@ async fn persist_message(
         })?,
     );
     Ok(())
+}
+
+/// Best-effort extraction of an agent message's text (joins its text parts).
+/// Serde-based so it doesn't depend on ailoy's `Part` internals.
+fn message_text(m: &Message) -> Option<String> {
+    let v = serde_json::to_value(m).ok()?;
+    let parts = v.get("contents").or_else(|| v.get("content"))?.as_array()?;
+    let text = parts
+        .iter()
+        .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
 }
 
 #[cfg(test)]

--- a/backend/src/state/session.rs
+++ b/backend/src/state/session.rs
@@ -799,6 +799,143 @@ impl SessionsState {
 
         Ok(())
     }
+
+    /// Persist one message at `seq` and publish it on the session channel.
+    async fn persist_message(
+        &self,
+        session_key: &str,
+        seq: i64,
+        message: &Message,
+        channel: &str,
+    ) -> StateResult<()> {
+        let stored = SessionMessage {
+            depth: 0,
+            source_agent: None,
+            message: message.clone(),
+        };
+        sqlx::query(
+            "INSERT INTO messages (session_id, seq, content, created_at) VALUES (?, ?, ?, ?)",
+        )
+        .bind(session_key)
+        .bind(seq)
+        .bind(serde_json::to_string(&stored)?)
+        .bind(Utc::now().to_rfc3339())
+        .execute(&self.db)
+        .await?;
+        self.events.publish(
+            channel,
+            serde_json::to_string(&SessionEvent::Message {
+                seq,
+                depth: 0,
+                source_agent: None,
+                message: message.clone(),
+            })?,
+        );
+        Ok(())
+    }
+
+    /// Drive a single user turn for `id` **to completion**, persisting the user
+    /// message and each agent output, honoring `cancel`. Unlike [`Self::run`]
+    /// (fire-and-forget, gated by the runs map) this awaits and returns the
+    /// result, so a caller like the automation worker can finalize the run.
+    /// Errors (including cancellation) surface as [`StateError`].
+    pub async fn drive_prompt(
+        &self,
+        id: Uuid,
+        query: Vec<Part>,
+        cancel: CancellationToken,
+    ) -> StateResult<()> {
+        let session_key = id.to_string();
+        let channel = message_channel(id);
+
+        let row = sqlx::query("SELECT spec, runenv FROM sessions WHERE id = ?")
+            .bind(&session_key)
+            .fetch_optional(&self.db)
+            .await?
+            .ok_or(StateError::NotFound)?;
+        let spec: AgentSpec = serde_json::from_str(&row.get::<String, _>("spec"))?;
+        let has_runenv: bool = row.get("runenv");
+
+        let dir = self.data_root.join("sessions").join(&session_key);
+        let archive_path = dir.join("sandbox.tar.zst");
+        let runenv = if has_runenv {
+            if !tokio::fs::try_exists(&archive_path).await? {
+                return Err(StateError::Sandbox(format!(
+                    "session {id} marked as having a runenv but archive is missing"
+                )));
+            }
+            Some(Arc::new(Mutex::new(
+                Sandbox::try_from_archive(&archive_path)
+                    .await
+                    .map_err(|e| StateError::Sandbox(format!("{e:#}")))?,
+            )))
+        } else {
+            None
+        };
+
+        let rows =
+            sqlx::query("SELECT content FROM messages WHERE session_id = ? ORDER BY seq ASC")
+                .bind(&session_key)
+                .fetch_all(&self.db)
+                .await?;
+        let history: Vec<Message> = rows
+            .iter()
+            .map(|r| serde_json::from_str::<Message>(&r.get::<String, _>("content")))
+            .collect::<Result<_, _>>()?;
+
+        let mut next_seq = history.len() as i64;
+        let mut agent_state = AgentState::new().with_history(history);
+        if let Some(ref r) = runenv {
+            agent_state = agent_state.with_runenv(r.clone());
+        }
+        let mut agent = Agent::try_with_state(spec, agent_state)
+            .map_err(|e| StateError::InvalidData(format!("agent init: {e:#}")))?;
+
+        let user_msg = Message::new(Role::User).with_contents(query);
+        self.persist_message(&session_key, next_seq, &user_msg, &channel)
+            .await?;
+        next_seq += 1;
+
+        let drive: StateResult<()> = async {
+            let mut stream = agent.run(user_msg);
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        return Err(StateError::InvalidData("cancelled".into()));
+                    }
+                    next = stream.next() => {
+                        let Some(output) = next else { break };
+                        let output = output
+                            .map_err(|e| StateError::InvalidData(format!("agent run: {e:#}")))?;
+                        self.persist_message(&session_key, next_seq, &output.message, &channel)
+                            .await?;
+                        next_seq += 1;
+                    }
+                }
+            }
+            Ok(())
+        }
+        .await;
+
+        if let Some(runenv) = runenv {
+            let mut sandbox = runenv.lock().await;
+            let archive: anyhow::Result<()> = async {
+                sandbox.stop().await?;
+                if tokio::fs::try_exists(&archive_path).await? {
+                    tokio::fs::remove_file(&archive_path).await?;
+                }
+                sandbox.archive(&archive_path).await?;
+                Ok(())
+            }
+            .await;
+            if let Err(e) = archive {
+                tracing::error!(session = %id, "sandbox archive failed: {e:#}");
+            }
+        }
+
+        drive
+    }
 }
 
 /// `INSERT` one message row for `session_key` at `seq` (stored in the wrapped

--- a/backend/src/state/source_poll.rs
+++ b/backend/src/state/source_poll.rs
@@ -1,0 +1,118 @@
+//! Per-mount snapshot store for external-source polling. The poller (worker.rs)
+//! scans a subscribed provider mount, diffs the fresh listing against the stored
+//! snapshot to synthesize `s3.*`/`notion.*` events, then overwrites the snapshot.
+
+use std::collections::HashMap;
+
+use sqlx::{Row as _, SqlitePool};
+use uuid::Uuid;
+
+use super::StateResult;
+
+/// A path → change-signature map for one mount (signature is `modified:size`).
+pub type Snapshot = HashMap<String, String>;
+
+#[derive(Clone)]
+pub struct SourcePollState {
+    db: SqlitePool,
+}
+
+impl SourcePollState {
+    pub fn new(db: SqlitePool) -> Self {
+        Self { db }
+    }
+
+    /// The last stored snapshot for `(workspace, prefix)`, or `None` if the mount
+    /// has never been polled (the first poll seeds a baseline without emitting).
+    pub async fn get(&self, workspace_id: Uuid, prefix: &str) -> StateResult<Option<Snapshot>> {
+        let row = sqlx::query(
+            "SELECT snapshot FROM source_poll_state WHERE workspace_id = ? AND prefix = ?",
+        )
+        .bind(workspace_id.to_string())
+        .bind(prefix)
+        .fetch_optional(&self.db)
+        .await?;
+        match row {
+            Some(r) => Ok(Some(serde_json::from_str(&r.get::<String, _>("snapshot"))?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Overwrite the snapshot for `(workspace, prefix)`.
+    pub async fn put(&self, workspace_id: Uuid, prefix: &str, snap: &Snapshot) -> StateResult<()> {
+        let snapshot = serde_json::to_string(snap)?;
+        sqlx::query(
+            "INSERT INTO source_poll_state (workspace_id, prefix, snapshot, updated_at) \
+             VALUES (?, ?, ?, ?) \
+             ON CONFLICT(workspace_id, prefix) DO UPDATE SET \
+                 snapshot = excluded.snapshot, updated_at = excluded.updated_at",
+        )
+        .bind(workspace_id.to_string())
+        .bind(prefix)
+        .bind(&snapshot)
+        .bind(chrono::Utc::now().to_rfc3339())
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+}
+
+/// One change discovered by diffing a fresh scan against the prior snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Change {
+    Created(String),
+    Modified(String),
+    Removed(String),
+}
+
+/// Diff `prev` → `next` into created/modified/removed changes (path-keyed).
+pub fn diff_snapshots(prev: &Snapshot, next: &Snapshot) -> Vec<Change> {
+    let mut out = Vec::new();
+    for (path, sig) in next {
+        match prev.get(path) {
+            None => out.push(Change::Created(path.clone())),
+            Some(old) if old != sig => out.push(Change::Modified(path.clone())),
+            Some(_) => {}
+        }
+    }
+    for path in prev.keys() {
+        if !next.contains_key(path) {
+            out.push(Change::Removed(path.clone()));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(pairs: &[(&str, &str)]) -> Snapshot {
+        pairs.iter().map(|(p, s)| (p.to_string(), s.to_string())).collect()
+    }
+
+    #[test]
+    fn diff_detects_add_change_remove() {
+        let prev = snap(&[("/m/a", "1"), ("/m/b", "1")]);
+        let next = snap(&[("/m/a", "1"), ("/m/b", "2"), ("/m/c", "1")]);
+        let mut got = diff_snapshots(&prev, &next);
+        got.sort_by_key(|c| match c {
+            Change::Created(p) | Change::Modified(p) | Change::Removed(p) => p.clone(),
+        });
+        assert_eq!(
+            got,
+            vec![
+                Change::Modified("/m/b".into()),
+                Change::Created("/m/c".into()),
+            ]
+        );
+        // /m/a unchanged → no event; nothing removed.
+    }
+
+    #[test]
+    fn diff_detects_removal() {
+        let prev = snap(&[("/m/a", "1")]);
+        let next = snap(&[]);
+        assert_eq!(diff_snapshots(&prev, &next), vec![Change::Removed("/m/a".into())]);
+    }
+}

--- a/backend/src/state/workspace/mod.rs
+++ b/backend/src/state/workspace/mod.rs
@@ -263,6 +263,13 @@ impl WorkspacesState {
         )))
     }
 
+    /// A hookless [`WorkspaceFs`] for read-only scanning (the source poller walks
+    /// provider-mount subtrees). Reuses the cached mount assembly and attaches no
+    /// hook, so a scan triggers no resync or event side effects.
+    pub async fn scan_fs(&self, wid: Uuid) -> StateResult<WorkspaceFs> {
+        self.fs_for(wid).await
+    }
+
     /// Absolute on-disk path of workspace `wid`'s file root
     /// (`data_root/workspaces/{wid}/files`).
     fn get_root(&self, wid: Uuid) -> PathBuf {

--- a/backend/src/state/workspace/mod.rs
+++ b/backend/src/state/workspace/mod.rs
@@ -8,7 +8,7 @@ use sqlx::{Row as _, SqlitePool, sqlite::SqliteRow};
 use uuid::Uuid;
 
 use super::knowledge::Resyncer;
-use super::{StateError, StateResult, User, parse_ts, parse_uuid};
+use super::{EventsState, NewEvent, StateError, StateResult, User, parse_ts, parse_uuid};
 
 mod mount;
 
@@ -210,7 +210,26 @@ impl WorkspacesState {
     pub async fn create_default(&self, user: &User) -> StateResult<Workspace> {
         let ws = Workspace::with_id(user.id, user.id, format!("{}'s workspace", user.username));
         self.upsert(ws.clone()).await?;
+        self.emit_workspace_created(&ws).await;
         Ok(ws)
+    }
+
+    /// Best-effort `workspace.created` domain event (doesn't fail creation).
+    async fn emit_workspace_created(&self, ws: &Workspace) {
+        let events = EventsState::new(self.db.clone());
+        if let Err(e) = events
+            .emit(NewEvent {
+                kind: "workspace.created".into(),
+                workspace_id: Some(ws.id),
+                payload: Some(serde_json::json!({
+                    "workspace_id": ws.id.to_string(),
+                    "title": ws.title,
+                })),
+            })
+            .await
+        {
+            tracing::error!("emit workspace.created failed: {e}");
+        }
     }
 
     /// Ensure the user's default workspace exists both as a row and on disk.
@@ -237,7 +256,11 @@ impl WorkspacesState {
     pub async fn get_fs(&self, wid: Uuid) -> StateResult<WorkspaceFs> {
         // Cached assembly (local `/files` + providers); the hook is per-call.
         let fs = self.fs_for(wid).await?;
-        Ok(fs.with_hook(knowledge_hook(wid, Some(self.resyncer.clone()))))
+        Ok(fs.with_hook(knowledge_hook(
+            wid,
+            Some(self.resyncer.clone()),
+            Some(EventsState::new(self.db.clone())),
+        )))
     }
 
     /// Absolute on-disk path of workspace `wid`'s file root
@@ -253,9 +276,15 @@ impl WorkspacesState {
     }
 }
 
-/// The change hook attached to every [`WorkspaceFs`] this backend builds: it
-/// runs the `knowledge/` side-processing (today just logging; ingestion/indexing
-/// lands later) and ignores everything else.
+/// Event type for a `knowledge/` file appearing or being updated.
+const KNOWLEDGE_INDEXED: &str = "knowledge.indexed";
+/// Event type for a `knowledge/` file leaving.
+const KNOWLEDGE_REMOVED: &str = "knowledge.removed";
+
+/// The change hook attached to every [`WorkspaceFs`] this backend builds: for
+/// `knowledge/` mutations it triggers a resync and emits a durable domain event
+/// (so automations can trigger on indexing-target changes); everything else is
+/// ignored.
 struct KnowledgeHook {
     /// The workspace this hook is bound to — the crate is workspace-agnostic, so
     /// the backend carries the DB identity here rather than in `WorkspaceFs`.
@@ -263,25 +292,59 @@ struct KnowledgeHook {
     /// Resync trigger. `None` for the guest-serving handle (the session run loop
     /// builds it without one), so guest writes don't auto-resync.
     resyncer: Option<Resyncer>,
+    /// Durable event emission. `None` for the guest-serving handle, so guest
+    /// writes don't fire automation triggers.
+    events: Option<EventsState>,
 }
 
 impl FsHook for KnowledgeHook {
     fn on_change(&self, event: FsEvent<'_>) {
-        let touched = match event {
-            FsEvent::Created(p) | FsEvent::Modified(p) | FsEvent::Removed(p) => {
-                super::knowledge::is_under_knowledge(p)
-            }
+        let (path, kind) = match event {
+            FsEvent::Created(p) | FsEvent::Modified(p) => (p, KNOWLEDGE_INDEXED),
+            FsEvent::Removed(p) => (p, KNOWLEDGE_REMOVED),
         };
-        if touched {
-            if let Some(r) = &self.resyncer {
-                r.spawn_resync(self.wid);
-            }
+        if !super::knowledge::is_under_knowledge(path) {
+            return;
+        }
+        if let Some(r) = &self.resyncer {
+            r.spawn_resync(self.wid);
+        }
+        if let Some(events) = &self.events {
+            emit_knowledge(events.clone(), self.wid, path.to_string(), kind);
         }
     }
 }
 
-fn knowledge_hook(wid: Uuid, resyncer: Option<Resyncer>) -> Option<Arc<dyn FsHook>> {
-    Some(Arc::new(KnowledgeHook { wid, resyncer }))
+/// Emit a `knowledge/` change event. `on_change` is synchronous, so the async
+/// append is spawned; best-effort, mirroring [`Resyncer::spawn_resync`].
+fn emit_knowledge(events: EventsState, wid: Uuid, rel_path: String, kind: &'static str) {
+    tokio::spawn(async move {
+        if let Err(e) = events
+            .emit(NewEvent {
+                kind: kind.into(),
+                workspace_id: Some(wid),
+                payload: Some(serde_json::json!({
+                    "workspace_id": wid.to_string(),
+                    "path": rel_path,
+                })),
+            })
+            .await
+        {
+            tracing::error!("emit {kind} failed: {e}");
+        }
+    });
+}
+
+fn knowledge_hook(
+    wid: Uuid,
+    resyncer: Option<Resyncer>,
+    events: Option<EventsState>,
+) -> Option<Arc<dyn FsHook>> {
+    Some(Arc::new(KnowledgeHook {
+        wid,
+        resyncer,
+        events,
+    }))
 }
 
 /// Build a [`WorkspaceFs`] for `wid` rooted under `data_root`, with `vfs`
@@ -306,7 +369,7 @@ pub(crate) fn workspace_fs(
     config.local_root = Some(root);
     let fs = WorkspaceFs::from_config(config)
         .map_err(|e| StateError::InvalidData(format!("workspace fs: {e}")))?;
-    Ok(fs.with_hook(knowledge_hook(wid, None)))
+    Ok(fs.with_hook(knowledge_hook(wid, None, None)))
 }
 
 #[cfg(test)]

--- a/backend/src/state/workspace/mount.rs
+++ b/backend/src/state/workspace/mount.rs
@@ -73,6 +73,15 @@ impl WorkspaceMount {
             ProviderConfig::Notion(c) => ("notion", serde_json::to_string(c)?),
         })
     }
+
+    /// Provider discriminator (`"s3"` / `"notion"`) — the source poller matches
+    /// this against a subscribed event source's provider.
+    pub fn provider_str(&self) -> &'static str {
+        match &self.provider {
+            ProviderConfig::S3(_) => "s3",
+            ProviderConfig::Notion(_) => "notion",
+        }
+    }
 }
 
 /// Rebuild a [`ProviderConfig`] from its stored discriminator + config JSON.

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -1,0 +1,310 @@
+//! Automation worker loop. Claims queued runs and drives a **single prompt**
+//! against the run's session to completion.
+//!
+//! Crash safety: each claimed run has its `lease_until` heartbeated by a
+//! companion task. If a heartbeat finds the row no longer ours (a reaper
+//! requeued it) it cancels the in-flight agent. A housekeeper periodically
+//! requeues expired-lease rows. A cron ticker fires due cron triggers.
+//!
+//! Single-prompt note: there is no per-step cursor, so a re-claimed run simply
+//! re-runs its one prompt on the (message-less) session — no replay/orphan.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use ailoy::message::Part;
+use chrono::Utc;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::{
+    cron::{default_tz_name, next_fire_after},
+    state::{AppState, AutomationRun, AutomationTrigger, RunLogKind, MAX_ATTEMPTS, RunStatus, TriggerSpec},
+};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const REAP_INTERVAL: Duration = Duration::from_secs(60);
+const CRON_TICK_INTERVAL: Duration = Duration::from_secs(15);
+const LEASE_MINUTES: i64 = 3;
+
+/// Backoffs between consecutive attempts. `RETRY_BACKOFFS[N-1]` is the wait
+/// after attempt N fails; length is `MAX_ATTEMPTS - 1`.
+const RETRY_BACKOFFS: [Duration; 2] = [Duration::from_secs(30), Duration::from_secs(120)];
+
+/// Spawn the full automation runtime: `count` claim/execute workers, one
+/// housekeeper (reaper), and one cron ticker. Call once at startup.
+pub fn spawn_runtime(state: Arc<AppState>, count: usize) {
+    for idx in 0..count {
+        let state = state.clone();
+        tokio::spawn(async move { worker_loop(state, idx).await });
+    }
+    spawn_housekeeper(state.clone());
+    spawn_cron_ticker(state);
+    tracing::info!(workers = count, "automation runtime spawned");
+}
+
+fn spawn_housekeeper(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        // Boot reap: any `running` row after a restart is orphaned.
+        match state.automations.reap_expired_leases(None).await {
+            Ok(reaped) if !reaped.is_empty() => {
+                tracing::warn!(count = reaped.len(), "boot reap: requeued orphaned running rows");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::error!("boot reap failed: {e}"),
+        }
+
+        let mut tick = tokio::time::interval(REAP_INTERVAL);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        tick.tick().await; // discard the immediate first tick (boot reap ran)
+        loop {
+            tick.tick().await;
+            match state.automations.reap_expired_leases(Some(Utc::now())).await {
+                Ok(reaped) => {
+                    for run_id in reaped {
+                        tracing::warn!(run = %run_id, "lease expired — requeued");
+                    }
+                }
+                Err(e) => tracing::error!("reap failed: {e}"),
+            }
+        }
+    });
+}
+
+fn spawn_cron_ticker(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(CRON_TICK_INTERVAL).await;
+            if let Err(e) = cron_tick_once(&state, Utc::now()).await {
+                tracing::error!("cron tick failed: {e}");
+            }
+        }
+    });
+}
+
+async fn cron_tick_once(state: &Arc<AppState>, now: chrono::DateTime<Utc>) -> Result<(), String> {
+    let due = state
+        .automations
+        .list_due_cron_triggers(now)
+        .await
+        .map_err(|e| e.to_string())?;
+    for trigger in due {
+        if let Err(e) = fire_cron_trigger_once(state, &trigger, now).await {
+            tracing::error!(trigger = %trigger.id, "cron fire failed: {e}");
+        }
+    }
+    Ok(())
+}
+
+async fn fire_cron_trigger_once(
+    state: &Arc<AppState>,
+    trigger: &AutomationTrigger,
+    now: chrono::DateTime<Utc>,
+) -> Result<(), String> {
+    let automation = state
+        .automations
+        .get_automation(trigger.automation_id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("automation {} not found", trigger.automation_id))?;
+    let spec = TriggerSpec::from_db(trigger.kind, &trigger.spec_json)
+        .map_err(|e| format!("trigger spec decode: {e}"))?;
+    let TriggerSpec::Cron { expr, tz } = &spec;
+    let tz_name = tz.as_deref().unwrap_or(default_tz_name());
+    let next_fire = next_fire_after(expr, tz_name, now)?;
+    let payload = json!({
+        "source": "cron",
+        "trigger_id": trigger.id.to_string(),
+        "fired_for": trigger.next_fire_at,
+    });
+    let run = state
+        .automations
+        .fire_cron_trigger(
+            &automation,
+            trigger.id,
+            trigger.next_fire_at.unwrap_or(now),
+            next_fire,
+            &payload,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    match run {
+        Some(run) => tracing::info!(trigger = %trigger.id, run = %run.id, "cron trigger fired"),
+        None => tracing::info!(trigger = %trigger.id, "cron fire skipped: automation disabled"),
+    }
+    Ok(())
+}
+
+async fn worker_loop(state: Arc<AppState>, idx: usize) {
+    loop {
+        match try_claim_and_execute(&state).await {
+            Ok(true) => continue,
+            Ok(false) => tokio::time::sleep(POLL_INTERVAL).await,
+            Err(e) => {
+                tracing::error!(worker = idx, "claim failed: {e}");
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+    }
+}
+
+async fn try_claim_and_execute(state: &Arc<AppState>) -> Result<bool, String> {
+    let now = Utc::now();
+    let lease_until = now + chrono::Duration::minutes(LEASE_MINUTES);
+    let claimed = state
+        .automations
+        .claim_due_run(now, lease_until)
+        .await
+        .map_err(|e| e.to_string())?;
+    let Some(run) = claimed else { return Ok(false) };
+
+    tracing::info!(run = %run.id, "claimed run");
+
+    let attempt = state
+        .automations
+        .compute_run_attempt(run.id)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let cancel = CancellationToken::new();
+    let _drop_guard = cancel.clone().drop_guard();
+    let lease_lost = Arc::new(AtomicBool::new(false));
+    let mut heartbeat = spawn_heartbeat(state.clone(), run.id, cancel.clone(), lease_lost.clone());
+
+    let agent_result = tokio::select! {
+        result = execute_run(state, &run, &cancel) => {
+            cancel.cancel();
+            Some(result)
+        }
+        hb_result = &mut heartbeat => {
+            cancel.cancel();
+            if let Err(je) = &hb_result
+                && je.is_panic()
+            {
+                tracing::error!(run = %run.id, "heartbeat task panicked");
+            }
+            None
+        }
+    };
+
+    let _ = heartbeat.await;
+
+    if agent_result.is_none() || lease_lost.load(Ordering::SeqCst) {
+        tracing::warn!(run = %run.id, "abandoning run (heartbeat ended or lease lost)");
+        return Ok(true);
+    }
+
+    let result = agent_result.expect("agent_result branch checked above");
+    let (final_status, kind, payload) = match &result {
+        Ok(()) => {
+            tracing::info!(run = %run.id, "run succeeded");
+            (RunStatus::Succeeded, RunLogKind::Succeeded, None)
+        }
+        Err(e) => {
+            tracing::warn!(run = %run.id, "run failed: {e}");
+            (RunStatus::Failed, RunLogKind::Failed, Some(json!({ "error": e })))
+        }
+    };
+
+    let finalize_owned = match state
+        .automations
+        .finalize_run(run.id, final_status, kind, payload.as_ref())
+        .await
+    {
+        Ok(true) => true,
+        Ok(false) => {
+            tracing::warn!(run = %run.id, "finalize found row no longer running (reaper raced us)");
+            false
+        }
+        Err(e) => {
+            tracing::error!(run = %run.id, "finalize failed: {e}");
+            false
+        }
+    };
+
+    if finalize_owned
+        && matches!(final_status, RunStatus::Failed)
+        && let Some(backoff) = retry_backoff_for(attempt)
+    {
+        let scheduled_for = Utc::now() + chrono::Duration::from_std(backoff).unwrap_or_default();
+        let next_attempt = attempt + 1;
+        match state
+            .automations
+            .schedule_retry(&run, scheduled_for, next_attempt)
+            .await
+        {
+            Ok(Some(retry_run)) => {
+                tracing::info!(run = %run.id, next = %retry_run.id, attempt = next_attempt, "retry scheduled");
+            }
+            Ok(None) => tracing::info!(run = %run.id, "retry skipped: automation disabled"),
+            Err(e) => tracing::error!(run = %run.id, "schedule_retry failed: {e}"),
+        }
+    }
+
+    Ok(true)
+}
+
+/// Wait before the next attempt given the just-failed attempt number. `None`
+/// when `MAX_ATTEMPTS` is reached.
+fn retry_backoff_for(current_attempt: i64) -> Option<Duration> {
+    if current_attempt >= MAX_ATTEMPTS {
+        return None;
+    }
+    let idx = (current_attempt - 1).max(0) as usize;
+    RETRY_BACKOFFS.get(idx).copied()
+}
+
+fn spawn_heartbeat(
+    state: Arc<AppState>,
+    run_id: Uuid,
+    cancel: CancellationToken,
+    lease_lost: Arc<AtomicBool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = tokio::time::sleep(HEARTBEAT_INTERVAL) => {}
+            }
+            let new_lease = Utc::now() + chrono::Duration::minutes(LEASE_MINUTES);
+            match state.automations.renew_lease(run_id, new_lease).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    tracing::warn!(run = %run_id, "lease lost — cancelling agent");
+                    lease_lost.store(true, Ordering::SeqCst);
+                    cancel.cancel();
+                    return;
+                }
+                Err(e) => tracing::error!(run = %run_id, "heartbeat renew error: {e}"),
+            }
+        }
+    })
+}
+
+async fn execute_run(
+    state: &Arc<AppState>,
+    run: &AutomationRun,
+    cancel: &CancellationToken,
+) -> Result<(), String> {
+    state
+        .automations
+        .append_log(run.id, RunLogKind::Started, None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // The run is self-describing: it carries the rendered prompt it executes, so
+    // no automation lookup is needed (and ad-hoc runs have no automation).
+    let parts = vec![Part::text(run.prompt.clone())];
+    state
+        .sessions
+        .drive_prompt(run.session_id, parts, cancel.clone())
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -25,13 +25,17 @@ use uuid::Uuid;
 
 use crate::{
     cron::{default_tz_name, next_fire_after},
-    state::{AppState, AutomationRun, AutomationTrigger, RunLogKind, MAX_ATTEMPTS, RunStatus, TriggerSpec},
+    state::{
+        AppState, AutomationRun, AutomationTrigger, Condition, RunLogKind, MAX_ATTEMPTS,
+        MAX_CHAIN_DEPTH, RunStatus, TriggerSpec,
+    },
 };
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const REAP_INTERVAL: Duration = Duration::from_secs(60);
 const CRON_TICK_INTERVAL: Duration = Duration::from_secs(15);
+const DISPATCH_INTERVAL: Duration = Duration::from_secs(2);
 const LEASE_MINUTES: i64 = 3;
 
 /// Backoffs between consecutive attempts. `RETRY_BACKOFFS[N-1]` is the wait
@@ -46,8 +50,122 @@ pub fn spawn_runtime(state: Arc<AppState>, count: usize) {
         tokio::spawn(async move { worker_loop(state, idx).await });
     }
     spawn_housekeeper(state.clone());
-    spawn_cron_ticker(state);
+    spawn_cron_ticker(state.clone());
+    spawn_dispatcher(state);
     tracing::info!(workers = count, "automation runtime spawned");
+}
+
+/// Poll the durable event outbox and fire matching event triggers.
+fn spawn_dispatcher(state: Arc<AppState>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(DISPATCH_INTERVAL).await;
+            if let Err(e) = dispatch_once(&state).await {
+                tracing::error!("event dispatch failed: {e}");
+            }
+        }
+    });
+}
+
+async fn dispatch_once(state: &Arc<AppState>) -> Result<(), String> {
+    let events = state
+        .event_store
+        .list_undispatched(100)
+        .await
+        .map_err(|e| e.to_string())?;
+    if events.is_empty() {
+        return Ok(());
+    }
+    // Pre-parse enabled event triggers into (trigger, conditions).
+    let triggers: Vec<(AutomationTrigger, Vec<Condition>)> = state
+        .automations
+        .list_event_triggers()
+        .await
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .filter_map(|t| match TriggerSpec::from_db(t.kind, &t.spec_json) {
+            Ok(TriggerSpec::Event { conditions }) => Some((t, conditions)),
+            _ => None,
+        })
+        .collect();
+
+    for event in events {
+        // Causal chain depth of any run this event spawns: a `run.succeeded`
+        // event continues its producer's chain (parent + 1); every other source
+        // roots a fresh chain at 0. Computed once per event (same for all
+        // matching triggers).
+        let spawn_depth = if event.kind == "run.succeeded" {
+            let parent = event
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("run_id"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| Uuid::parse_str(s).ok());
+            let parent_depth = match parent {
+                Some(rid) => state
+                    .automations
+                    .run_chain_depth(rid)
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0),
+                None => 0,
+            };
+            parent_depth + 1
+        } else {
+            0
+        };
+
+        for (trigger, conditions) in &triggers {
+            // OR: fire if any condition (its own source + filter) matches.
+            if !conditions.iter().any(|c| c.matches(&event.kind, event.payload.as_ref())) {
+                continue;
+            }
+            // Loop guard: suppress the run once the causal chain hits the cap.
+            if spawn_depth > MAX_CHAIN_DEPTH {
+                tracing::warn!(
+                    trigger = %trigger.id, event = %event.id, depth = spawn_depth,
+                    "chain depth cap ({MAX_CHAIN_DEPTH}) reached — run suppressed"
+                );
+                continue;
+            }
+            // Idempotency: one run per (trigger, event) — guards re-processing.
+            match state.automations.run_exists_for_event(trigger.id, event.id).await {
+                Ok(true) => continue,
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::error!(trigger = %trigger.id, "run_exists check failed: {e}");
+                    continue;
+                }
+            }
+            let automation = match state.automations.get_automation(trigger.automation_id).await {
+                Ok(Some(a)) => a,
+                Ok(None) => continue,
+                Err(e) => {
+                    tracing::error!(trigger = %trigger.id, "get_automation failed: {e}");
+                    continue;
+                }
+            };
+            let input = event.payload.clone().unwrap_or_else(|| json!({}));
+            match state
+                .automations
+                .create_event_run(&automation, trigger.id, event.id, input, spawn_depth)
+                .await
+            {
+                Ok(Some(run)) => {
+                    tracing::info!(trigger = %trigger.id, run = %run.id, event = %event.id, "event trigger fired")
+                }
+                Ok(None) => {} // automation disabled
+                Err(e) => tracing::error!(trigger = %trigger.id, "create_event_run failed: {e}"),
+            }
+        }
+        state
+            .event_store
+            .mark_dispatched(event.id)
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
 }
 
 fn spawn_housekeeper(state: Arc<AppState>) {
@@ -117,7 +235,7 @@ async fn fire_cron_trigger_once(
     let spec = TriggerSpec::from_db(trigger.kind, &trigger.spec_json)
         .map_err(|e| format!("trigger spec decode: {e}"))?;
     let TriggerSpec::Cron { expr, tz } = &spec else {
-        return Err(format!("trigger {} is not a cron trigger", trigger.id));
+        return Err("non-cron trigger surfaced in cron path".into());
     };
     let tz_name = tz.as_deref().unwrap_or(default_tz_name());
     let next_fire = next_fire_after(expr, tz_name, now)?;
@@ -205,7 +323,7 @@ async fn try_claim_and_execute(state: &Arc<AppState>) -> Result<bool, String> {
 
     let result = agent_result.expect("agent_result branch checked above");
     let (final_status, kind, payload) = match &result {
-        Ok(()) => {
+        Ok(_) => {
             tracing::info!(run = %run.id, "run succeeded");
             (RunStatus::Succeeded, RunLogKind::Succeeded, None)
         }
@@ -247,6 +365,28 @@ async fn try_claim_and_execute(state: &Arc<AppState>) -> Result<bool, String> {
             }
             Ok(None) => tracing::info!(run = %run.id, "retry skipped: automation disabled"),
             Err(e) => tracing::error!(run = %run.id, "schedule_retry failed: {e}"),
+        }
+    }
+
+    // Chaining: a successful run emits `run.succeeded` carrying its output, which
+    // other automations can subscribe to (fan-out via multiple subscribers).
+    if finalize_owned && matches!(final_status, RunStatus::Succeeded) {
+        let output = result.ok().flatten();
+        let payload = json!({
+            "automation_id": run.automation_id.map(|a| a.to_string()),
+            "run_id": run.id.to_string(),
+            "output": output,
+        });
+        if let Err(e) = state
+            .event_store
+            .emit(crate::state::NewEvent {
+                kind: "run.succeeded".into(),
+                workspace_id: Some(run.workspace_id),
+                payload: Some(payload),
+            })
+            .await
+        {
+            tracing::error!(run = %run.id, "emit run.succeeded failed: {e}");
         }
     }
 
@@ -294,19 +434,159 @@ async fn execute_run(
     state: &Arc<AppState>,
     run: &AutomationRun,
     cancel: &CancellationToken,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     state
         .automations
         .append_log(run.id, RunLogKind::Started, None)
         .await
         .map_err(|e| e.to_string())?;
 
-    // The run is self-describing: it carries the rendered prompt it executes, so
-    // no automation lookup is needed (and ad-hoc runs have no automation).
-    let parts = vec![Part::text(run.prompt.clone())];
+    // Render the prompt template at execution time against the triggering event
+    // payload (`{{event.*}}`) + date builtins. Fail-closed on undefined vars.
+    let prompt = crate::state::render(&run.prompt, run.input.as_ref())
+        .map_err(|e| format!("template render: {e}"))?;
+    let parts = vec![Part::text(prompt)];
     state
         .sessions
         .drive_prompt(run.session_id, parts, cancel.clone())
         .await
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dispatch_once;
+    use crate::auth::JwtConfig;
+    use crate::state::{AppState, Condition, MAX_CHAIN_DEPTH, NewEvent, TriggerSpec, render};
+    use chrono::Utc;
+    use serde_json::json;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    /// Fresh AppState on a temp file DB, plus a second pool to the same file for
+    /// seeding/asserting (AppState owns its pool privately). Returns
+    /// `(state, seed_pool, dir)`; caller removes `dir`.
+    async fn boot() -> (Arc<AppState>, SqlitePool, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!("agentk-e2e-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_url = format!("sqlite://{}/e2e.db", dir.display());
+        let state = AppState::new(&db_url, dir.clone(), JwtConfig::new("test", 3600))
+            .await
+            .unwrap();
+        let pool = SqlitePool::connect(&db_url).await.unwrap();
+        (Arc::new(state), pool, dir)
+    }
+
+    async fn seed_user_ws(pool: &SqlitePool) -> (Uuid, Uuid) {
+        let (uid, wid) = (Uuid::new_v4(), Uuid::new_v4());
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO users (id, username, password_hash, role, is_active, preferred_language, created_at, updated_at) \
+             VALUES (?, ?, 'x', 'user', 1, 'en', ?, ?)",
+        )
+        .bind(uid.to_string()).bind(format!("u-{uid}")).bind(&now).bind(&now)
+        .execute(pool).await.unwrap();
+        sqlx::query("INSERT INTO workspaces (id, user_id, title, created_at, updated_at) VALUES (?, ?, 'W', ?, ?)")
+            .bind(wid.to_string()).bind(uid.to_string()).bind(&now).bind(&now)
+            .execute(pool).await.unwrap();
+        (uid, wid)
+    }
+
+    /// End-to-end through the real dispatch pipeline (no agent execution):
+    /// outbox event → `dispatch_once` → run creation, covering filter matching,
+    /// payload→input+render, dedup, `run.succeeded` chaining, and the
+    /// chain-depth loop guard.
+    #[tokio::test]
+    async fn dispatch_pipeline_e2e() {
+        let (state, pool, dir) = boot().await;
+        let (uid, wid) = seed_user_ws(&pool).await;
+
+        // Automation A: knowledge.indexed for *.pdf; prompt renders {{event.path}}.
+        let a = state
+            .automations
+            .create_automation(
+                wid, "index pdf".into(), None,
+                "New PDF at {{event.path}}".into(), "coworker".into(), None, uid,
+            )
+            .await.unwrap();
+        let a_spec = TriggerSpec::Event {
+            conditions: vec![Condition {
+                source: "knowledge.indexed".into(),
+                filter: Some(json!({ "path": { "glob": "*.pdf" } })),
+            }],
+        };
+        state.automations.create_trigger(a.id, &a_spec, true, None, None).await.unwrap();
+
+        // (1) Non-matching event (.txt) → no run.
+        state.event_store.emit(NewEvent {
+            kind: "knowledge.indexed".into(),
+            workspace_id: Some(wid),
+            payload: Some(json!({ "path": "/knowledge/note.txt" })),
+        }).await.unwrap();
+        dispatch_once(&state).await.unwrap();
+        assert_eq!(state.automations.list_runs(a.id).await.unwrap().len(), 0, "txt must not match *.pdf");
+
+        // (2) Matching event (.pdf) → one run; input = payload, event set, depth 0.
+        let ev = state.event_store.emit(NewEvent {
+            kind: "knowledge.indexed".into(),
+            workspace_id: Some(wid),
+            payload: Some(json!({ "path": "/knowledge/report.pdf" })),
+        }).await.unwrap();
+        dispatch_once(&state).await.unwrap();
+        let runs = state.automations.list_runs(a.id).await.unwrap();
+        assert_eq!(runs.len(), 1, "pdf must trigger exactly one run");
+        let a_run = runs[0].clone();
+        assert_eq!(a_run.event_id, Some(ev.id));
+        assert_eq!(a_run.chain_depth, 0);
+        assert_eq!(a_run.input.as_ref().unwrap()["path"], "/knowledge/report.pdf");
+        assert_eq!(
+            render(&a_run.prompt, a_run.input.as_ref()).unwrap(),
+            "New PDF at /knowledge/report.pdf",
+        );
+
+        // (3) Dedup: the event is marked dispatched; re-dispatch adds nothing.
+        dispatch_once(&state).await.unwrap();
+        assert_eq!(state.automations.list_runs(a.id).await.unwrap().len(), 1, "no duplicate run");
+
+        // (4) Chaining: B subscribes to run.succeeded; A's success spawns a B run
+        //     at parent depth + 1.
+        let b = state
+            .automations
+            .create_automation(wid, "on success".into(), None, "chained".into(), "coworker".into(), None, uid)
+            .await.unwrap();
+        let b_spec = TriggerSpec::Event {
+            conditions: vec![Condition { source: "run.succeeded".into(), filter: None }],
+        };
+        state.automations.create_trigger(b.id, &b_spec, true, None, None).await.unwrap();
+
+        state.event_store.emit(NewEvent {
+            kind: "run.succeeded".into(),
+            workspace_id: Some(wid),
+            payload: Some(json!({ "automation_id": a.id.to_string(), "run_id": a_run.id.to_string(), "output": "done" })),
+        }).await.unwrap();
+        dispatch_once(&state).await.unwrap();
+        let b_runs = state.automations.list_runs(b.id).await.unwrap();
+        assert_eq!(b_runs.len(), 1, "run.succeeded must chain into B");
+        assert_eq!(b_runs[0].chain_depth, 1, "chained run is parent depth + 1");
+
+        // (5) Loop guard: a run.succeeded from a run already AT the cap is
+        //     suppressed (spawn depth would exceed MAX_CHAIN_DEPTH).
+        sqlx::query("UPDATE automation_runs SET chain_depth = ? WHERE id = ?")
+            .bind(MAX_CHAIN_DEPTH).bind(b_runs[0].id.to_string())
+            .execute(&pool).await.unwrap();
+        state.event_store.emit(NewEvent {
+            kind: "run.succeeded".into(),
+            workspace_id: Some(wid),
+            payload: Some(json!({ "run_id": b_runs[0].id.to_string() })),
+        }).await.unwrap();
+        dispatch_once(&state).await.unwrap();
+        assert_eq!(
+            state.automations.list_runs(b.id).await.unwrap().len(),
+            1,
+            "chain at cap must be suppressed",
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -10,6 +10,7 @@
 //! re-runs its one prompt on the (message-less) session — no replay/orphan.
 
 use std::{
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -19,15 +20,17 @@ use std::{
 
 use ailoy::message::Part;
 use chrono::Utc;
+use futures_util::StreamExt as _;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
+use workspace::WorkspaceFs;
 
 use crate::{
     cron::{default_tz_name, next_fire_after},
     state::{
-        AppState, AutomationRun, AutomationTrigger, Condition, RunLogKind, MAX_ATTEMPTS,
-        MAX_CHAIN_DEPTH, RunStatus, TriggerSpec,
+        AppState, AutomationRun, AutomationTrigger, Change, Condition, RunLogKind, MAX_ATTEMPTS,
+        MAX_CHAIN_DEPTH, NewEvent, RunStatus, Snapshot, TriggerSpec, diff_snapshots,
     },
 };
 
@@ -51,8 +54,194 @@ pub fn spawn_runtime(state: Arc<AppState>, count: usize) {
     }
     spawn_housekeeper(state.clone());
     spawn_cron_ticker(state.clone());
-    spawn_dispatcher(state);
+    spawn_dispatcher(state.clone());
+    spawn_source_poller(state);
     tracing::info!(workers = count, "automation runtime spawned");
+}
+
+/// Interval between external-source poll sweeps. `0` disables polling.
+fn source_poll_interval() -> Duration {
+    let secs = std::env::var("AGENT_K_SOURCE_POLL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(60);
+    Duration::from_secs(secs)
+}
+
+/// Cap on files recorded per mount per poll — a backstop against walking an
+/// enormous provider tree.
+const SCAN_ENTRY_CAP: usize = 5000;
+
+/// Periodically poll subscribed external mounts and emit change events.
+fn spawn_source_poller(state: Arc<AppState>) {
+    let interval = source_poll_interval();
+    if interval.is_zero() {
+        tracing::info!("source polling disabled (AGENT_K_SOURCE_POLL_SECS=0)");
+        return;
+    }
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if let Err(e) = poll_sources_once(&state).await {
+                tracing::error!("source poll failed: {e}");
+            }
+        }
+    });
+}
+
+/// The provider a subscribed event `source` belongs to (`s3.*` → `"s3"`), or
+/// `None` for non-provider sources (workspace/knowledge/run/webhook).
+fn provider_of_source(source: &str) -> Option<&'static str> {
+    if source.starts_with("s3.") {
+        Some("s3")
+    } else if source.starts_with("notion.") {
+        Some("notion")
+    } else {
+        None
+    }
+}
+
+/// The event kind for a provider + change (e.g. s3 + Created → s3.object_created).
+fn source_event_kind(provider: &str, change: &Change) -> &'static str {
+    match (provider, change) {
+        ("s3", Change::Created(_)) => "s3.object_created",
+        ("s3", Change::Modified(_)) => "s3.object_modified",
+        ("s3", Change::Removed(_)) => "s3.object_removed",
+        ("notion", Change::Created(_)) => "notion.page_created",
+        ("notion", Change::Modified(_)) => "notion.page_updated",
+        ("notion", Change::Removed(_)) => "notion.page_removed",
+        // Unknown provider: a generic, still-filterable fallback.
+        (_, Change::Created(_)) => "source.created",
+        (_, Change::Modified(_)) => "source.modified",
+        (_, Change::Removed(_)) => "source.removed",
+    }
+}
+
+/// One poll sweep: for each workspace with an enabled event subscriber, poll its
+/// mounts of the subscribed providers (lazy activation), diff, and emit events.
+async fn poll_sources_once(state: &Arc<AppState>) -> Result<(), String> {
+    let subs = state
+        .automations
+        .list_enabled_event_trigger_sources()
+        .await
+        .map_err(|e| e.to_string())?;
+    // workspace_id → set of subscribed providers.
+    let mut want: HashMap<Uuid, HashSet<&'static str>> = HashMap::new();
+    for (wid, sources) in subs {
+        for s in &sources {
+            if let Some(p) = provider_of_source(s) {
+                want.entry(wid).or_default().insert(p);
+            }
+        }
+    }
+    for (wid, providers) in want {
+        let mounts = match state.workspaces.list_mounts(wid).await {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(%wid, "poll: list_mounts failed: {e}");
+                continue;
+            }
+        };
+        for m in mounts {
+            let provider = m.provider_str();
+            if !providers.contains(provider) {
+                continue;
+            }
+            if let Err(e) = poll_mount(state, wid, &m.prefix, provider).await {
+                tracing::warn!(%wid, prefix = %m.prefix, "poll mount failed: {e}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Scan one mount, diff against its stored snapshot, emit change events, and save
+/// the new snapshot. The first poll only seeds the baseline (emits nothing).
+async fn poll_mount(
+    state: &Arc<AppState>,
+    wid: Uuid,
+    prefix: &str,
+    provider: &str,
+) -> Result<(), String> {
+    let fs = state.workspaces.scan_fs(wid).await.map_err(|e| e.to_string())?;
+    let mut next = Snapshot::new();
+    scan_tree(&fs, prefix, &mut next, 0).await;
+    if next.len() >= SCAN_ENTRY_CAP {
+        // The scan was truncated: the partial snapshot is order-dependent, so
+        // diffs would churn. Skip emitting/persisting rather than fire spurious
+        // events for a mount this large.
+        tracing::warn!(%wid, prefix, cap = SCAN_ENTRY_CAP, "source poll: mount exceeds scan cap — skipping");
+        return Ok(());
+    }
+
+    match state.source_poll.get(wid, prefix).await.map_err(|e| e.to_string())? {
+        None => {} // first poll — seed baseline below without emitting
+        Some(prev) => {
+            for change in diff_snapshots(&prev, &next) {
+                let path = match &change {
+                    Change::Created(p) | Change::Modified(p) | Change::Removed(p) => p.clone(),
+                };
+                let kind = source_event_kind(provider, &change);
+                if let Err(e) = state
+                    .event_store
+                    .emit(NewEvent {
+                        kind: kind.into(),
+                        workspace_id: Some(wid),
+                        payload: Some(json!({
+                            "workspace_id": wid.to_string(),
+                            "prefix": prefix,
+                            "path": path,
+                        })),
+                    })
+                    .await
+                {
+                    tracing::error!(%wid, "emit {kind} failed: {e}");
+                }
+            }
+        }
+    }
+    state.source_poll.put(wid, prefix, &next).await.map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Recursively walk `path` under a mount, recording each file's change signature
+/// (`modified:len`) into `out`. Bounded by [`SCAN_ENTRY_CAP`] and a depth cap.
+async fn scan_tree(fs: &WorkspaceFs, path: &str, out: &mut Snapshot, depth: usize) {
+    if out.len() >= SCAN_ENTRY_CAP || depth > 32 {
+        return;
+    }
+    let Ok(mut stream) = fs.read_dir(path).await else {
+        return;
+    };
+    while let Some(entry) = stream.next().await {
+        let Ok(entry) = entry else { continue };
+        let name = String::from_utf8_lossy(&entry.name()).into_owned();
+        if name.is_empty() || name == "." || name == ".." {
+            continue;
+        }
+        let child = format!("{}/{}", path.trim_end_matches('/'), name);
+        match entry.metadata() {
+            Ok(stat) if stat.is_dir() => {
+                Box::pin(scan_tree(fs, &child, out, depth + 1)).await;
+            }
+            Ok(stat) => {
+                // Stable signature (`nanos:len`): a `Debug` format of SystemTime
+                // could change across a library update and re-fire every file.
+                let mtime_ns = stat
+                    .modified
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0);
+                out.insert(child, format!("{mtime_ns}:{}", stat.len));
+            }
+            Err(_) => {}
+        }
+        if out.len() >= SCAN_ENTRY_CAP {
+            break;
+        }
+    }
 }
 
 /// Poll the durable event outbox and fire matching event triggers.
@@ -116,6 +305,10 @@ async fn dispatch_once(state: &Arc<AppState>) -> Result<(), String> {
             0
         };
 
+        // A transient DB error on any trigger leaves the event undispatched so the
+        // next sweep retries it; the (trigger, event) dedup makes reprocessing of
+        // already-created runs a no-op.
+        let mut all_ok = true;
         for (trigger, conditions) in &triggers {
             // OR: fire if any condition (its own source + filter) matches.
             if !conditions.iter().any(|c| c.matches(&event.kind, event.payload.as_ref())) {
@@ -135,6 +328,7 @@ async fn dispatch_once(state: &Arc<AppState>) -> Result<(), String> {
                 Ok(false) => {}
                 Err(e) => {
                     tracing::error!(trigger = %trigger.id, "run_exists check failed: {e}");
+                    all_ok = false;
                     continue;
                 }
             }
@@ -143,6 +337,7 @@ async fn dispatch_once(state: &Arc<AppState>) -> Result<(), String> {
                 Ok(None) => continue,
                 Err(e) => {
                     tracing::error!(trigger = %trigger.id, "get_automation failed: {e}");
+                    all_ok = false;
                     continue;
                 }
             };
@@ -156,14 +351,20 @@ async fn dispatch_once(state: &Arc<AppState>) -> Result<(), String> {
                     tracing::info!(trigger = %trigger.id, run = %run.id, event = %event.id, "event trigger fired")
                 }
                 Ok(None) => {} // automation disabled
-                Err(e) => tracing::error!(trigger = %trigger.id, "create_event_run failed: {e}"),
+                Err(e) => {
+                    tracing::error!(trigger = %trigger.id, "create_event_run failed: {e}");
+                    all_ok = false;
+                }
             }
         }
-        state
-            .event_store
-            .mark_dispatched(event.id)
-            .await
-            .map_err(|e| e.to_string())?;
+        // Only consume the event once every matching trigger was handled cleanly.
+        if all_ok {
+            state
+                .event_store
+                .mark_dispatched(event.id)
+                .await
+                .map_err(|e| e.to_string())?;
+        }
     }
     Ok(())
 }

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -116,7 +116,9 @@ async fn fire_cron_trigger_once(
         .ok_or_else(|| format!("automation {} not found", trigger.automation_id))?;
     let spec = TriggerSpec::from_db(trigger.kind, &trigger.spec_json)
         .map_err(|e| format!("trigger spec decode: {e}"))?;
-    let TriggerSpec::Cron { expr, tz } = &spec;
+    let TriggerSpec::Cron { expr, tz } = &spec else {
+        return Err(format!("trigger {} is not a cron trigger", trigger.id));
+    };
     let tz_name = tz.as_deref().unwrap_or(default_tz_name());
     let next_fire = next_fire_after(expr, tz_name, now)?;
     let payload = json!({


### PR DESCRIPTION
## Description

Extend automations beyond schedules and webhooks. A durable event outbox lets triggers react to internal and external domain events, and the event payload is fed into the prompt as render input. This PR contains the event infrastructure (triggers, dispatcher, render) and the external-source lazy polling built on top of it.

## Design: trigger = single event + rich filter

The real requirement is not pairing distinct events by a correlation key, but a predicate combination over a single event (`path ~ *.pdf` AND `date ≥ X`). So, with no correlation id or join-state, `TriggerSpec::Event { conditions }` is an OR of `{source, filter}` predicates. Multi-step work is handled by a single tool-using agent given a prompt, so chaining/DAG/fan-in orchestration is not built here.

## Design: durable outbox + dispatcher

Producers INSERT events into `events` (the outbox) alongside their domain change. A dispatcher worker matches undispatched events to enabled Event triggers and creates runs, using per-(trigger, event) dedup to prevent at-least-once duplicate firing. `run.succeeded` chaining is bounded by a `chain_depth` loop guard.

## Changes

### Event infrastructure
- **`state/events.rs`** (new) — `EventsState` outbox.
- **`worker.rs`** — dispatcher (undispatched events → trigger matching → run creation).
- **`state/automation.rs`** — `TriggerSpec::Event`, filter matcher (`eq`/`glob`/`gte`/`lte`/`contains`), `render()` for `{{event.*}}`, run `input`/`event_id`, dedup, `chain_depth`.
- **Webhook body/filter** — `create_webhook_run` carries the POST body as render input; `TriggerSpec::Webhook` gains an optional body `filter` (reuses `event_filter_matches`) — a non-matching POST is accepted (202 `matched:false`) but fires no run.
- Internal producers: `workspace.created`, `knowledge.indexed/removed`.

### External-source lazy polling
- **`state/source_poll.rs`** (new) — per-mount snapshot store + `diff_snapshots`.
- **`worker.rs`** — `spawn_source_poller`/`poll_sources_once`/`poll_mount`/`scan_tree`: scans only provider mounts an enabled Event trigger subscribes to (`s3.*`/`notion.*`), diffs against the snapshot, and emits `s3.object_*`/`notion.page_*` events. The first poll only seeds a baseline.
- **`workspace/`** — hookless `scan_fs`, `WorkspaceMount::provider_str`.

### Migration
Add the `events` outbox and `source_poll_state` tables to `0003_automations.sql`.

## Tests

Includes an E2E dispatch pipeline test. `cargo build` / `clippy --all-targets` clean; `cargo test -p agent-k-backend` **72 passed / 0 failed**.

## Notes

- Poll interval via `AGENT_K_SOURCE_POLL_SECS` (0 disables); scan capped at 5000 entries.
- AND (fan-in) and correlation joins are not implemented — follow-up if needed.