### PR TITLE
fix(workspace): declare the reqwest feature the crate actually uses

### DIFF
--- a/workspace/Cargo.toml
+++ b/workspace/Cargo.toml
@@ -22,7 +22,7 @@ fuser = { version = "0.18", default-features = false, features = ["macos-no-moun
 html2text = "0.17.1"
 libc = "0.2"
 object_store = { version = "0.14", features = ["aws"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["form", "json", "rustls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.17"


### PR DESCRIPTION
`cargo check -p workspace` does not compile: `.form()` is gone from `RequestBuilder`, and gmail.rs calls it twice.

Two merges that were each fine alone. #219 moved reqwest 0.12 → 0.13, where `form` stopped being unconditional and went behind a feature this crate does not ask for — but nothing in workspace/src called it yet, so the bump broke nothing. #212 then landed gmail.rs, written against 0.12.

CI stayed green because the whole-workspace build unifies features and ailoy enables `reqwest/form`, so the crate compiles by borrowing a feature it never declared from one it has nothing to do with. The root sets `resolver = "3"`, which is why `--workspace` and `-p workspace` disagree.

Worth declaring rather than leaving: the borrow is invisible where it is used, it evaporates if ailoy drops the feature, and `-p workspace` is how this crate's own live tests are run.

Checked each crate alone, since the whole-workspace build hides exactly this; backend, agent-k and docling-sys were already fine. Cargo.lock is unchanged — serde_urlencoded was already in the graph via the enable this replaces.